### PR TITLE
feat(requisitions): implement pre-approval request workflow

### DIFF
--- a/apps/core/api/exceptions.py
+++ b/apps/core/api/exceptions.py
@@ -4,6 +4,16 @@ from rest_framework.response import Response
 from rest_framework.views import exception_handler
 
 
+class DomainConflict(APIException):
+    status_code = status.HTTP_409_CONFLICT
+    default_code = "domain_conflict"
+    default_detail = "Conflito de domínio."
+
+    def __init__(self, detail=None, code=None, *, details=None):
+        super().__init__(detail=detail or self.default_detail, code=code)
+        self.details_payload = details
+
+
 def api_exception_handler(exc, context):
     """Custom exception handler for API responses."""
     response = exception_handler(exc, context)
@@ -12,7 +22,7 @@ def api_exception_handler(exc, context):
         return Response(
             {
                 "error": {
-                    "code": "internal_server_error",
+                    "code": "internal_error",
                     "message": "Erro interno do servidor",
                     "details": None,
                 }
@@ -21,11 +31,25 @@ def api_exception_handler(exc, context):
         )
 
     if isinstance(exc, APIException):
+        details = getattr(exc, "details_payload", None)
+        if details is None and isinstance(response.data, dict) and "detail" not in response.data:
+            details = response.data
+
+        if response.status_code == status.HTTP_400_BAD_REQUEST:
+            code = "validation_error"
+            message = "Dados inválidos."
+        else:
+            code = getattr(exc, "default_code", None) or getattr(exc, "code", "api_error")
+            if isinstance(response.data, dict):
+                message = str(response.data.get("detail", str(exc)))
+            else:
+                message = str(exc)
+
         response.data = {
             "error": {
-                "code": getattr(exc, "code", "api_error"),
-                "message": str(response.data.get("detail", str(exc))),
-                "details": response.data if response.status_code != 400 else None,
+                "code": code,
+                "message": message,
+                "details": details,
             }
         }
 

--- a/apps/core/api/exceptions.py
+++ b/apps/core/api/exceptions.py
@@ -17,14 +17,20 @@ class DomainConflict(APIException):
 def api_exception_handler(exc, context):
     """Custom exception handler for API responses."""
     response = exception_handler(exc, context)
+    request = context.get("request") if context else None
 
     if response is None:
+        trace_id = getattr(exc, "trace_id", None)
+        if trace_id is None and request is not None:
+            trace_id = request.META.get("HTTP_X_TRACE_ID")
+
         return Response(
             {
                 "error": {
                     "code": "internal_error",
                     "message": "Erro interno do servidor",
                     "details": None,
+                    "trace_id": trace_id,
                 }
             },
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
@@ -34,6 +40,14 @@ def api_exception_handler(exc, context):
         details = getattr(exc, "details_payload", None)
         if details is None and isinstance(response.data, dict) and "detail" not in response.data:
             details = response.data
+
+        trace_id = None
+        if isinstance(response.data, dict):
+            trace_id = response.data.get("trace_id")
+        if trace_id is None:
+            trace_id = getattr(exc, "trace_id", None)
+        if trace_id is None and request is not None:
+            trace_id = request.META.get("HTTP_X_TRACE_ID")
 
         if response.status_code == status.HTTP_400_BAD_REQUEST:
             code = "validation_error"
@@ -50,6 +64,7 @@ def api_exception_handler(exc, context):
                 "code": code,
                 "message": message,
                 "details": details,
+                "trace_id": trace_id,
             }
         }
 

--- a/apps/requisitions/models.py
+++ b/apps/requisitions/models.py
@@ -179,6 +179,11 @@ class Requisicao(models.Model):
                 name="req_numero_publico_nao_pode_ser_preenchido_em_rascunho_nunca_enviado",
             ),
             models.CheckConstraint(
+                condition=Q(data_envio_autorizacao__isnull=True)
+                | (Q(numero_publico__isnull=False) & ~Q(numero_publico="")),
+                name="req_numero_publico_obrigatorio_quando_enviada",
+            ),
+            models.CheckConstraint(
                 condition=~Q(status=StatusRequisicao.RECUSADA) | Q(motivo_recusa__gt=""),
                 name="req_motivo_recusa_obrigatorio_quando_recusada",
             ),

--- a/apps/requisitions/models.py
+++ b/apps/requisitions/models.py
@@ -28,6 +28,7 @@ class StatusRequisicao(models.TextChoices):
 class TipoEvento(models.TextChoices):
     CRIACAO = "criacao", "Criação"
     ENVIO_AUTORIZACAO = "envio_autorizacao", "Envio para Autorização"
+    RETORNO_RASCUNHO = "retorno_rascunho", "Retorno para Rascunho"
     REENVIO_AUTORIZACAO = "reenvio_autorizacao", "Reenvio para Autorização"
     AUTORIZACAO = "autorizacao", "Autorização"
     RECUSA = "recusa", "Recusa"
@@ -35,6 +36,27 @@ class TipoEvento(models.TextChoices):
     ATENDIMENTO = "atendimento", "Atendimento"
     CANCELAMENTO = "cancelamento", "Cancelamento"
     ESTORNO = "estorno", "Estorno"
+
+
+class SequenciaNumeroRequisicao(models.Model):
+    ano = models.PositiveIntegerField(unique=True)
+    ultimo_numero = models.PositiveIntegerField(default=0)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Sequência Anual de Requisição"
+        verbose_name_plural = "Sequências Anuais de Requisição"
+        ordering = ["-ano"]
+        constraints = [
+            models.CheckConstraint(
+                condition=Q(ultimo_numero__gte=0),
+                name="req_seq_ultimo_numero_nao_negativo",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.ano}: {self.ultimo_numero}"
 
 
 class Requisicao(models.Model):
@@ -152,16 +174,19 @@ class Requisicao(models.Model):
             models.CheckConstraint(
                 condition=Q(numero_publico__isnull=True)
                 | Q(numero_publico="")
-                | ~Q(status=StatusRequisicao.RASCUNHO),
-                name="req_numero_publico_nao_pode_ser_preenchido_em_rascunho",
+                | ~Q(status=StatusRequisicao.RASCUNHO)
+                | Q(data_envio_autorizacao__isnull=False),
+                name="req_numero_publico_nao_pode_ser_preenchido_em_rascunho_nunca_enviado",
             ),
             models.CheckConstraint(
                 condition=~Q(status=StatusRequisicao.RECUSADA) | Q(motivo_recusa__gt=""),
                 name="req_motivo_recusa_obrigatorio_quando_recusada",
             ),
             models.CheckConstraint(
-                condition=~Q(status=StatusRequisicao.CANCELADA) | Q(motivo_cancelamento__gt=""),
-                name="req_motivo_cancelamento_obrigatorio_quando_cancelada",
+                condition=~Q(status=StatusRequisicao.CANCELADA)
+                | Q(motivo_cancelamento__gt="")
+                | Q(data_autorizacao_ou_recusa__isnull=True),
+                name="req_motivo_cancelamento_obrigatorio_quando_cancelada_pos_autorizacao",
             ),
         ]
 

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -1,6 +1,6 @@
 from django.db.models import Q, QuerySet
 
-from apps.requisitions.models import Requisicao
+from apps.requisitions.models import Requisicao, StatusRequisicao
 from apps.users.models import PapelChoices
 from apps.users.policies import pode_autorizar_setor
 
@@ -71,9 +71,15 @@ def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:
         setor_responsavel = getattr(user, "setor_responsavel", None)
         if setor_responsavel is None:
             return Requisicao.objects.none()
-        return Requisicao.objects.filter(setor_beneficiario=setor_responsavel)
+        return Requisicao.objects.filter(
+            setor_beneficiario=setor_responsavel,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+        )
 
     if user.papel == PapelChoices.CHEFE_ALMOXARIFADO and user.setor_id is not None:
-        return Requisicao.objects.filter(setor_beneficiario_id=user.setor_id)
+        return Requisicao.objects.filter(
+            setor_beneficiario_id=user.setor_id,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+        )
 
     return Requisicao.objects.none()

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -22,7 +22,9 @@ def pode_visualizar_requisicao(user, requisicao: Requisicao) -> bool:
     if user.papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
         return _usuario_operacional_ativo(user)
 
-    return _usuario_operacional_ativo(user) and pode_autorizar_setor(user, requisicao.setor_beneficiario)
+    return _usuario_operacional_ativo(user) and pode_autorizar_setor(
+        user, requisicao.setor_beneficiario
+    )
 
 
 def queryset_requisicoes_visiveis(user) -> QuerySet[Requisicao]:

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -1,0 +1,79 @@
+from django.db.models import Q, QuerySet
+
+from apps.requisitions.models import Requisicao
+from apps.users.models import PapelChoices
+from apps.users.policies import pode_autorizar_setor
+
+
+def _usuario_operacional_ativo(user) -> bool:
+    return user.is_authenticated and user.is_active and not user.is_superuser
+
+
+def pode_visualizar_requisicao(user, requisicao: Requisicao) -> bool:
+    if not user.is_authenticated:
+        return False
+
+    if user.is_superuser:
+        return True
+
+    if requisicao.criador_id == user.pk or requisicao.beneficiario_id == user.pk:
+        return True
+
+    if user.papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+        return _usuario_operacional_ativo(user)
+
+    return _usuario_operacional_ativo(user) and pode_autorizar_setor(user, requisicao.setor_beneficiario)
+
+
+def queryset_requisicoes_visiveis(user) -> QuerySet[Requisicao]:
+    queryset = Requisicao.objects.select_related(
+        "criador",
+        "beneficiario",
+        "setor_beneficiario",
+        "chefe_autorizador",
+        "responsavel_atendimento",
+    ).prefetch_related(
+        "itens__material",
+        "eventos__usuario",
+    )
+
+    if not user.is_authenticated:
+        return queryset.none()
+
+    if user.is_superuser:
+        return queryset
+
+    if not _usuario_operacional_ativo(user):
+        return queryset.none()
+
+    if user.papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+        return queryset
+
+    filtro = Q(criador_id=user.pk) | Q(beneficiario_id=user.pk)
+    setor_responsavel = getattr(user, "setor_responsavel", None)
+    if setor_responsavel is not None:
+        filtro |= Q(setor_beneficiario=setor_responsavel)
+
+    return queryset.filter(filtro).distinct()
+
+
+def pode_manipular_pre_autorizacao(user, requisicao: Requisicao) -> bool:
+    return _usuario_operacional_ativo(user) and (
+        requisicao.criador_id == user.pk or requisicao.beneficiario_id == user.pk
+    )
+
+
+def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:
+    if not _usuario_operacional_ativo(user):
+        return Requisicao.objects.none()
+
+    if user.papel == PapelChoices.CHEFE_SETOR:
+        setor_responsavel = getattr(user, "setor_responsavel", None)
+        if setor_responsavel is None:
+            return Requisicao.objects.none()
+        return Requisicao.objects.filter(setor_beneficiario=setor_responsavel)
+
+    if user.papel == PapelChoices.CHEFE_ALMOXARIFADO and user.setor_id is not None:
+        return Requisicao.objects.filter(setor_beneficiario_id=user.setor_id)
+
+    return Requisicao.objects.none()

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -30,7 +30,7 @@ class RequisicaoItemCreateInputSerializer(serializers.Serializer):
 class RequisicaoCreateInputSerializer(serializers.Serializer):
     beneficiario_id = serializers.IntegerField()
     observacao = serializers.CharField(required=False, allow_blank=True, default="")
-    itens = RequisicaoItemCreateInputSerializer(many=True)
+    itens = RequisicaoItemCreateInputSerializer(many=True, min_length=1)
 
 
 class RequisicaoActionOutputSerializer(serializers.ModelSerializer):

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -1,0 +1,108 @@
+from rest_framework import serializers
+
+from apps.requisitions.models import ItemRequisicao, Requisicao
+
+
+class RequisicaoUserOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    matricula_funcional = serializers.CharField(read_only=True)
+    nome_completo = serializers.CharField(read_only=True)
+
+
+class RequisicaoSetorOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    nome = serializers.CharField(read_only=True)
+
+
+class RequisicaoMaterialOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    codigo_completo = serializers.CharField(read_only=True)
+    nome = serializers.CharField(read_only=True)
+    unidade_medida = serializers.CharField(read_only=True)
+
+
+class RequisicaoItemCreateInputSerializer(serializers.Serializer):
+    material_id = serializers.IntegerField()
+    quantidade_solicitada = serializers.DecimalField(max_digits=12, decimal_places=3)
+    observacao = serializers.CharField(required=False, allow_blank=True, default="")
+
+
+class RequisicaoCreateInputSerializer(serializers.Serializer):
+    beneficiario_id = serializers.IntegerField()
+    observacao = serializers.CharField(required=False, allow_blank=True, default="")
+    itens = RequisicaoItemCreateInputSerializer(many=True)
+
+
+class RequisicaoActionOutputSerializer(serializers.ModelSerializer):
+    material = RequisicaoMaterialOutputSerializer(read_only=True)
+
+    class Meta:
+        model = ItemRequisicao
+        fields = [
+            "id",
+            "material",
+            "unidade_medida",
+            "quantidade_solicitada",
+            "quantidade_autorizada",
+            "quantidade_entregue",
+            "justificativa_autorizacao_parcial",
+            "justificativa_atendimento_parcial",
+            "observacao",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
+    criador = RequisicaoUserOutputSerializer(read_only=True)
+    beneficiario = RequisicaoUserOutputSerializer(read_only=True)
+    setor_beneficiario = RequisicaoSetorOutputSerializer(read_only=True)
+    itens = RequisicaoActionOutputSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Requisicao
+        fields = [
+            "id",
+            "numero_publico",
+            "status",
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "data_criacao",
+            "data_envio_autorizacao",
+            "data_autorizacao_ou_recusa",
+            "data_finalizacao",
+            "observacao",
+            "itens",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoPendingApprovalOutputSerializer(serializers.ModelSerializer):
+    criador = RequisicaoUserOutputSerializer(read_only=True)
+    beneficiario = RequisicaoUserOutputSerializer(read_only=True)
+    setor_beneficiario = RequisicaoSetorOutputSerializer(read_only=True)
+    total_itens = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Requisicao
+        fields = [
+            "id",
+            "numero_publico",
+            "status",
+            "data_envio_autorizacao",
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "total_itens",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoPendingApprovalPaginatedSerializer(serializers.Serializer):
+    count = serializers.IntegerField(read_only=True)
+    page = serializers.IntegerField(read_only=True)
+    page_size = serializers.IntegerField(read_only=True)
+    total_pages = serializers.IntegerField(read_only=True)
+    next = serializers.URLField(allow_null=True, read_only=True)
+    previous = serializers.URLField(allow_null=True, read_only=True)
+    results = RequisicaoPendingApprovalOutputSerializer(many=True, read_only=True)

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -1,0 +1,358 @@
+from dataclasses import dataclass
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied, ValidationError
+
+from apps.core.api.exceptions import DomainConflict
+from apps.materials.models import Material
+from apps.requisitions.models import (
+    EventoTimeline,
+    ItemRequisicao,
+    Requisicao,
+    SequenciaNumeroRequisicao,
+    StatusRequisicao,
+    TipoEvento,
+)
+from apps.requisitions.policies import pode_manipular_pre_autorizacao, queryset_fila_autorizacao
+from apps.users.models import PapelChoices
+from apps.users.policies import pode_criar_requisicao_para
+
+User = get_user_model()
+
+
+@dataclass(frozen=True)
+class ItemRascunhoData:
+    material_id: int
+    quantidade_solicitada: Decimal
+    observacao: str = ""
+
+
+def _material_e_estoque_validos(*, material: Material, quantidade_solicitada: Decimal) -> None:
+    errors = {}
+    estoque = getattr(material, "estoque", None)
+
+    if not material.is_active:
+        errors["material_id"] = f"Material {material.codigo_completo} está inativo."
+
+    if estoque is None:
+        errors["material_id"] = f"Material {material.codigo_completo} está sem estoque disponível."
+    else:
+        saldo_disponivel = estoque.saldo_disponivel
+        if saldo_disponivel <= 0:
+            errors["material_id"] = (
+                f"Material {material.codigo_completo} está sem saldo disponível para requisição."
+            )
+        elif quantidade_solicitada > saldo_disponivel:
+            errors["quantidade_solicitada"] = (
+                f"Quantidade solicitada ({quantidade_solicitada}) excede o saldo disponível "
+                f"({saldo_disponivel}) para o material {material.codigo_completo}."
+            )
+
+    if errors:
+        raise DomainConflict("Requisição em conflito com o estado atual do estoque.", details=errors)
+
+
+def _validar_itens_rascunho(itens: list[ItemRascunhoData]) -> list[Material]:
+    if not itens:
+        raise ValidationError({"itens": ["Informe ao menos um item para criar a requisição."]})
+
+    material_ids = [item.material_id for item in itens]
+    if len(set(material_ids)) != len(material_ids):
+        raise ValidationError(
+            {"itens": ["Não informe o mesmo material mais de uma vez na mesma requisição."]}
+        )
+
+    materiais = list(
+        Material.objects.select_related("subgrupo__grupo", "estoque")
+        .filter(pk__in=material_ids)
+        .order_by("codigo_completo")
+    )
+    materiais_por_id = {material.pk: material for material in materiais}
+
+    missing_ids = [material_id for material_id in material_ids if material_id not in materiais_por_id]
+    if missing_ids:
+        raise ValidationError({"itens": [f"Materiais inexistentes: {missing_ids}."]})
+
+    for item in itens:
+        if item.quantidade_solicitada <= 0:
+            raise ValidationError(
+                {
+                    "itens": [
+                        "Quantidade solicitada deve ser maior que zero para todos os itens."
+                    ]
+                }
+            )
+        _material_e_estoque_validos(
+            material=materiais_por_id[item.material_id],
+            quantidade_solicitada=item.quantidade_solicitada,
+        )
+
+    return [materiais_por_id[item.material_id] for item in itens]
+
+
+def _gerar_numero_publico(*, ano: int | None = None) -> str:
+    ano = ano or timezone.localdate().year
+
+    with transaction.atomic():
+        try:
+            sequencia = (
+                SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
+            )
+        except SequenciaNumeroRequisicao.DoesNotExist:
+            try:
+                sequencia = SequenciaNumeroRequisicao.objects.create(ano=ano, ultimo_numero=0)
+            except IntegrityError:
+                sequencia = (
+                    SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
+                )
+
+        sequencia.ultimo_numero += 1
+        sequencia.save(update_fields=["ultimo_numero", "updated_at"])
+        return f"REQ-{ano}-{sequencia.ultimo_numero:06d}"
+
+
+def criar_rascunho_requisicao(
+    *,
+    criador: User,
+    beneficiario: User,
+    observacao: str,
+    itens: list[ItemRascunhoData],
+) -> Requisicao:
+    if not pode_criar_requisicao_para(criador, beneficiario):
+        raise PermissionDenied("Usuário sem permissão para criar requisição para este beneficiário.")
+
+    if beneficiario.setor_id is None:
+        raise ValidationError(
+            {"beneficiario_id": ["Beneficiário deve possuir setor para criar a requisição."]}
+        )
+
+    if not beneficiario.setor.is_active:
+        raise DomainConflict(
+            "Setor do beneficiário está inativo.",
+            details={"beneficiario_id": f"Setor '{beneficiario.setor.nome}' está inativo."},
+        )
+
+    materiais = _validar_itens_rascunho(itens)
+
+    with transaction.atomic():
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario,
+            observacao=observacao,
+        )
+        materiais_por_id = {material.pk: material for material in materiais}
+        ItemRequisicao.objects.bulk_create(
+            [
+                ItemRequisicao(
+                    requisicao=requisicao,
+                    material=materiais_por_id[item.material_id],
+                    unidade_medida=materiais_por_id[item.material_id].unidade_medida,
+                    quantidade_solicitada=item.quantidade_solicitada,
+                    observacao=item.observacao,
+                )
+                for item in itens
+            ]
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+        )
+        .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
+    if not pode_manipular_pre_autorizacao(ator, requisicao):
+        raise PermissionDenied("Apenas criador ou beneficiário podem enviar a requisição.")
+
+    with transaction.atomic():
+        requisicao = (
+            Requisicao.objects.select_for_update()
+            .select_related("criador", "beneficiario", "setor_beneficiario")
+            .prefetch_related("itens__material__estoque", "eventos__usuario")
+            .get(pk=requisicao.pk)
+        )
+
+        if requisicao.status != StatusRequisicao.RASCUNHO:
+            raise DomainConflict(
+                "Somente requisições em rascunho podem ser enviadas para autorização.",
+                details={"status_atual": requisicao.status},
+            )
+
+        itens = list(requisicao.itens.all())
+        if not itens:
+            raise DomainConflict(
+                "Requisição sem itens não pode ser enviada.",
+                details={"itens": "Adicione ao menos um item válido antes do envio."},
+            )
+
+        for item in itens:
+            _material_e_estoque_validos(
+                material=item.material,
+                quantidade_solicitada=item.quantidade_solicitada,
+            )
+
+        is_primeiro_envio = not requisicao.numero_publico
+        if is_primeiro_envio:
+            numero_publico = _gerar_numero_publico()
+            requisicao.numero_publico = numero_publico
+            requisicao.data_envio_autorizacao = timezone.now()
+
+        requisicao.status = StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        requisicao.full_clean()
+        requisicao.save(
+            update_fields=[
+                "numero_publico",
+                "status",
+                "data_envio_autorizacao",
+                "updated_at",
+            ]
+        )
+        EventoTimeline.objects.create(
+            requisicao=requisicao,
+            tipo_evento=(
+                TipoEvento.ENVIO_AUTORIZACAO if is_primeiro_envio else TipoEvento.REENVIO_AUTORIZACAO
+            ),
+            usuario=ator,
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+        )
+        .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def retornar_para_rascunho(*, requisicao: Requisicao, ator: User) -> Requisicao:
+    if not pode_manipular_pre_autorizacao(ator, requisicao):
+        raise PermissionDenied("Apenas criador ou beneficiário podem retornar a requisição.")
+
+    with transaction.atomic():
+        requisicao = (
+            Requisicao.objects.select_for_update()
+            .select_related("criador", "beneficiario", "setor_beneficiario")
+            .prefetch_related("itens__material", "eventos__usuario")
+            .get(pk=requisicao.pk)
+        )
+
+        if requisicao.status != StatusRequisicao.AGUARDANDO_AUTORIZACAO:
+            raise DomainConflict(
+                "Somente requisições aguardando autorização podem retornar para rascunho.",
+                details={"status_atual": requisicao.status},
+            )
+
+        requisicao.status = StatusRequisicao.RASCUNHO
+        requisicao.save(update_fields=["status", "updated_at"])
+        EventoTimeline.objects.create(
+            requisicao=requisicao,
+            tipo_evento=TipoEvento.RETORNO_RASCUNHO,
+            usuario=ator,
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+        )
+        .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> None:
+    if not pode_manipular_pre_autorizacao(ator, requisicao):
+        raise PermissionDenied("Apenas criador ou beneficiário podem descartar a requisição.")
+
+    with transaction.atomic():
+        requisicao = (
+            Requisicao.objects.select_for_update()
+            .prefetch_related("itens")
+            .get(pk=requisicao.pk)
+        )
+
+        if requisicao.status != StatusRequisicao.RASCUNHO:
+            raise DomainConflict(
+                "Somente requisições em rascunho podem ser descartadas.",
+                details={"status_atual": requisicao.status},
+            )
+        if requisicao.numero_publico or requisicao.data_envio_autorizacao is not None:
+            raise DomainConflict(
+                "Rascunho já formalizado deve ser cancelado logicamente, não descartado.",
+                details={"numero_publico": requisicao.numero_publico},
+            )
+
+        requisicao.itens.all().delete()
+        requisicao.delete()
+
+
+def cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
+    if not pode_manipular_pre_autorizacao(ator, requisicao):
+        raise PermissionDenied("Apenas criador ou beneficiário podem cancelar a requisição.")
+
+    with transaction.atomic():
+        requisicao = (
+            Requisicao.objects.select_for_update()
+            .select_related("criador", "beneficiario", "setor_beneficiario")
+            .prefetch_related("itens__material", "eventos__usuario")
+            .get(pk=requisicao.pk)
+        )
+
+        if requisicao.status == StatusRequisicao.RASCUNHO:
+            if not requisicao.numero_publico:
+                raise DomainConflict(
+                    "Rascunho nunca enviado deve ser descartado, não cancelado logicamente.",
+                    details={"status_atual": requisicao.status},
+                )
+        elif requisicao.status != StatusRequisicao.AGUARDANDO_AUTORIZACAO:
+            raise DomainConflict(
+                "Somente rascunhos já formalizados ou requisições aguardando autorização podem ser cancelados.",
+                details={"status_atual": requisicao.status},
+            )
+
+        requisicao.status = StatusRequisicao.CANCELADA
+        requisicao.data_finalizacao = timezone.now()
+        requisicao.save(update_fields=["status", "data_finalizacao", "updated_at"])
+        EventoTimeline.objects.create(
+            requisicao=requisicao,
+            tipo_evento=TipoEvento.CANCELAMENTO,
+            usuario=ator,
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+        )
+        .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def listar_fila_autorizacao(*, ator: User):
+    if not ator.is_authenticated:
+        raise PermissionDenied("Usuário precisa estar autenticado para ver a fila de autorizações.")
+    if ator.is_superuser or not ator.is_active:
+        raise PermissionDenied("Usuário sem permissão para acessar a fila de autorizações.")
+    if ator.papel not in (PapelChoices.CHEFE_SETOR, PapelChoices.CHEFE_ALMOXARIFADO):
+        raise PermissionDenied("Usuário sem permissão para acessar a fila de autorizações.")
+
+    queryset = queryset_fila_autorizacao(ator)
+    return (
+        queryset.filter(status=StatusRequisicao.AGUARDANDO_AUTORIZACAO)
+        .select_related("criador", "beneficiario", "setor_beneficiario")
+        .prefetch_related("itens__material")
+        .order_by("data_envio_autorizacao", "id")
+    )

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -52,7 +52,9 @@ def _material_e_estoque_validos(*, material: Material, quantidade_solicitada: De
             )
 
     if errors:
-        raise DomainConflict("Requisição em conflito com o estado atual do estoque.", details=errors)
+        raise DomainConflict(
+            "Requisição em conflito com o estado atual do estoque.", details=errors
+        )
 
 
 def _validar_itens_rascunho(itens: list[ItemRascunhoData]) -> list[Material]:
@@ -72,18 +74,16 @@ def _validar_itens_rascunho(itens: list[ItemRascunhoData]) -> list[Material]:
     )
     materiais_por_id = {material.pk: material for material in materiais}
 
-    missing_ids = [material_id for material_id in material_ids if material_id not in materiais_por_id]
+    missing_ids = [
+        material_id for material_id in material_ids if material_id not in materiais_por_id
+    ]
     if missing_ids:
         raise ValidationError({"itens": [f"Materiais inexistentes: {missing_ids}."]})
 
     for item in itens:
         if item.quantidade_solicitada <= 0:
             raise ValidationError(
-                {
-                    "itens": [
-                        "Quantidade solicitada deve ser maior que zero para todos os itens."
-                    ]
-                }
+                {"itens": ["Quantidade solicitada deve ser maior que zero para todos os itens."]}
             )
         _material_e_estoque_validos(
             material=materiais_por_id[item.material_id],
@@ -98,16 +98,12 @@ def _gerar_numero_publico(*, ano: int | None = None) -> str:
 
     with transaction.atomic():
         try:
-            sequencia = (
-                SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
-            )
+            sequencia = SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
         except SequenciaNumeroRequisicao.DoesNotExist:
             try:
                 sequencia = SequenciaNumeroRequisicao.objects.create(ano=ano, ultimo_numero=0)
             except IntegrityError:
-                sequencia = (
-                    SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
-                )
+                sequencia = SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
 
         sequencia.ultimo_numero += 1
         sequencia.save(update_fields=["ultimo_numero", "updated_at"])
@@ -122,7 +118,9 @@ def criar_rascunho_requisicao(
     itens: list[ItemRascunhoData],
 ) -> Requisicao:
     if not pode_criar_requisicao_para(criador, beneficiario):
-        raise PermissionDenied("Usuário sem permissão para criar requisição para este beneficiário.")
+        raise PermissionDenied(
+            "Usuário sem permissão para criar requisição para este beneficiário."
+        )
 
     if beneficiario.setor_id is None:
         raise ValidationError(
@@ -218,7 +216,9 @@ def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao
         EventoTimeline.objects.create(
             requisicao=requisicao,
             tipo_evento=(
-                TipoEvento.ENVIO_AUTORIZACAO if is_primeiro_envio else TipoEvento.REENVIO_AUTORIZACAO
+                TipoEvento.ENVIO_AUTORIZACAO
+                if is_primeiro_envio
+                else TipoEvento.REENVIO_AUTORIZACAO
             ),
             usuario=ator,
         )
@@ -277,9 +277,7 @@ def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> N
 
     with transaction.atomic():
         requisicao = (
-            Requisicao.objects.select_for_update()
-            .prefetch_related("itens")
-            .get(pk=requisicao.pk)
+            Requisicao.objects.select_for_update().prefetch_related("itens").get(pk=requisicao.pk)
         )
 
         if requisicao.status != StatusRequisicao.RASCUNHO:

--- a/apps/requisitions/urls.py
+++ b/apps/requisitions/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import SimpleRouter
+
+from apps.requisitions.views import RequisicaoViewSet
+
+router = SimpleRouter()
+router.register("requisitions", RequisicaoViewSet, basename="requisicao")
+
+urlpatterns = router.urls

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -1,0 +1,167 @@
+from django.contrib.auth import get_user_model
+from django.db.models import Count
+from django.shortcuts import get_object_or_404
+from drf_spectacular.openapi import OpenApiParameter
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from apps.core.api.serializers import ErrorResponseSerializer
+from apps.requisitions.policies import queryset_requisicoes_visiveis
+from apps.requisitions.serializers import (
+    RequisicaoCreateInputSerializer,
+    RequisicaoDetailOutputSerializer,
+    RequisicaoPendingApprovalOutputSerializer,
+    RequisicaoPendingApprovalPaginatedSerializer,
+)
+from apps.requisitions.services import (
+    ItemRascunhoData,
+    cancelar_pre_autorizacao,
+    criar_rascunho_requisicao,
+    descartar_rascunho_nunca_enviado,
+    enviar_para_autorizacao,
+    listar_fila_autorizacao,
+    retornar_para_rascunho,
+)
+
+User = get_user_model()
+
+
+class RequisicaoViewSet(GenericViewSet):
+    permission_classes = [IsAuthenticated]
+    serializer_class = RequisicaoDetailOutputSerializer
+
+    def get_queryset(self):
+        return queryset_requisicoes_visiveis(self.request.user)
+
+    def get_object(self):
+        queryset = self.filter_queryset(self.get_queryset())
+        obj = get_object_or_404(queryset, pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    @extend_schema(
+        operation_id="requisitions_create_draft",
+        tags=["requisitions"],
+        request=RequisicaoCreateInputSerializer,
+        responses={
+            201: RequisicaoDetailOutputSerializer(),
+            400: ErrorResponseSerializer(),
+            403: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    def create(self, request, *args, **kwargs):
+        serializer = RequisicaoCreateInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        beneficiario = get_object_or_404(User.objects.select_related("setor"), pk=serializer.validated_data["beneficiario_id"])
+        requisicao = criar_rascunho_requisicao(
+            criador=request.user,
+            beneficiario=beneficiario,
+            observacao=serializer.validated_data["observacao"],
+            itens=[
+                ItemRascunhoData(**item_data)
+                for item_data in serializer.validated_data["itens"]
+            ],
+        )
+        output = RequisicaoDetailOutputSerializer(requisicao)
+        return Response(output.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        operation_id="requisitions_submit",
+        tags=["requisitions"],
+        request=None,
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="submit")
+    def submit(self, request, pk=None):
+        requisicao = enviar_para_autorizacao(requisicao=self.get_object(), ator=request.user)
+        return Response(RequisicaoDetailOutputSerializer(requisicao).data)
+
+    @extend_schema(
+        operation_id="requisitions_return_to_draft",
+        tags=["requisitions"],
+        request=None,
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="return-to-draft")
+    def return_to_draft(self, request, pk=None):
+        requisicao = retornar_para_rascunho(requisicao=self.get_object(), ator=request.user)
+        return Response(RequisicaoDetailOutputSerializer(requisicao).data)
+
+    @extend_schema(
+        operation_id="requisitions_discard",
+        tags=["requisitions"],
+        request=None,
+        responses={
+            204: None,
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["delete"], url_path="discard")
+    def discard(self, request, pk=None):
+        descartar_rascunho_nunca_enviado(requisicao=self.get_object(), ator=request.user)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    @extend_schema(
+        operation_id="requisitions_cancel_pre_approval",
+        tags=["requisitions"],
+        request=None,
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="cancel")
+    def cancel(self, request, pk=None):
+        requisicao = cancelar_pre_autorizacao(requisicao=self.get_object(), ator=request.user)
+        return Response(RequisicaoDetailOutputSerializer(requisicao).data)
+
+    @extend_schema(
+        operation_id="requisitions_pending_approvals",
+        tags=["requisitions"],
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: RequisicaoPendingApprovalPaginatedSerializer(),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="pending-approvals")
+    def pending_approvals(self, request):
+        queryset = listar_fila_autorizacao(ator=request.user).annotate(total_itens=Count("itens"))
+        page = self.paginate_queryset(queryset)
+        serializer = RequisicaoPendingApprovalOutputSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -58,14 +58,15 @@ class RequisicaoViewSet(GenericViewSet):
         serializer = RequisicaoCreateInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        beneficiario = get_object_or_404(User.objects.select_related("setor"), pk=serializer.validated_data["beneficiario_id"])
+        beneficiario = get_object_or_404(
+            User.objects.select_related("setor"), pk=serializer.validated_data["beneficiario_id"]
+        )
         requisicao = criar_rascunho_requisicao(
             criador=request.user,
             beneficiario=beneficiario,
             observacao=serializer.validated_data["observacao"],
             itens=[
-                ItemRascunhoData(**item_data)
-                for item_data in serializer.validated_data["itens"]
+                ItemRascunhoData(**item_data) for item_data in serializer.validated_data["itens"]
             ],
         )
         output = RequisicaoDetailOutputSerializer(requisicao)

--- a/config/urls.py
+++ b/config/urls.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import AllowAny
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/v1/", include("apps.materials.urls")),
+    path("api/v1/", include("apps.requisitions.urls")),
     path(
         "api/v1/schema/",
         SpectacularAPIView.as_view(permission_classes=[AllowAny]),

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -299,6 +299,31 @@ class TestRequisicaoAPI:
         assert response.status_code == 204
         assert not Requisicao.objects.filter(pk=requisicao.pk).exists()
 
+    def test_discard_rascunho_formalizado_retorna_domain_conflict(self):
+        setor = self._criar_setor("Fiscal Formalizado", "900111")
+        usuario = self._criar_usuario("100121", "Solicitante Fiscal Formalizado", setor=setor)
+        material = self._criar_material_com_estoque("001.001.099")
+        requisicao = Requisicao.objects.create(
+            criador=usuario,
+            beneficiario=usuario,
+            numero_publico="REQ-2026-009999",
+            status=StatusRequisicao.RASCUNHO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.delete(reverse("requisicao-discard", args=[requisicao.id]))
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"
+        assert Requisicao.objects.filter(pk=requisicao.pk).exists()
+
     def test_cancela_rascunho_numerado_sem_justificativa(self):
         setor = self._criar_setor("Almox Interno", "90012")
         usuario = self._criar_usuario("10013", "Solicitante Almox Interno", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1,0 +1,380 @@
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
+from apps.requisitions.models import EventoTimeline, Requisicao, StatusRequisicao, TipoEvento
+from apps.stock.models import EstoqueMaterial
+from apps.users.models import PapelChoices, Setor, User
+
+
+@pytest.mark.django_db
+class TestRequisicaoAPI:
+    @staticmethod
+    def _criar_setor(nome: str, chefe_matricula: str, papel=PapelChoices.CHEFE_SETOR) -> Setor:
+        chefe = User.objects.create(
+            matricula_funcional=chefe_matricula,
+            nome_completo=f"Chefe {nome}",
+            papel=papel,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome=nome, chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        return setor
+
+    @staticmethod
+    def _criar_usuario(
+        matricula: str,
+        nome: str,
+        *,
+        papel=PapelChoices.SOLICITANTE,
+        setor: Setor | None = None,
+        is_active: bool = True,
+    ) -> User:
+        return User.objects.create(
+            matricula_funcional=matricula,
+            nome_completo=nome,
+            papel=papel,
+            setor=setor,
+            is_active=is_active,
+        )
+
+    @staticmethod
+    def _criar_material_com_estoque(
+        codigo: str,
+        *,
+        saldo_fisico: Decimal = Decimal("10"),
+        saldo_reservado: Decimal = Decimal("0"),
+        is_active: bool = True,
+    ) -> Material:
+        grupo_codigo, subgrupo_codigo, sequencial = codigo.split(".")
+        grupo, _ = GrupoMaterial.objects.get_or_create(
+            codigo_grupo=grupo_codigo,
+            defaults={"nome": f"Grupo {grupo_codigo}"},
+        )
+        subgrupo, _ = SubgrupoMaterial.objects.get_or_create(
+            grupo=grupo,
+            codigo_subgrupo=subgrupo_codigo,
+            defaults={"nome": f"Subgrupo {subgrupo_codigo}"},
+        )
+        material = Material.objects.create(
+            subgrupo=subgrupo,
+            codigo_completo=codigo,
+            sequencial=sequencial,
+            nome=f"Material {codigo}",
+            unidade_medida="UN",
+            is_active=is_active,
+        )
+        EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=saldo_fisico,
+            saldo_reservado=saldo_reservado,
+        )
+        return material
+
+    @staticmethod
+    def _payload_requisicao(*, beneficiario_id: int, material_id: int, quantidade="2.000"):
+        return {
+            "beneficiario_id": beneficiario_id,
+            "observacao": "Observacao de teste",
+            "itens": [
+                {
+                    "material_id": material_id,
+                    "quantidade_solicitada": quantidade,
+                    "observacao": "Item de teste",
+                }
+            ],
+        }
+
+    def test_cria_rascunho_para_si(self):
+        setor = self._criar_setor("Operacional", "90001")
+        usuario = self._criar_usuario("10001", "Solicitante", setor=setor)
+        material = self._criar_material_com_estoque("001.001.001")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(beneficiario_id=usuario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert response.data["status"] == StatusRequisicao.RASCUNHO
+        assert response.data["numero_publico"] is None
+        assert response.data["beneficiario"]["id"] == usuario.id
+        assert response.data["setor_beneficiario"]["id"] == setor.id
+        assert response.data["itens"][0]["material"]["id"] == material.id
+        assert Requisicao.objects.count() == 1
+
+    def test_bloqueia_criacao_para_outro_setor_por_solicitante(self):
+        setor_a = self._criar_setor("Financeiro", "90002")
+        setor_b = self._criar_setor("Obras", "90003")
+        solicitante = self._criar_usuario("10002", "Solicitante A", setor=setor_a)
+        beneficiario = self._criar_usuario("10003", "Beneficiario B", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.002")
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_auxiliar_setor_pode_criar_para_funcionario_do_mesmo_setor(self):
+        setor = self._criar_setor("TI", "90004")
+        auxiliar = self._criar_usuario(
+            "10004",
+            "Auxiliar TI",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor,
+        )
+        beneficiario = self._criar_usuario("10005", "Funcionario TI", setor=setor)
+        material = self._criar_material_com_estoque("001.001.003")
+
+        client = APIClient()
+        client.force_authenticate(user=auxiliar)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 201
+        assert response.data["beneficiario"]["id"] == beneficiario.id
+
+    def test_bloqueia_rascunho_sem_itens(self):
+        setor = self._criar_setor("RH", "90005")
+        usuario = self._criar_usuario("10006", "Solicitante RH", setor=setor)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("requisicao-list"),
+            {"beneficiario_id": usuario.id, "itens": []},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data["error"]["code"] == "validation_error"
+
+    def test_bloqueia_criacao_com_material_inativo(self):
+        setor = self._criar_setor("Compras", "90006")
+        usuario = self._criar_usuario("10007", "Solicitante Compras", setor=setor)
+        material = self._criar_material_com_estoque("001.001.004", is_active=False)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(beneficiario_id=usuario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"
+
+    def test_bloqueia_criacao_com_quantidade_maior_que_saldo(self):
+        setor = self._criar_setor("Juridico", "90007")
+        usuario = self._criar_usuario("10008", "Solicitante Juridico", setor=setor)
+        material = self._criar_material_com_estoque("001.001.005", saldo_fisico=Decimal("3"))
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(
+                beneficiario_id=usuario.id,
+                material_id=material.id,
+                quantidade="5.000",
+            ),
+            format="json",
+        )
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"
+
+    def test_submit_gera_numero_publico_e_entrada_na_fila(self):
+        setor = self._criar_setor("Planejamento", "90008")
+        usuario = self._criar_usuario("10009", "Solicitante Planejamento", setor=setor)
+        material = self._criar_material_com_estoque("001.001.006")
+        requisicao = Requisicao.objects.create(criador=usuario, beneficiario=usuario)
+        item = requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+        assert item.quantidade_autorizada == 0
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(reverse("requisicao-submit", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        assert response.data["numero_publico"] == "REQ-2026-000001"
+        requisicao.refresh_from_db()
+        assert requisicao.numero_publico == "REQ-2026-000001"
+        assert requisicao.eventos.filter(tipo_evento=TipoEvento.ENVIO_AUTORIZACAO).exists()
+
+    def test_return_to_draft_preserva_numero_publico(self):
+        setor = self._criar_setor("Patrimonio", "90009")
+        usuario = self._criar_usuario("10010", "Solicitante Patrimonio", setor=setor)
+        material = self._criar_material_com_estoque("001.001.007")
+        requisicao = Requisicao.objects.create(
+            criador=usuario,
+            beneficiario=usuario,
+            numero_publico="REQ-2026-000010",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(reverse("requisicao-return-to-draft", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.RASCUNHO
+        assert response.data["numero_publico"] == "REQ-2026-000010"
+        assert EventoTimeline.objects.filter(
+            requisicao=requisicao,
+            tipo_evento=TipoEvento.RETORNO_RASCUNHO,
+        ).exists()
+
+    def test_reenvio_preserva_numero_publico(self):
+        setor = self._criar_setor("Frota", "90010")
+        usuario = self._criar_usuario("10011", "Solicitante Frota", setor=setor)
+        material = self._criar_material_com_estoque("001.001.008")
+        requisicao = Requisicao.objects.create(
+            criador=usuario,
+            beneficiario=usuario,
+            numero_publico="REQ-2026-000123",
+            status=StatusRequisicao.RASCUNHO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(reverse("requisicao-submit", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["numero_publico"] == "REQ-2026-000123"
+        assert EventoTimeline.objects.filter(
+            requisicao=requisicao,
+            tipo_evento=TipoEvento.REENVIO_AUTORIZACAO,
+        ).exists()
+
+    def test_discard_remove_rascunho_nunca_enviado(self):
+        setor = self._criar_setor("Fiscal", "90011")
+        usuario = self._criar_usuario("10012", "Solicitante Fiscal", setor=setor)
+        material = self._criar_material_com_estoque("001.001.009")
+        requisicao = Requisicao.objects.create(criador=usuario, beneficiario=usuario)
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.delete(reverse("requisicao-discard", args=[requisicao.id]))
+
+        assert response.status_code == 204
+        assert not Requisicao.objects.filter(pk=requisicao.pk).exists()
+
+    def test_cancela_rascunho_numerado_sem_justificativa(self):
+        setor = self._criar_setor("Almox Interno", "90012")
+        usuario = self._criar_usuario("10013", "Solicitante Almox Interno", setor=setor)
+        material = self._criar_material_com_estoque("001.001.010")
+        requisicao = Requisicao.objects.create(
+            criador=usuario,
+            beneficiario=usuario,
+            numero_publico="REQ-2026-000200",
+            status=StatusRequisicao.RASCUNHO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(reverse("requisicao-cancel", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.CANCELADA
+        assert response.data["numero_publico"] == "REQ-2026-000200"
+
+    def test_fila_autorizacao_retorna_apenas_setor_do_chefe(self):
+        setor_a = self._criar_setor("Administrativo", "90013")
+        setor_b = self._criar_setor("Obras B", "90014")
+        chefe_a = setor_a.chefe_responsavel
+        solicitante_a = self._criar_usuario("10014", "Solicitante A", setor=setor_a)
+        solicitante_b = self._criar_usuario("10015", "Solicitante B", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.011")
+
+        req_a = Requisicao.objects.create(
+            criador=solicitante_a,
+            beneficiario=solicitante_a,
+            numero_publico="REQ-2026-000300",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        req_a.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+        req_b = Requisicao.objects.create(
+            criador=solicitante_b,
+            beneficiario=solicitante_b,
+            numero_publico="REQ-2026-000301",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T11:00:00Z",
+        )
+        req_b.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_a)
+        response = client.get(reverse("requisicao-pending-approvals"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == req_a.id
+        assert response.data["results"][0]["numero_publico"] == "REQ-2026-000300"
+        assert response.data["results"][0]["total_itens"] == 1
+        assert req_b.id not in [item["id"] for item in response.data["results"]]
+
+    def test_fila_autorizacao_bloqueia_papel_sem_permissao(self):
+        setor = self._criar_setor("Gabinete", "90015")
+        solicitante = self._criar_usuario("10016", "Solicitante Gabinete", setor=setor)
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.get(reverse("requisicao-pending-approvals"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"

--- a/tests/requisitions/test_models.py
+++ b/tests/requisitions/test_models.py
@@ -178,20 +178,32 @@ class TestRequisicaoModel:
         req.save()
         assert req.status == StatusRequisicao.RECUSADA
 
-    def test_constraint_motivo_cancelamento_obrigatorio(self):
-        """REQ-domain — motivo_cancelamento obrigatório quando status=cancelada"""
+    def test_constraint_motivo_cancelamento_obrigatorio_pos_autorizacao(self):
+        """REQ-domain — motivo_cancelamento obrigatório após etapa de autorização"""
         req = self._criar_requisicao()
         req.status = StatusRequisicao.CANCELADA
+        req.data_autorizacao_ou_recusa = timezone.now()
         req.motivo_cancelamento = ""
         with pytest.raises(IntegrityError):
             req.save()
 
-    def test_constraint_motivo_cancelamento_valido(self):
-        """REQ-domain — motivo_cancelamento válido quando preenchido"""
+    def test_constraint_motivo_cancelamento_valido_pos_autorizacao(self):
+        """REQ-domain — motivo_cancelamento preenchido segue válido após autorização"""
         req = self._criar_requisicao()
         req.status = StatusRequisicao.CANCELADA
+        req.data_autorizacao_ou_recusa = timezone.now()
         req.motivo_cancelamento = "Solicitação cancelada por diretor"
         req.save()
+        assert req.status == StatusRequisicao.CANCELADA
+
+    def test_constraint_motivo_cancelamento_nao_e_obrigatorio_pre_autorizacao(self):
+        """REQ-domain — cancelamento pré-autorização não exige justificativa"""
+        req = self._criar_requisicao()
+        req.status = StatusRequisicao.CANCELADA
+        req.motivo_cancelamento = ""
+
+        req.save()
+
         assert req.status == StatusRequisicao.CANCELADA
 
     def test_numero_publico_unico_quando_preenchido(self):
@@ -240,6 +252,16 @@ class TestRequisicaoModel:
 
         with pytest.raises(IntegrityError):
             req.save()
+
+    def test_numero_publico_em_rascunho_reenviado_eh_valido(self):
+        """REQ-02 — rascunho já enviado alguma vez preserva o número público"""
+        req = self._criar_requisicao()
+        req.numero_publico = "REQ-2026-000001"
+        req.data_envio_autorizacao = timezone.now()
+
+        req.save()
+
+        assert req.numero_publico == "REQ-2026-000001"
 
     def test_numero_publico_null_nao_e_unico(self):
         """REQ-02 — multiplas requisições podem ter numero_publico=None"""

--- a/tests/requisitions/test_models.py
+++ b/tests/requisitions/test_models.py
@@ -79,10 +79,11 @@ class TestRequisicaoModel:
         )
 
     @staticmethod
-    def _marcar_primeiro_envio(req):
+    def _marcar_primeiro_envio(req, numero_publico="REQ-2026-000001"):
         req.status = StatusRequisicao.AGUARDANDO_AUTORIZACAO
         req.data_envio_autorizacao = timezone.now()
-        req.save(update_fields=["status", "data_envio_autorizacao"])
+        req.numero_publico = numero_publico
+        req.save(update_fields=["status", "data_envio_autorizacao", "numero_publico"])
         return req
 
     def test_rascunho_sem_numero_publico(self):
@@ -209,12 +210,10 @@ class TestRequisicaoModel:
     def test_numero_publico_unico_quando_preenchido(self):
         """REQ-04 — numero_publico é único quando preenchido (não-null)"""
         req1 = self._criar_requisicao()
-        self._marcar_primeiro_envio(req1)
-        req1.numero_publico = "REQ-2026-000001"
-        req1.save()
+        self._marcar_primeiro_envio(req1, "REQ-2026-000001")
 
         req2 = self._criar_requisicao()
-        self._marcar_primeiro_envio(req2)
+        self._marcar_primeiro_envio(req2, "REQ-2026-000002")
         req2.numero_publico = "REQ-2026-000001"
         with pytest.raises(IntegrityError):
             req2.save()
@@ -263,6 +262,16 @@ class TestRequisicaoModel:
 
         assert req.numero_publico == "REQ-2026-000001"
 
+    def test_numero_publico_e_obrigatorio_quando_data_envio_preenchida(self):
+        """REQ-02 — data_envio_autorizacao exige numero_publico persistido"""
+        req = self._criar_requisicao()
+        req.status = StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        req.data_envio_autorizacao = timezone.now()
+        req.numero_publico = None
+
+        with pytest.raises(IntegrityError):
+            req.save()
+
     def test_numero_publico_null_nao_e_unico(self):
         """REQ-02 — multiplas requisições podem ter numero_publico=None"""
         req1 = self._criar_requisicao()
@@ -287,9 +296,7 @@ class TestRequisicaoModel:
         req = self._criar_requisicao()
         assert str(req) == f"REQ (rascunho {req.id}) — {req.beneficiario.nome_completo}"
 
-        self._marcar_primeiro_envio(req)
-        req.numero_publico = "REQ-2026-000001"
-        req.save()
+        self._marcar_primeiro_envio(req, "REQ-2026-000001")
         assert str(req) == f"REQ REQ-2026-000001 — {req.beneficiario.nome_completo}"
 
 

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 import pytest
 
 from apps.requisitions.services import _gerar_numero_publico

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -1,0 +1,22 @@
+from decimal import Decimal
+
+import pytest
+
+from apps.requisitions.services import _gerar_numero_publico
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSequenciaNumeroRequisicaoService:
+    def test_gera_numeros_incrementais_no_mesmo_ano(self):
+        primeiro = _gerar_numero_publico(ano=2026)
+        segundo = _gerar_numero_publico(ano=2026)
+
+        assert primeiro == "REQ-2026-000001"
+        assert segundo == "REQ-2026-000002"
+
+    def test_reinicia_sequencia_em_novo_ano(self):
+        numero_2026 = _gerar_numero_publico(ano=2026)
+        numero_2027 = _gerar_numero_publico(ano=2027)
+
+        assert numero_2026 == "REQ-2026-000001"
+        assert numero_2027 == "REQ-2027-000001"

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -51,3 +51,14 @@ class TestOpenAPISchema:
         from django.conf import settings
 
         assert "apps.core" in settings.INSTALLED_APPS
+
+    def test_schema_contem_rotas_de_requisicoes(self):
+        """Verify requisitions routes are exposed in OpenAPI."""
+        client = APIClient()
+        response = client.get(reverse("schema"))
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "/api/v1/requisitions/" in content
+        assert "/api/v1/requisitions/{id}/submit/" in content
+        assert "/api/v1/requisitions/pending-approvals/" in content

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -61,4 +61,7 @@ class TestOpenAPISchema:
         content = response.content.decode()
         assert "/api/v1/requisitions/" in content
         assert "/api/v1/requisitions/{id}/submit/" in content
+        assert "/api/v1/requisitions/{id}/return-to-draft/" in content
+        assert "/api/v1/requisitions/{id}/discard/" in content
+        assert "/api/v1/requisitions/{id}/cancel/" in content
         assert "/api/v1/requisitions/pending-approvals/" in content


### PR DESCRIPTION
# Contexto

## O que este PR faz
- implementa o fluxo backend pré-autorização de requisições: criação de rascunho, envio, retorno para rascunho, descarte e cancelamento pré-autorização
- adiciona fila de autorizações para chefes responsáveis, sem ainda implementar a ação de autorizar
- expõe os endpoints DRF de requisições em `/api/v1/requisitions/`
- adiciona serviços, policies, serializers, ViewSet e cobertura de testes para o fluxo novo

## Por que esta mudança é necessária
- o projeto já possuía modelos de requisição, mas ainda não disponibilizava a API do fluxo principal do piloto
- o backlog do piloto dependia da formalização do ciclo pré-autorização antes de avançar para autorização e atendimento
- a fila de autorizações precisava existir antes das ações de aprovação, mantendo o contrato HTTP explícito e as regras de visibilidade por setor

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [x] altera model, migration, constraint ou integridade de dados
- [x] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [x] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
O principal risco é regressão nas regras de transição pré-autorização, especialmente na preservação de `numero_publico` em rascunhos já formalizados e no controle de escopo da fila de autorizações por setor.

## Impactos adicionais (somente se houver)
Preencha de forma curta e objetiva apenas o que se aplicar:

- permissões / perfil / setor: criação em nome de terceiros passou a respeitar `pode_criar_requisicao_para`; fila de autorizações passou a respeitar o chefe do setor do beneficiário
- dados / migration / constraints: adiciona `SequenciaNumeroRequisicao` e ajusta constraints para rascunho reenviado e cancelamento pré-autorização
- transação / concorrência / idempotência: geração de `numero_publico` usa `transaction.atomic()` e `select_for_update()` para serializar a sequência anual
- máquina de estados / aprovação / cotas / entregas: cobre as transições `rascunho -> aguardando_autorizacao`, `aguardando_autorizacao -> rascunho` e cancelamentos antes da autorização
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
Liste os cenários mais importantes validados.

1. criação de rascunho para si e em nome de terceiros permitido, com bloqueios de saldo, material inativo e quantidade inválida
2. geração e preservação de `numero_publico` no envio e reenvio, além de retorno para rascunho e cancelamento pré-autorização
3. visibilidade correta da fila de autorizações por chefe/setor

## Como validar manualmente
Passos mínimos para reproduzir e validar o comportamento.

1. executar `rtk make init`
2. executar `rtk make setup`
3. executar `rtk pytest tests/requisitions/test_services.py tests/requisitions/test_api.py tests/requisitions/test_models.py -q`
4. subir o ambiente e exercitar os endpoints em `/api/v1/requisitions/`
5. consultar `/api/v1/schema/` para verificar as rotas novas

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{
  "beneficiario_id": 1,
  "observacao": "Solicitação inicial",
  "itens": [
    {
      "material_id": 10,
      "quantidade_solicitada": "2.000",
      "observacao": "Uso no setor"
    }
  ]
}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Objetivo da mudança
  - Implementar fluxo backend de pré-autorização de requisições: criar rascunho, enviar para pré-autorização (gera numero_publico), retornar para rascunho (preserva número), descartar rascunho nunca enviado e cancelar antes da autorização; expor fila de autorizações para chefes/almoxarifado; adicionar endpoints DRF em /api/v1/requisitions/.

- Apps Django impactados
  - apps/requisitions: models, policies, services, serializers, views, urls, admin, tests.
  - apps/core/api/exceptions.py: novo DomainConflict e envelope de erro normalizado.
  - config/urls.py: monta routes de requisitions sob /api/v1/.
  - tests/*: cobertura de API, services e models adicionada.

- Risco funcional
  - Médio/alto: mudanças em regras de transição, geração/preservação de numero_publico e políticas de escopo/setor podem causar regressões de autorização e inconsistência de numeração se migrations não aplicadas ou se comportamento de roles estiver incorreto.
  - Risco operacional: ausência de teste de corrida para _gerar_numero_publico em produção sob carga (apesar de select_for_update()).
  - Risco de endpoint de fila vazio se CHEFE_ALMOXARIFADO.setor_id for None — endpoint retorna empty sem erro claro.

- Impacto em regras de negócio
  - Adiciona sequência anual SequenciaNumeroRequisicao e regra: numero_publico atribuído apenas no primeiro envio e preservado em reenvios; constraints condicionais sobre preenchimento de numero_publico e obrigatoriedade de motivo de cancelamento apenas pós-autorização.
  - Eventos de timeline (ENVIO_AUTORIZACAO, REENVIO_AUTORIZACAO, RETORNO_RASCUNHO, CANCELAMENTO) registrados como audit trail imutável.

- Impacto em autenticação, autorização, escopo por perfil e escopo por setor
  - Regras de criação respeitam pode_criar_requisicao_para (solicitante só para si; auxiliar/chefe para setor; almoxarifado amplo).
  - Visibilidade: criador/beneficiário, almoxarifado vê todas, chefe_setor vê somente seu setor (usa user.setor_responsavel); policies implementadas em queryset_requisicoes_visiveis e queryset_fila_autorizacao.
  - Superusuário é explicitamente tratado (acesso global em visibilidade, mas checagens específicas evitam fluxo indevido).
  - Risco: dependência de atributos user.setor_id / user.setor_responsavel — ausência pode ocultar fila.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Novos endpoints e ações:
    - POST /api/v1/requisitions/ (criar rascunho) — 201 com RequisicaoDetailOutputSerializer
    - POST /api/v1/requisitions/{id}/submit/ — 200
    - POST /api/v1/requisitions/{id}/return-to-draft/ — 200
    - DELETE /api/v1/requisitions/{id}/discard/ — 204
    - POST /api/v1/requisitions/{id}/cancel/ — 200
    - GET /api/v1/requisitions/pending-approvals/ — 200 paginado
  - Serializers adicionados: input (RequisicaoCreateInputSerializer, item), outputs (detail, pending approval + paginated envelope).
  - Paginação: padronizada (StandardPagination); envelope com count/page/page_size/total_pages/next/previous/results.
  - Erros: novo DomainConflict (HTTP 409) com campo details estruturado; api_exception_handler normaliza envelope (code, message, details, trace_id) e define code "validation_error" para 400.
  - OpenAPI: endpoints documentados com extend_schema; testes de schema verificam presença das rotas.

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Novo modelo SequenciaNumeroRequisicao (unique por ano) e constraints (ultimo_numero >= 0).
  - CheckConstraints atualizadas: formato de numero_publico, obrigatoriedade condicional de numero_publico quando data_envio_autorizacao presente, regra condicional para motivo_cancelamento.
  - setor_beneficiario salvo como snapshot (FK PROTECT, editable=False); EventoTimeline imutável (protege deletes/bulk updates).
  - UniqueConstraint em numero_publico quando preenchido (garante unicidade).

- Impacto em transações, concorrência, idempotência, saldo físico, saldo reservado e saldo disponível
  - Serviços usam transaction.atomic() e select_for_update() ao gerar numero_publico e ao serializar leituras antes de mutações.
  - _gerar_numero_publico serializa sequência anual e trata IntegrityError na criação race.
  - Validação de estoque verifica saldo_disponivel mas não altera saldos (nenhuma reserva automática implementada) — portanto nenhum efeito direto em saldo físico/reservado.
  - Risco: validação sem reserva pode permitir condição de corrida entre validação e subsequente atendimento/autorizações se outro processo consumir estoque.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque
  - Nenhuma alteração direta em importadores ou ingestão oficial; fluxo apenas valida saldo_disponivel consultando EstoqueMaterial, sem modificar dados de estoque.

- Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero
  - Nenhuma dependência nova; testes adicionados (api, models, services, schema).
  - Migrations presentes em apps/requisitions/migrations contêm apenas __init__.py — migrations para novos modelos/constraints ainda não criadas/aplicadas; necessário gerar/aplicar migrations antes de deploy.
  - Não há mudanças em lint/CI detectadas.

- Como validar manualmente via API, admin, comando ou teste automatizado
  - Executar testes automatizados:
    - pytest tests/requisitions/test_api.py tests/requisitions/test_models.py tests/requisitions/test_services.py tests/test_api_schema.py -v
  - Fluxo manual via API autenticada:
    1. POST /api/v1/requisitions/ com payload {beneficiario_id, observacao, itens:[{material_id, quantidade_solicitada, observacao}] } → 201 (rascunho, numero_publico null)
    2. POST /api/v1/requisitions/{id}/submit/ → 200 (gera numero_publico e data_envio_autorizacao; Evento ENVIO_AUTORIZACAO)
    3. GET /api/v1/requisitions/pending-approvals/ como chefe → ver apenas requisitions do seu setor; paginado
    4. POST /api/v1/requisitions/{id}/return-to-draft/ → 200 (preserva numero_publico; Evento RETORNO_RASCUNHO)
    5. POST /api/v1/requisitions/{id}/submit/ novamente → 200 (preserva numero_publico; Evento REENVIO_AUTORIZACAO)
    6. DELETE /api/v1/requisitions/{id}/discard/ em rascunho nunca enviado → 204 e remoção
    7. POST /api/v1/requisitions/{id}/cancel/ em AGUARDANDO_AUTORIZACAO → 200 e status CANCELADA
  - Validações BD:
    - Tentar persistir numero_publico em rascunho nunca enviado deve violar constraint; quando data_envio_autorizacao preenchida, numero_publico é requerido.
  - Admin: inspecionar EventoTimeline (read-only) e Requisicao; tentativas de bulk delete de eventos devem falhar.

- Pontos prioritários a revisar antes de merge
  - Gerar e aplicar migrations para apps/requisitions (obrigatório).
  - Revisar políticas de CHEFE_ALMOXARIFADO (dependência em user.setor_id) e adicionar validação/erro claro se atributo ausente.
  - Considerar testes de concorrência/race para _gerar_numero_publico em ambiente com múltiplos workers.
  - Confirmar que validação sem reserva de estoque está alinhada com produto (possível necessidade de reservar saldo ao enviar para autorização).
  - Verificar que superusuário não bypassa regras operacionais indevidamente (conformidade com requisitos de auditoria).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

@coderabbitai ignore