### PR TITLE
feat: PIL-BE-ACE-005 — Implementar criação em nome de terceiros no piloto

### DIFF
--- a/tests/users/test_papeis_policies.py
+++ b/tests/users/test_papeis_policies.py
@@ -117,6 +117,19 @@ class TestPodeCriarRequisicaoPara:
 
         assert pode_criar_requisicao_para(pseudo_chefe, beneficiario) is False
 
+    def test_per03_chefe_setor_nao_pode_criar_para_outro_setor(self):
+        """PER-03 — negado: chefe com setor_responsavel não pode criar para outro setor."""
+        chefe_a = _criar_user("20013", PapelChoices.CHEFE_SETOR)
+        _criar_setor("Jurídico", chefe_a)
+
+        chefe_b = _criar_user("20014", PapelChoices.CHEFE_SETOR)
+        setor_b = _criar_setor("Financeiro", chefe_b)
+
+        beneficiario_b = _criar_user("20015", PapelChoices.SOLICITANTE, setor=setor_b)
+
+        # chefe_a tem setor_responsavel via criação acima, tenta criar para setor_b
+        assert pode_criar_requisicao_para(chefe_a, beneficiario_b) is False
+
     def test_per04_auxiliar_almoxarifado_pode_criar_para_qualquer_funcionario(self):
         """PER-04 — caminho feliz: auxiliar de Almoxarifado cria para qualquer setor."""
         chefe_alm = _criar_user("30001", PapelChoices.CHEFE_ALMOXARIFADO)


### PR DESCRIPTION
## Summary

Completar PIL-BE-ACE-005 — Implementar criação em nome de terceiros no piloto com o teste faltante.

A política de validação de beneficiário (`pode_criar_requisicao_para`) já foi implementada durante PIL-BE-ACE-003. Este PR adiciona o teste de negócio que ainda faltava:

- **Teste adicionado**: Chefe de setor com `setor_responsavel` não pode criar requisição para usuário de outro setor (PER-03)

## Test plan

- [x] Executar testes localmente: `rtk make test`
- [x] Todos os 72 testes passam
- [x] CI verifica linting (ruff) e testes PostgreSQL

## Details

**Invariantes cobertas:**
- PER-01: Solicitante cria apenas para si ✅
- PER-02: Auxiliar de setor atua apenas no próprio setor ✅
- PER-03: Chefe autoriza só setor do beneficiário ✅ (novo teste)
- PER-04: Almoxarifado cria em nome de qualquer funcionário ✅
- PER-05: Chefe de Almoxarifado herda auxiliar de Almoxarifado ✅
- PER-06: Superusuário não é operador cotidiano ✅
- USR-03: Usuário inativo não opera ✅

**Pré-requisito para:**
- PIL-BE-REQ-001 (Criar modelos de requisição)
- PIL-BE-REQ-004 (Integrar permissões de beneficiário na criação)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test ensuring sector managers can only create requisitions within their designated sector, preventing unauthorized cross-sector access attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->