### PR TITLE
chore: alinhar fluxo de CI ao setup efemero via make

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: test-secret-key-for-ci
+      DATABASE_URL: postgres://saep:saep@localhost:5432/test_erp_saep
+      DJANGO_SETTINGS_MODULE: config.settings.test
+      TEST_SETTINGS_MODULE: config.settings.test
     services:
       postgres:
         image: postgres:16
@@ -49,26 +54,13 @@ jobs:
       - uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
-      - name: Install dependencies
-        run: uv sync --locked
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Bootstrap environment
+        run: make init
+      - name: Rebuild ephemeral schema/migrations
+        run: make setup
       - name: Django check
-        env:
-          SECRET_KEY: test-secret-key-for-ci
-          DATABASE_URL: postgres://saep:saep@localhost:5432/test_erp_saep
-          DJANGO_SETTINGS_MODULE: config.settings.test
-        run: |
-          uv run python manage.py check
-      - name: Create ephemeral migrations
-        env:
-          SECRET_KEY: test-secret-key-for-ci
-          DATABASE_URL: postgres://saep:saep@localhost:5432/test_erp_saep
-          DJANGO_SETTINGS_MODULE: config.settings.test
-        run: |
-          uv run python manage.py makemigrations
+        run: uv run python manage.py check
       - name: Run pytest
-        env:
-          SECRET_KEY: test-secret-key-for-ci
-          DATABASE_URL: postgres://saep:saep@localhost:5432/test_erp_saep
-          DJANGO_SETTINGS_MODULE: config.settings.test
-        run: |
-          uv run pytest
+        run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
       - name: Install PostgreSQL client
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Bootstrap environment
-        run: make init
+        run: make init DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
       - name: Rebuild ephemeral schema/migrations
-        run: make setup
+        run: make setup DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
       - name: Django check
         run: uv run python manage.py check
       - name: Run pytest
-        run: make test
+        run: make test DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,9 @@ Durante a fase inicial, o ambiente local é descartável.
 - o banco local pode ser apagado e recriado;
 - o fluxo padrão é resetar banco -> aplicar migrations -> carregar dados mínimos (quando existirem);
 - migrations locais são não versionadas e ignoradas pelo `.gitignore`.
+- `rtk make init` deve ser usado no setup inicial do projeto para criar `.venv` e instalar dependências.
+- `rtk make setup` é o comando principal do ciclo efêmero: apaga migrations locais e recria tudo do zero.
+- neste momento do projeto, toda edição de `models`/schema deve ser seguida de `rtk make setup`, para não depender de gestão manual de migrations.
 - migrations de apps devem ser tratadas como artefato efêmero: antes de testar ou concluir uma implementação que altere schema, apagar e recriar as migrations locais do zero, simulando uma primeira execução limpa do app.
 - confeccionar novos arquivos de migration não faz parte da entrega normal do trabalho neste contexto efêmero.
 - a fonte de verdade para mudanças estruturais são `models`, constraints, índices, regras de domínio e testes; migrations locais servem apenas para materializar o banco local.
@@ -54,8 +57,8 @@ Rotinas principais do projeto via `rtk make`:
 
 - `rtk make help`: lista as rotinas disponíveis;
 - `rtk make prepare`: materializa `.env` a partir de `.env.example`;
-- `rtk make init`: recria o ambiente Python e instala dependências com `uv sync`;
-- `rtk make setup`: limpa o ambiente, recria schema/migrations locais e coleta estáticos;
+- `rtk make init`: bootstrap inicial (uma vez por ambiente) para criar/recriar o ambiente Python e instalar dependências com `uv sync`;
+- `rtk make setup`: comando principal do desenvolvimento efêmero; limpa o ambiente, apaga/recria schema+migrations locais e coleta estáticos; usar sempre após editar `models`/schema;
 - `rtk make clean`: remove caches e artefatos locais sem afetar o banco;
 - `rtk make cleanall`: executa limpeza local e reseta o schema `public` do PostgreSQL;
 - `rtk make veryclean`: remove `.venv`, caches e migrations locais geradas;

--- a/Makefile
+++ b/Makefile
@@ -60,40 +60,39 @@ help: ## Mostrar rotinas disponíveis
 # Bootstrap
 # ------------------------------------------------------------------------------
 
-prepare: ## Materializar .env a partir do exemplo
+prepare: ## Materializar .env a partir do exemplo e instalar dependencias
 	@test -f $(ENV_FILE) || cp $(ENV_EXAMPLE_FILE) $(ENV_FILE)
 
-init: veryclean prepare ## Recriar ambiente Python e instalar dependências
+init: veryclean prepare ## Recriar ambiente Python e instalar dependências	
 	$(UV) sync
+
+compile:: ## Treat file generation
+	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) collectstatic --noinput --clear
 
 # ------------------------------------------------------------------------------
 # Project setup
 # ------------------------------------------------------------------------------
 
-setup: cleanall ## Preparar projeto do zero para desenvolvimento
+setup: clean compile ## Preparar projeto do zero para desenvolvimento
 	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) makemigrations
-	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) migrate
-	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) collectstatic --noinput --clear
+	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) migrate --run-syncdb
 
 # ------------------------------------------------------------------------------
 # Cleaning
 # ------------------------------------------------------------------------------
 
-clean: ## Limpar artefatos locais e caches (sem afetar o banco)
+clean: resetpostgres ## Limpar artefatos locais e caches (sem afetar o banco)
 	-rm -rf $(EPHEMERAL_DIRS)
 	-rm -f $(PID_FILE)
-	-find . -type d -name "__pycache__" -exec rm -rf {} +
-	-find . -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
-
-cleanall: clean resetpostgres ## Limpar tudo incluindo o banco PostgreSQL
-	@:
-
-veryclean: clean cleanall ## Voltar o workspace para um estado quase "do zero"
-	-rm -rf $(VENV_DIR)
-	-find . -path "*/migrations/*.py" \
+		-find . -path "*/migrations/*.py" \
 		-not -name "__init__.py" \
+		-not -path "./$(VENV_DIR)/*" \
 		-delete
-	-find . -path "*/migrations/*.pyc" -delete
+
+veryclean: clean ## Voltar o workspace para um estado "do zero".
+	-rm -rf $(VENV_DIR)
+	find . -iname "*.pyc" -iname "*.pyo" -delete
+	find . -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
 
 # Reset agressivo do PostgreSQL para simular o efeito de apagar um db.sqlite3
 # Requer DATABASE_URL disponível no ambiente/.env e o cliente psql instalado.
@@ -108,15 +107,15 @@ resetpostgres: ## Apagar schema public do PostgreSQL e recriá-lo do zero
 # Extra úteis
 # ------------------------------------------------------------------------------
 
+finish:: ## Stop application execution
+	-test -r $(PID_FILE) && pkill --echo --pidfile $(PID_FILE)
+
 test: ## Rodar testes com settings de teste
+	-rm -fr .pytest_cache/
 	DJANGO_SETTINGS_MODULE=$(TEST_SETTINGS_MODULE) $(UV) run pytest
 
 run: ## Subir servidor de desenvolvimento
 	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) runserver
-
-resetdb: ## Reaplicar migrations do banco atual (sem apagar arquivos de migration)
-	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) migrate zero --noinput
-	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) migrate
 
 .PHONY: help prepare init setup clean cleanall veryclean test run resetdb resetpostgres
 .EXPORT_ALL_VARIABLES:

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ help: ## Mostrar rotinas disponíveis
 # Bootstrap
 # ------------------------------------------------------------------------------
 
-prepare: ## Materializar .env a partir do exemplo e instalar dependencias
+prepare: ## Materializar .env a partir do exemplo
 	@test -f $(ENV_FILE) || cp $(ENV_EXAMPLE_FILE) $(ENV_FILE)
 
 init: veryclean prepare ## Recriar ambiente Python e instalar dependências	

--- a/docs/code-review-guidelines.md
+++ b/docs/code-review-guidelines.md
@@ -11,6 +11,8 @@ O objetivo é orientar o CodeRabbit a fazer revisões alinhadas com o contexto r
 ## Ambiente efêmero (dev local)
 
 O banco de dados local é descartável — o fluxo padrão é resetar e reaplicar migrations do zero.
+`rtk make init` é reservado para o setup inicial do ambiente (venv + dependências).
+`rtk make setup` é o comando principal do ciclo efêmero e deve ser executado sempre que houver edição de `models`/schema.
 
 ### Implicações para review
 


### PR DESCRIPTION
## Objetivo
Alinhar o job de testes do CI ao fluxo efemero definido no projeto, usando os alvos do Makefile como fonte de verdade operacional.

## O que mudou
- Centraliza env vars do job de teste (Django/Postgres).
- Usa make init no bootstrap do ambiente.
- Usa make setup para rebuild efemero de schema/migrations.
- Roda make test em vez de pytest direto.
- Instala cliente PostgreSQL no runner para suportar resetpostgres.

## Resultado esperado
- O CI passa a validar o mesmo fluxo que usamos no dev efemero local.
- Mudancas em models/schema deixam de depender de etapa manual de migrations no workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined development and continuous integration workflows for improved team efficiency.
  * Updated internal documentation for development processes and code review procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->