### PR TITLE
docs: align pre-materialization documentation

### DIFF
--- a/.serena/memories/tech_stack.md
+++ b/.serena/memories/tech_stack.md
@@ -15,8 +15,7 @@ Current active stack for ERP-SAEP:
 - factory_boy as the chosen standard for test data generation.
 
 Materialization baseline:
-- Django is materialized through `docs/backlog/backlog-materializacao-django.md` (`MAT-*`) before any `PIL-*` functional work.
-- Bootstrap is manual minimum, without external project generators.
+- Django materialization follows `docs/backlog/backlog-materializacao-django.md` tasks (`MAT-000` to `MAT-006`) before any `PIL-*` functional work begins.\n  - `MAT-000`: Align docs pre-materialization; close ambiguity about bootstrap approach.\n  - `MAT-001`: Inspect repo structure and confirm baseline.\n  - `MAT-002`: Create minimal Django bootstrap.\n  - `MAT-003`: Configure settings structure, environment, PostgreSQL via `DATABASE_URL`.\n  - `MAT-004`: Set up smoke tests and pytest.\n  - `MAT-005`: Configure DRF, OpenAPI/drf-spectacular, `apps/core/` technical infrastructure.\n  - `MAT-006`: Adjust CI (ruff, pytest, `manage.py check`) and pre-commit hooks.\n- Bootstrap is manual minimum, without external project generators.
 - Initial settings are `config.settings.base`, `config.settings.dev`, and `config.settings.test`; do not create a separate `test_postgres` settings module.
 - `config/` owns settings, URLs, ASGI/WSGI, and project bootstrap.
 - `apps/core/` is technical API infrastructure only; it may host pagination, error envelope, schema helpers, and non-domain API utilities.

--- a/docs/backlog/backlog-tecnico-piloto.md
+++ b/docs/backlog/backlog-tecnico-piloto.md
@@ -1,12 +1,23 @@
 # Backlog Técnico — Piloto Inicial
 
-Este documento reúne apenas o escopo do piloto inicial.
+Este documento reúne apenas o escopo funcional do piloto inicial.
 
 Para o backlog do MVP completo, consultar `docs/backlog/backlog-tecnico-mvp.md`.
 
-Antes de iniciar qualquer tarefa `PIL-*`, executar o backlog de materialização mínima em `docs/backlog/backlog-materializacao-django.md`.
+## Pré-condição técnica obrigatória
 
-As tarefas `MAT-*` são pré-condição técnica para criar a base Django inicializável. Elas não fazem parte do domínio funcional do piloto. O backlog funcional do piloto começa em `PIL-BE-ACE-001`.
+Antes de iniciar qualquer tarefa `PIL-*`, executar completamente o backlog de materialização técnica em `docs/backlog/backlog-materializacao-django.md` (tarefas `MAT-000` a `MAT-006`).
+
+As tarefas `MAT-*` são responsáveis por:
+- Alinhar documentação pré-materialização (`MAT-000`)
+- Inspecionar estrutura existente (`MAT-001`)
+- Criar bootstrap Django mínimo (`MAT-002`)
+- Configurar settings, ambiente e PostgreSQL (`MAT-003`)
+- Configurar testes de smoke (`MAT-004`)
+- Configurar DRF/OpenAPI/core API sem domínio (`MAT-005`)
+- Ajustar CI genérica de bootstrap (`MAT-006`)
+
+As tarefas `MAT-*` não fazem parte do domínio funcional do piloto. O backlog funcional do piloto começa em `PIL-BE-ACE-001`, que deve ser iniciado apenas após a materialização estar completa.
 
 ## 1. Estratégia de implementação
 
@@ -165,10 +176,11 @@ O piloto só deve iniciar com usuários reais quando estiverem funcionando:
 - **Fase:** Piloto inicial
 - **Tipo:** Backend / Banco de dados
 - **Agente sugerido:** Agente backend
-- **Depende de:** nenhuma
+- **Depende de:** Backlog de materialização completo (`MAT-000` a `MAT-006`)
 - **Objetivo:** criar o app de usuários do ERP-SAEP em `apps/users/` com usuário customizado por matrícula funcional.
 - **Contexto técnico:**
-  - A materialização mínima cria apenas a base Django e não cria `apps/users/`.
+  - A materialização mínima (`docs/backlog/backlog-materializacao-django.md`) cria apenas a base Django e não cria `apps/users/`.
+  - Esta tarefa é a primeira do backlog funcional, após a base técnica estar pronta.
   - Esta tarefa deve criar `apps/users/` como app de usuários oficial do ERP-SAEP.
   - Não criar novo app `accounts` ou outro app de usuários sem decisão registrada.
   - Implementar `apps/users/models.py`, `managers.py`, `forms.py`, `admin.py` e configurações relacionadas.

--- a/docs/design-acesso-rapido/stack.md
+++ b/docs/design-acesso-rapido/stack.md
@@ -233,24 +233,67 @@ Diretrizes:
 
 ## 12. Organização sugerida de apps Django
 
-A organização deve favorecer fronteiras claras de domínio e partir de um bootstrap Django manual mínimo.
+A organização deve favorecer fronteiras claras de domínio e parte de um **bootstrap Django manual mínimo** descrito em `docs/backlog/backlog-materializacao-django.md`.
 
-Diretriz estrutural:
+### Estrutura antes da materialização
 
-- os apps Django do projeto devem ficar sob a pasta `apps/`.
-- a pasta `config/` permanece responsável por settings, URLs, ASGI/WSGI e bootstrap do projeto.
+Antes de executar as tarefas `MAT-*`, o repositório contém apenas:
 
-Estrutura mínima esperada após a materialização técnica:
+```text
+.github/
+docs/
+tests/ (opcional, criado em MAT-004)
+Makefile
+requirements.txt
+pyproject.toml
+.env.example
+```
+
+Não há `manage.py`, `config/` ou `apps/` ainda.
+
+### Estrutura após a materialização técnica (MAT-000 a MAT-006)
+
+Após executar o backlog `docs/backlog/backlog-materializacao-django.md`, a estrutura mínima será:
 
 ```text
 config/
+  __init__.py
+  settings/
+    __init__.py
+    base.py
+    dev.py
+    test.py
+  urls.py
+  asgi.py
+  wsgi.py
 apps/
+  __init__.py
   core/
+    (app técnico, preenchido em MAT-005)
+manage.py
 ```
 
-O app `apps/core/` deve ser técnico e transversal, limitado a infraestrutura comum, como API, paginação, envelope de erro e schema OpenAPI. Ele não deve conter regra de negócio de domínio.
+### Estrutura após o piloto (PIL-001 em diante)
 
-O app de usuários oficial deve ser criado em `apps/users/` na tarefa `PIL-BE-ACE-001`. Não criar `accounts` ou outro app alternativo de usuários sem decisão registrada.
+Após materializar a base, adicionar apps de domínio conforme o escopo avançar:
+
+```text
+apps/
+  core/       (infraestrutura comum: API, paginação, envelope de erro, OpenAPI)
+  users/      (usuário customizado, criado em PIL-BE-ACE-001)
+  organizational/ (setores, departamentos)
+  materials/  (grupos, subgrupos, materiais)
+  stock/      (saldos, reservas, movimentações)
+  requisitions/ (cabeçalho, itens, ciclo de requisição)
+  ...
+```
+
+### Diretriz estrutural
+
+- Os apps Django devem ficar sob a pasta `apps/`.
+- A pasta `config/` permanece responsável por settings, URLs, ASGI/WSGI e bootstrap do projeto.
+- O app `apps/core/` deve ser **técnico e transversal**, limitado a infraestrutura comum como API, paginação, envelope de erro e schema OpenAPI. Ele não deve conter regra de negócio de domínio.
+- O app de usuários oficial deve ser criado em `apps/users/` na tarefa `PIL-BE-ACE-001`. Não criar `accounts` ou outro app alternativo de usuários sem decisão registrada.
 
 Apps ou módulos de domínio podem ser criados conforme o escopo avançar:
 


### PR DESCRIPTION
## Summary

Align documentation to close ambiguity about Django materialization strategy before `MAT-*` tasks begin.

- **MAT-000**: Clarify that materialization happens through a series of discrete tasks (`MAT-000` to `MAT-006`) with explicit before/after repository structure
- Rewrite `stack.md` section 12 to show structure evolution: pre-materialization → post-MAT → post-PIL
- Reorganize `backlog-tecnico-piloto.md` to highlight that `MAT-*` tasks are mandatory prerequisites
- Update `PIL-BE-ACE-001` to explicitly depend on the complete `MAT-*` backlog
- Update Serena memory to document the full materialization sequence

## Test plan

- [x] Verify `docs/design-acesso-rapido/stack.md` clearly describes before/after structure
- [x] Verify `docs/backlog/backlog-tecnico-piloto.md` lists `MAT-*` tasks as prerequisites
- [x] Verify `PIL-BE-ACE-001` shows dependency on complete materialization
- [x] Verify Serena memory updated with MAT task breakdown
- [x] No references to external project generators remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)