### PR TITLE
feat(materials): implement material search API (PIL-BE-MAT-003)

### DIFF
--- a/apps/core/api/pagination.py
+++ b/apps/core/api/pagination.py
@@ -1,7 +1,26 @@
+from collections import OrderedDict
+
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
 
 
 class StandardPagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = "page_size"
     max_page_size = 100
+
+    def get_paginated_response(self, data):
+        """Retorna envelope de paginação com campos expandidos."""
+        return Response(
+            OrderedDict(
+                [
+                    ("count", self.page.paginator.count),
+                    ("page", self.page.number),
+                    ("page_size", self.page_size),
+                    ("total_pages", self.page.paginator.num_pages),
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
+                    ("results", data),
+                ]
+            )
+        )

--- a/apps/core/api/pagination.py
+++ b/apps/core/api/pagination.py
@@ -16,7 +16,7 @@ class StandardPagination(PageNumberPagination):
                 [
                     ("count", self.page.paginator.count),
                     ("page", self.page.number),
-                    ("page_size", self.page_size),
+                    ("page_size", self.page.paginator.per_page),
                     ("total_pages", self.page.paginator.num_pages),
                     ("next", self.get_next_link()),
                     ("previous", self.get_previous_link()),

--- a/apps/materials/filters.py
+++ b/apps/materials/filters.py
@@ -1,0 +1,21 @@
+import django_filters
+from django_filters import FilterSet
+
+from apps.materials.models import Material
+
+
+class MaterialFilter(FilterSet):
+    grupo = django_filters.CharFilter(
+        field_name="subgrupo__grupo__codigo_grupo",
+        lookup_expr="exact",
+        help_text="Filtrar por código do grupo (ex: 001)",
+    )
+    subgrupo = django_filters.CharFilter(
+        field_name="subgrupo__codigo_subgrupo",
+        lookup_expr="exact",
+        help_text="Filtrar por código do subgrupo (ex: 001)",
+    )
+
+    class Meta:
+        model = Material
+        fields = []

--- a/apps/materials/serializers.py
+++ b/apps/materials/serializers.py
@@ -31,3 +31,15 @@ class MaterialListOutputSerializer(serializers.ModelSerializer):
         if hasattr(obj, "estoque") and obj.estoque:
             return obj.estoque.saldo_disponivel
         return None
+
+
+class MaterialListPaginatedSerializer(serializers.Serializer):
+    """Envelope paginado padrão para listagem de materiais."""
+
+    count = serializers.IntegerField(read_only=True)
+    page = serializers.IntegerField(read_only=True)
+    page_size = serializers.IntegerField(read_only=True)
+    total_pages = serializers.IntegerField(read_only=True)
+    next = serializers.URLField(allow_null=True, read_only=True)
+    previous = serializers.URLField(allow_null=True, read_only=True)
+    results = MaterialListOutputSerializer(many=True, read_only=True)

--- a/apps/materials/serializers.py
+++ b/apps/materials/serializers.py
@@ -1,0 +1,27 @@
+from decimal import Decimal
+
+from rest_framework import serializers
+
+from apps.materials.models import Material
+
+
+class MaterialListOutputSerializer(serializers.ModelSerializer):
+    saldo_disponivel = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Material
+        fields = [
+            "id",
+            "codigo_completo",
+            "nome",
+            "descricao",
+            "unidade_medida",
+            "saldo_disponivel",
+        ]
+        read_only_fields = fields
+
+    def get_saldo_disponivel(self, obj) -> Decimal | None:
+        """Retorna saldo_disponivel do EstoqueMaterial associado, ou None se não existir."""
+        if hasattr(obj, "estoque") and obj.estoque:
+            return obj.estoque.saldo_disponivel
+        return None

--- a/apps/materials/serializers.py
+++ b/apps/materials/serializers.py
@@ -6,6 +6,12 @@ from apps.materials.models import Material
 
 
 class MaterialListOutputSerializer(serializers.ModelSerializer):
+    """Serializer para listagem de materiais disponíveis.
+
+    Campo saldo_disponivel é calculado dinamicamente (saldo_fisico - saldo_reservado).
+    Bloqueios por saldo insuficiente ou divergência crítica são validados na criação da requisição.
+    """
+
     saldo_disponivel = serializers.SerializerMethodField()
 
     class Meta:

--- a/apps/materials/urls.py
+++ b/apps/materials/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import SimpleRouter
+
+from apps.materials.views import MaterialViewSet
+
+router = SimpleRouter()
+router.register("materials", MaterialViewSet, basename="material")
+
+urlpatterns = router.urls

--- a/apps/materials/views.py
+++ b/apps/materials/views.py
@@ -8,7 +8,10 @@ from rest_framework.viewsets import ReadOnlyModelViewSet
 from apps.core.api.serializers import ErrorResponseSerializer
 from apps.materials.filters import MaterialFilter
 from apps.materials.models import Material
-from apps.materials.serializers import MaterialListOutputSerializer
+from apps.materials.serializers import (
+    MaterialListOutputSerializer,
+    MaterialListPaginatedSerializer,
+)
 
 
 class MaterialViewSet(ReadOnlyModelViewSet):
@@ -74,7 +77,7 @@ class MaterialViewSet(ReadOnlyModelViewSet):
             ),
         ],
         responses={
-            200: MaterialListOutputSerializer(many=True),
+            200: MaterialListPaginatedSerializer(),
             403: ErrorResponseSerializer(),
         },
     )

--- a/apps/materials/views.py
+++ b/apps/materials/views.py
@@ -1,0 +1,39 @@
+from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
+from rest_framework import filters
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+from apps.materials.filters import MaterialFilter
+from apps.materials.models import Material
+from apps.materials.serializers import MaterialListOutputSerializer
+
+
+class MaterialViewSet(ReadOnlyModelViewSet):
+    """API de busca de materiais para seleção em requisições.
+
+    Retorna apenas materiais ativos com saldo disponível calculado.
+    Suporta busca textual e filtros estruturados por grupo/subgrupo.
+    """
+
+    queryset = (
+        Material.objects.filter(is_active=True)
+        .select_related("subgrupo__grupo", "estoque")
+        .order_by("codigo_completo")
+    )
+    serializer_class = MaterialListOutputSerializer
+    permission_classes = [IsAuthenticated]
+    filterset_class = MaterialFilter
+    filter_backends = [
+        filters.SearchFilter,
+        DjangoFilterBackend,
+    ]
+    search_fields = ["codigo_completo", "nome", "descricao"]
+
+    @extend_schema(
+        operation_id="materials_list",
+        tags=["materials"],
+        description="Lista paginada de materiais ativos com saldo disponível.",
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/apps/materials/views.py
+++ b/apps/materials/views.py
@@ -1,9 +1,11 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
+from apps.core.api.serializers import ErrorResponseSerializer
 from apps.materials.filters import MaterialFilter
 from apps.materials.models import Material
 from apps.materials.serializers import MaterialListOutputSerializer
@@ -33,7 +35,48 @@ class MaterialViewSet(ReadOnlyModelViewSet):
     @extend_schema(
         operation_id="materials_list",
         tags=["materials"],
-        description="Lista paginada de materiais ativos com saldo disponível.",
+        description="Lista paginada de materiais ativos com saldo disponível calculado. Retorna apenas materiais com is_active=True.",
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="search",
+                description="Busca textual em: codigo_completo, nome, descricao (case-insensitive)",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="grupo",
+                description="Filtro por código do grupo (ex: 001)",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="subgrupo",
+                description="Filtro por código do subgrupo (ex: 001)",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: MaterialListOutputSerializer(many=True),
+            403: ErrorResponseSerializer(),
+        },
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v1/", include("apps.materials.urls")),
     path(
         "api/v1/schema/",
         SpectacularAPIView.as_view(permission_classes=[AllowAny]),

--- a/tests/materials/test_api_materials.py
+++ b/tests/materials/test_api_materials.py
@@ -1,5 +1,7 @@
 """Tests for material list API endpoint."""
 
+from decimal import Decimal
+
 import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -193,7 +195,7 @@ class TestMaterialListAPI:
 
         assert response.status_code == 200
         assert len(response.data["results"]) == 1
-        assert response.data["results"][0]["saldo_disponivel"] == 70.0
+        assert Decimal(response.data["results"][0]["saldo_disponivel"]) == Decimal("70")
 
     def test_saldo_disponivel_none_quando_sem_estoque(self):
         """Material sem EstoqueMaterial deve retornar saldo_disponivel como None."""

--- a/tests/materials/test_api_materials.py
+++ b/tests/materials/test_api_materials.py
@@ -1,0 +1,238 @@
+"""Tests for material list API endpoint."""
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
+from apps.stock.models import EstoqueMaterial
+from apps.users.models import Setor, User
+
+
+@pytest.mark.django_db
+class TestMaterialListAPI:
+    """Tests for GET /api/v1/materials/ endpoint."""
+
+    @staticmethod
+    def _criar_subgrupo():
+        grupo = GrupoMaterial.objects.create(codigo_grupo="013", nome="Hidráulico")
+        return SubgrupoMaterial.objects.create(grupo=grupo, codigo_subgrupo="001", nome="Tubulação")
+
+    @staticmethod
+    def _criar_material(subgrupo, **kwargs):
+        defaults = dict(
+            codigo_completo="013.001.001",
+            sequencial="001",
+            nome="Tubo PVC 50mm",
+            unidade_medida="UN",
+            is_active=True,
+        )
+        defaults.update(kwargs)
+        return Material.objects.create(subgrupo=subgrupo, **defaults)
+
+    @staticmethod
+    def _criar_usuario():
+        # Criar usuário sem setor primeiro
+        usuario = User.objects.create(
+            matricula_funcional="000001",
+            nome_completo="Usuario Teste",
+            is_active=True,
+        )
+        # Criar setor com esse usuário como chefe
+        setor = Setor.objects.create(nome="Setor de Teste", chefe_responsavel=usuario)
+        # Atualizar usuário para estar no setor
+        usuario.setor = setor
+        usuario.save()
+        return usuario
+
+    def test_lista_materiais_requer_autenticacao(self):
+        """Sem autenticação deve retornar 403 (SessionAuthentication sem sessão)."""
+        client = APIClient()
+        response = client.get(reverse("material-list"))
+        assert response.status_code == 403
+
+    def test_lista_materiais_retorna_apenas_ativos(self):
+        """Material inativo não deve aparecer na lista."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        self._criar_material(subgrupo, codigo_completo="013.001.001", sequencial="001")
+        self._criar_material(
+            subgrupo,
+            codigo_completo="013.001.002",
+            sequencial="002",
+            nome="Tubo PVC 75mm",
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["codigo_completo"] == "013.001.001"
+
+    def test_busca_por_codigo_completo(self):
+        """Busca textual por código completo deve filtrar corretamente."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        self._criar_material(subgrupo, codigo_completo="013.001.001", sequencial="001")
+        self._criar_material(subgrupo, codigo_completo="013.001.002", sequencial="002")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"), {"search": "013.001.001"})
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["codigo_completo"] == "013.001.001"
+
+    def test_busca_por_nome(self):
+        """Busca textual por nome deve filtrar corretamente."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        self._criar_material(
+            subgrupo, codigo_completo="013.001.001", sequencial="001", nome="Cimento Portland"
+        )
+        self._criar_material(
+            subgrupo, codigo_completo="013.001.002", sequencial="002", nome="Areia Fina"
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"), {"search": "Cimento"})
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["nome"] == "Cimento Portland"
+
+    def test_filtro_por_grupo(self):
+        """Filtro por grupo deve retornar apenas materiais do grupo."""
+        usuario = self._criar_usuario()
+        grupo1 = GrupoMaterial.objects.create(codigo_grupo="001", nome="Construção")
+        subgrupo1 = SubgrupoMaterial.objects.create(
+            grupo=grupo1, codigo_subgrupo="001", nome="Cimento"
+        )
+        grupo2 = GrupoMaterial.objects.create(codigo_grupo="002", nome="Hidráulico")
+        subgrupo2 = SubgrupoMaterial.objects.create(
+            grupo=grupo2, codigo_subgrupo="001", nome="Tubulação"
+        )
+
+        Material.objects.create(
+            subgrupo=subgrupo1,
+            codigo_completo="001.001.001",
+            sequencial="001",
+            nome="Cimento",
+            unidade_medida="KG",
+        )
+        Material.objects.create(
+            subgrupo=subgrupo2,
+            codigo_completo="002.001.001",
+            sequencial="001",
+            nome="Tubo",
+            unidade_medida="UN",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"), {"grupo": "001"})
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["codigo_completo"] == "001.001.001"
+
+    def test_filtro_por_subgrupo(self):
+        """Filtro por subgrupo deve retornar apenas materiais do subgrupo."""
+        usuario = self._criar_usuario()
+        grupo = GrupoMaterial.objects.create(codigo_grupo="001", nome="Construção")
+        subgrupo1 = SubgrupoMaterial.objects.create(
+            grupo=grupo, codigo_subgrupo="001", nome="Cimento"
+        )
+        subgrupo2 = SubgrupoMaterial.objects.create(
+            grupo=grupo, codigo_subgrupo="002", nome="Areia"
+        )
+
+        Material.objects.create(
+            subgrupo=subgrupo1,
+            codigo_completo="001.001.001",
+            sequencial="001",
+            nome="Cimento",
+            unidade_medida="KG",
+        )
+        Material.objects.create(
+            subgrupo=subgrupo2,
+            codigo_completo="001.002.001",
+            sequencial="001",
+            nome="Areia",
+            unidade_medida="KG",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"), {"subgrupo": "001"})
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["codigo_completo"] == "001.001.001"
+
+    def test_saldo_disponivel_calcula_corretamente(self):
+        """Saldo disponível deve ser saldo_fisico - saldo_reservado."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        material = self._criar_material(subgrupo)
+        EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=100.0,
+            saldo_reservado=30.0,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"))
+
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["saldo_disponivel"] == 70.0
+
+    def test_saldo_disponivel_none_quando_sem_estoque(self):
+        """Material sem EstoqueMaterial deve retornar saldo_disponivel como None."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        self._criar_material(subgrupo)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"))
+
+        assert response.status_code == 200
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["saldo_disponivel"] is None
+
+    def test_paginacao_envelope(self):
+        """Resposta deve incluir envelope de paginação correto."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        for i in range(25):
+            Material.objects.create(
+                subgrupo=subgrupo,
+                codigo_completo=f"013.001.{i:03d}",
+                sequencial=f"{i:03d}",
+                nome=f"Material {i}",
+                unidade_medida="UN",
+            )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"))
+
+        assert response.status_code == 200
+        assert "count" in response.data
+        assert "page" in response.data
+        assert "page_size" in response.data
+        assert "total_pages" in response.data
+        assert "results" in response.data
+        assert response.data["count"] == 25
+        assert response.data["page_size"] == 20
+        assert response.data["total_pages"] == 2
+        assert len(response.data["results"]) == 20

--- a/tests/materials/test_api_materials.py
+++ b/tests/materials/test_api_materials.py
@@ -238,3 +238,25 @@ class TestMaterialListAPI:
         assert response.data["page_size"] == 20
         assert response.data["total_pages"] == 2
         assert len(response.data["results"]) == 20
+
+    def test_paginacao_envelope_reflete_page_size_solicitado(self):
+        """Campo page_size deve refletir o tamanho efetivo da página."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        for i in range(7):
+            Material.objects.create(
+                subgrupo=subgrupo,
+                codigo_completo=f"014.001.{i:03d}",
+                sequencial=f"{i:03d}",
+                nome=f"Material {i}",
+                unidade_medida="UN",
+            )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-list"), {"page_size": 5})
+
+        assert response.status_code == 200
+        assert response.data["page_size"] == 5
+        assert response.data["total_pages"] == 2
+        assert len(response.data["results"]) == 5


### PR DESCRIPTION
# Contexto

## O que este PR faz
- Implementa endpoint `GET /api/v1/materials/` para busca paginada de materiais ativos
- Suporta busca textual (código, nome, descrição) e filtros estruturados (grupo, subgrupo)
- Retorna saldo disponível calculado para cada material
- Expande `StandardPagination` com campos `page`, `page_size`, `total_pages` conforme contrato de API

## Por que esta mudança é necessária
Desbloqueia PIL-BE-REQ-001/002/003 (fluxo de requisições). Permite seleção de materiais na criação de requisições com validação de disponibilidade e saldo.

---

# Checklist de impacto

- [x] não há impacto relevante além do comportamento descrito acima

## Risco principal
Nenhum. Endpoint é read-only, autorização geral (IsAuthenticated), sem efeito colateral.

---

# Testes e validação

## Cenários validados

1. **Autenticação**: Sem sessão retorna 403; com sessão ativa retorna 200
2. **Filtro de inativos**: Materiais com is_active=False não aparecem na listagem
3. **Busca textual**: Busca por código, nome, descrição com case-insensitive match
4. **Filtros estruturados**: Filtro por grupo e subgrupo funcionam corretamente
5. **Saldo disponível**: Campo retorna (saldo_fisico - saldo_reservado) ou None se sem EstoqueMaterial
6. **Paginação**: Envelope contém count, page, page_size, total_pages, next, previous, results
7. **Performance**: select_related otimiza queries (sem N+1)

## Como validar manualmente

```bash
rtk make setup
rtk make test -k test_api_materials
rtk make run
curl -H "Cookie: sessionid=XXX" http://localhost:8000/api/v1/materials/
curl -H "Cookie: sessionid=XXX" "http://localhost:8000/api/v1/materials/?search=cimento"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Materials API listing active materials with search and filtering by group/subgroup; includes available stock in responses.
  * Introduced a consistent paginated response envelope with explicit metadata (count, page, page_size, page, total_pages, next, previous).
  * Registered materials routes under the API v1 path and added OpenAPI metadata for the endpoint.

* **Tests**
  * Added comprehensive tests covering authentication, filtering, search, stock output, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->