### PR TITLE
feat: configure DRF/OpenAPI/core API infrastructure (MAT-005)

### DIFF
--- a/apps/core/__init__.py
+++ b/apps/core/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = "apps.core.apps.CoreConfig"

--- a/apps/core/api/exceptions.py
+++ b/apps/core/api/exceptions.py
@@ -1,0 +1,33 @@
+from django.http import JsonResponse
+from rest_framework import status
+from rest_framework.exceptions import APIException
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+
+def api_exception_handler(exc, context):
+    """Custom exception handler for API responses."""
+    response = exception_handler(exc, context)
+
+    if response is None:
+        return Response(
+            {
+                "error": {
+                    "code": "internal_server_error",
+                    "message": "Erro interno do servidor",
+                    "details": None,
+                }
+            },
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        )
+
+    if isinstance(exc, APIException):
+        response.data = {
+            "error": {
+                "code": getattr(exc, "code", "api_error"),
+                "message": str(response.data.get("detail", str(exc))),
+                "details": response.data if response.status_code != 400 else None,
+            }
+        }
+
+    return response

--- a/apps/core/api/pagination.py
+++ b/apps/core/api/pagination.py
@@ -1,0 +1,7 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class StandardPagination(PageNumberPagination):
+    page_size = 20
+    page_size_query_param = "page_size"
+    max_page_size = 100

--- a/apps/core/api/serializers.py
+++ b/apps/core/api/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+
+class ErrorDetailSerializer(serializers.Serializer):
+    code = serializers.CharField()
+    message = serializers.CharField()
+    details = serializers.JSONField(required=False, allow_null=True)
+
+
+class ErrorResponseSerializer(serializers.Serializer):
+    error = ErrorDetailSerializer()

--- a/apps/core/apps.py
+++ b/apps/core/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.core"
+    verbose_name = "Core API Infrastructure"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -24,6 +24,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "drf_spectacular",
     "django_filters",
+    "apps.core",
 ]
 
 MIDDLEWARE = [
@@ -93,8 +94,7 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 20,
+    "DEFAULT_PAGINATION_CLASS": "apps.core.api.pagination.StandardPagination",
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
@@ -103,6 +103,7 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "apps.core.api.exceptions.api_exception_handler",
 }
 
 SPECTACULAR_SETTINGS = {

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,13 @@
 from django.contrib import admin
 from django.urls import path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v1/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "api/v1/docs/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
 ]

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -1,0 +1,73 @@
+"""Smoke tests for DRF/OpenAPI configuration."""
+import json
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+
+@pytest.mark.django_db
+class TestOpenAPISchema:
+    """Test OpenAPI schema generation and accessibility."""
+
+    def test_schema_endpoint_is_accessible(self):
+        """Verify /api/v1/schema/ endpoint is accessible."""
+        client = APIClient()
+        url = reverse("schema")
+        assert url == "/api/v1/schema/"
+
+    def test_schema_returns_valid_json(self):
+        """Verify schema endpoint returns valid JSON."""
+        client = APIClient()
+        response = client.get(reverse("schema"))
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, dict)
+
+    def test_schema_contains_required_fields(self):
+        """Verify schema contains title, description, version."""
+        client = APIClient()
+        response = client.get(reverse("schema"))
+        data = response.json()
+        assert "info" in data
+        assert "title" in data["info"]
+        assert data["info"]["title"] == "ERP-SAEP API"
+
+    def test_swagger_ui_is_accessible(self):
+        """Verify Swagger UI endpoint is accessible."""
+        client = APIClient()
+        url = reverse("swagger-ui")
+        assert url == "/api/v1/docs/"
+
+    def test_swagger_ui_returns_html(self):
+        """Verify Swagger UI returns HTML content."""
+        client = APIClient()
+        response = client.get(reverse("swagger-ui"))
+        assert response.status_code == 200
+        assert b"<!DOCTYPE html>" in response.content or b"<!DOCTYPE" in response.content
+
+    def test_drf_is_properly_configured(self):
+        """Verify DRF is properly configured with custom pagination."""
+        from django.conf import settings
+
+        assert "DEFAULT_PAGINATION_CLASS" in settings.REST_FRAMEWORK
+        assert (
+            settings.REST_FRAMEWORK["DEFAULT_PAGINATION_CLASS"]
+            == "apps.core.api.pagination.StandardPagination"
+        )
+
+    def test_exception_handler_is_configured(self):
+        """Verify custom exception handler is configured."""
+        from django.conf import settings
+
+        assert "EXCEPTION_HANDLER" in settings.REST_FRAMEWORK
+        assert (
+            settings.REST_FRAMEWORK["EXCEPTION_HANDLER"]
+            == "apps.core.api.exceptions.api_exception_handler"
+        )
+
+    def test_core_app_is_installed(self):
+        """Verify apps.core is in INSTALLED_APPS."""
+        from django.conf import settings
+
+        assert "apps.core" in settings.INSTALLED_APPS


### PR DESCRIPTION
## Summary

Set up technical DRF/OpenAPI infrastructure without domain models.

- **apps/core/**: Technical API infrastructure app
  - Standard pagination (20 items/page, max 100)
  - Custom exception handler (error envelope format)
  - Error serializers for API responses
- **API endpoints**:
  - `/api/v1/schema/`: OpenAPI schema (drf-spectacular)
  - `/api/v1/docs/`: Swagger UI documentation
- **DRF configuration**:
  - Custom pagination class
  - Custom exception handler
  - Filter backend for list endpoints
- **Tests**: 8 smoke tests validating schema, docs, and configuration

No domain models, no migrations. Ready for domain apps (PIL-*) to extend.

## Deliverables

- [x] apps/core/ technical app created
- [x] API infrastructure (pagination, exceptions, serializers)
- [x] /api/v1/schema/ endpoint (OpenAPI schema)
- [x] /api/v1/docs/ endpoint (Swagger UI)
- [x] DRF configured with custom pagination and exception handler
- [x] drf-spectacular configured in settings
- [x] django-filter configured in settings
- [x] Smoke tests for schema and docs (8 tests)
- [x] All tests pass

## Validation

All tests pass:
```bash
rtk make test
# or individually:
rtk .venv/bin/pytest tests/test_api_schema.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)