### PR TITLE
feat: add warehouse fulfillment flow

### DIFF
--- a/apps/requisitions/models.py
+++ b/apps/requisitions/models.py
@@ -153,6 +153,11 @@ class Requisicao(models.Model):
         default="",
         help_text="Observações gerais",
     )
+    observacao_atendimento = models.TextField(
+        blank=True,
+        default="",
+        help_text="Observações gerais do atendimento",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -2,7 +2,11 @@ from django.db.models import Q, QuerySet
 
 from apps.requisitions.models import Requisicao, StatusRequisicao
 from apps.users.models import PapelChoices
-from apps.users.policies import pode_autorizar_setor, pode_ver_fila_atendimento
+from apps.users.policies import (
+    pode_autorizar_setor,
+    pode_operar_estoque,
+    pode_ver_fila_atendimento,
+)
 
 
 def _usuario_operacional_ativo(user) -> bool:
@@ -69,6 +73,10 @@ def pode_autorizar_requisicao(user, requisicao: Requisicao) -> bool:
     return _usuario_operacional_ativo(user) and pode_autorizar_setor(
         user, requisicao.setor_beneficiario
     )
+
+
+def pode_atender_requisicao(user, requisicao: Requisicao) -> bool:
+    return pode_operar_estoque(user) and pode_visualizar_requisicao(user, requisicao)
 
 
 def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -2,7 +2,7 @@ from django.db.models import Q, QuerySet
 
 from apps.requisitions.models import Requisicao, StatusRequisicao
 from apps.users.models import PapelChoices
-from apps.users.policies import pode_autorizar_setor
+from apps.users.policies import pode_autorizar_setor, pode_ver_fila_atendimento
 
 
 def _usuario_operacional_ativo(user) -> bool:
@@ -93,3 +93,10 @@ def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:
         )
 
     return Requisicao.objects.none()
+
+
+def queryset_fila_atendimento(user) -> QuerySet[Requisicao]:
+    if not pode_ver_fila_atendimento(user):
+        return Requisicao.objects.none()
+
+    return Requisicao.objects.filter(status=StatusRequisicao.AUTORIZADA)

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -63,6 +63,11 @@ class RequisicaoRefuseInputSerializer(serializers.Serializer):
     motivo_recusa = serializers.CharField(allow_blank=False)
 
 
+class RequisicaoFulfillInputSerializer(serializers.Serializer):
+    retirante_fisico = serializers.CharField(required=False, allow_blank=True, default="")
+    observacao_atendimento = serializers.CharField(required=False, allow_blank=True, default="")
+
+
 class RequisicaoActionOutputSerializer(serializers.ModelSerializer):
     material = RequisicaoMaterialOutputSerializer(read_only=True)
 
@@ -87,6 +92,7 @@ class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
     beneficiario = RequisicaoUserOutputSerializer(read_only=True)
     setor_beneficiario = RequisicaoSetorOutputSerializer(read_only=True)
     chefe_autorizador = RequisicaoUserOutputSerializer(read_only=True)
+    responsavel_atendimento = RequisicaoUserOutputSerializer(read_only=True)
     itens = RequisicaoActionOutputSerializer(many=True, read_only=True)
 
     class Meta:
@@ -99,12 +105,15 @@ class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
             "beneficiario",
             "setor_beneficiario",
             "chefe_autorizador",
+            "responsavel_atendimento",
             "data_criacao",
             "data_envio_autorizacao",
             "data_autorizacao_ou_recusa",
             "motivo_recusa",
             "data_finalizacao",
+            "retirante_fisico",
             "observacao",
+            "observacao_atendimento",
             "itens",
         ]
         read_only_fields = fields
@@ -139,3 +148,34 @@ class RequisicaoPendingApprovalPaginatedSerializer(serializers.Serializer):
     next = serializers.URLField(allow_null=True, read_only=True)
     previous = serializers.URLField(allow_null=True, read_only=True)
     results = RequisicaoPendingApprovalOutputSerializer(many=True, read_only=True)
+
+
+class RequisicaoPendingFulfillmentOutputSerializer(serializers.ModelSerializer):
+    beneficiario = RequisicaoUserOutputSerializer(read_only=True)
+    setor_beneficiario = RequisicaoSetorOutputSerializer(read_only=True)
+    chefe_autorizador = RequisicaoUserOutputSerializer(read_only=True)
+    total_itens = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Requisicao
+        fields = [
+            "id",
+            "numero_publico",
+            "status",
+            "beneficiario",
+            "setor_beneficiario",
+            "chefe_autorizador",
+            "data_autorizacao_ou_recusa",
+            "total_itens",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoPendingFulfillmentPaginatedSerializer(serializers.Serializer):
+    count = serializers.IntegerField(read_only=True)
+    page = serializers.IntegerField(read_only=True)
+    page_size = serializers.IntegerField(read_only=True)
+    total_pages = serializers.IntegerField(read_only=True)
+    next = serializers.URLField(allow_null=True, read_only=True)
+    previous = serializers.URLField(allow_null=True, read_only=True)
+    results = RequisicaoPendingFulfillmentOutputSerializer(many=True, read_only=True)

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -19,12 +19,20 @@ from apps.requisitions.models import (
 from apps.requisitions.policies import (
     pode_autorizar_requisicao,
     pode_manipular_pre_autorizacao,
+    queryset_fila_atendimento,
     queryset_fila_autorizacao,
 )
 from apps.stock.models import EstoqueMaterial
-from apps.stock.services import registrar_reserva_por_autorizacao
+from apps.stock.services import (
+    registrar_reserva_por_autorizacao,
+    registrar_saida_por_atendimento,
+)
 from apps.users.models import PapelChoices
-from apps.users.policies import pode_criar_requisicao_para
+from apps.users.policies import (
+    pode_criar_requisicao_para,
+    pode_operar_estoque,
+    pode_ver_fila_atendimento,
+)
 
 User = get_user_model()
 
@@ -90,6 +98,19 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "chefe_autorizador",
             "data_autorizacao_ou_recusa",
             "motivo_recusa",
+            "status",
+        ),
+        "side_effects": (),
+    },
+    "atender_total": {
+        "from_status": (StatusRequisicao.AUTORIZADA,),
+        "to_status": StatusRequisicao.ATENDIDA,
+        "timeline_event_type": TipoEvento.ATENDIMENTO,
+        "audit_fields_to_set": (
+            "responsavel_atendimento",
+            "data_finalizacao",
+            "retirante_fisico",
+            "observacao_atendimento",
             "status",
         ),
         "side_effects": (),
@@ -257,6 +278,15 @@ def _material_e_estoque_validos(*, material: Material, quantidade_solicitada: De
 
 
 def _recarregar_requisicao_para_autorizacao(requisicao: Requisicao) -> Requisicao:
+    return (
+        Requisicao.objects.select_for_update()
+        .select_related("criador", "beneficiario", "setor_beneficiario")
+        .prefetch_related("itens__material__estoque", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def _recarregar_requisicao_para_atendimento(requisicao: Requisicao) -> Requisicao:
     return (
         Requisicao.objects.select_for_update()
         .select_related("criador", "beneficiario", "setor_beneficiario")
@@ -694,4 +724,97 @@ def listar_fila_autorizacao(*, ator: User):
         .select_related("criador", "beneficiario", "setor_beneficiario")
         .prefetch_related("itens__material")
         .order_by("data_envio_autorizacao", "id")
+    )
+
+
+def listar_fila_atendimento(*, ator: User):
+    if not ator.is_authenticated:
+        raise PermissionDenied("Usuário precisa estar autenticado para ver a fila de atendimento.")
+    if not pode_ver_fila_atendimento(ator):
+        raise PermissionDenied("Usuário sem permissão para acessar a fila de atendimento.")
+
+    return (
+        queryset_fila_atendimento(ator)
+        .select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "chefe_autorizador",
+        )
+        .prefetch_related("itens__material")
+        .order_by("data_autorizacao_ou_recusa", "id")
+    )
+
+
+def atender_requisicao_completa(
+    *,
+    requisicao: Requisicao,
+    ator: User,
+    retirante_fisico: str = "",
+    observacao_atendimento: str = "",
+) -> Requisicao:
+    with transaction.atomic():
+        requisicao = _recarregar_requisicao_para_atendimento(requisicao)
+        if not pode_operar_estoque(ator):
+            raise PermissionDenied("Usuário sem permissão para atender esta requisição.")
+
+        if requisicao.status != StatusRequisicao.AUTORIZADA:
+            raise DomainConflict(
+                "Somente requisições autorizadas podem ser atendidas.",
+                details={"status_atual": requisicao.status},
+            )
+
+        itens_requisicao = list(
+            ItemRequisicao.objects.select_for_update()
+            .select_related("material")
+            .filter(requisicao=requisicao)
+            .order_by("material_id", "id")
+        )
+        itens_autorizados = [item for item in itens_requisicao if item.quantidade_autorizada > 0]
+        if not itens_autorizados:
+            raise DomainConflict(
+                "Requisição autorizada não possui itens com quantidade autorizada.",
+                details={"requisicao_id": requisicao.id},
+            )
+
+        for item in itens_autorizados:
+            quantidade_entregue = item.quantidade_autorizada
+            registrar_saida_por_atendimento(
+                requisicao=requisicao,
+                item=item,
+                quantidade=quantidade_entregue,
+            )
+            item.quantidade_entregue = quantidade_entregue
+            item.justificativa_atendimento_parcial = ""
+            item.full_clean()
+            item.save(
+                update_fields=[
+                    "quantidade_entregue",
+                    "justificativa_atendimento_parcial",
+                    "updated_at",
+                ]
+            )
+
+        _apply_requisicao_transition(
+            requisicao=requisicao,
+            transition_name="atender_total",
+            actor=ator,
+            payload={
+                "responsavel_atendimento": ator,
+                "data_finalizacao": timezone.now(),
+                "retirante_fisico": retirante_fisico.strip(),
+                "observacao_atendimento": observacao_atendimento.strip(),
+            },
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "chefe_autorizador",
+            "responsavel_atendimento",
+        )
+        .prefetch_related("itens__material__estoque", "eventos__usuario")
+        .get(pk=requisicao.pk)
     )

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -17,6 +17,7 @@ from apps.requisitions.models import (
     TipoEvento,
 )
 from apps.requisitions.policies import (
+    pode_atender_requisicao,
     pode_autorizar_requisicao,
     pode_manipular_pre_autorizacao,
     queryset_fila_atendimento,
@@ -30,7 +31,6 @@ from apps.stock.services import (
 from apps.users.models import PapelChoices
 from apps.users.policies import (
     pode_criar_requisicao_para,
-    pode_operar_estoque,
     pode_ver_fila_atendimento,
 )
 
@@ -755,7 +755,7 @@ def atender_requisicao_completa(
 ) -> Requisicao:
     with transaction.atomic():
         requisicao = _recarregar_requisicao_para_atendimento(requisicao)
-        if not pode_operar_estoque(ator):
+        if not pode_atender_requisicao(ator, requisicao):
             raise PermissionDenied("Usuário sem permissão para atender esta requisição.")
 
         if requisicao.status != StatusRequisicao.AUTORIZADA:

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -15,18 +15,23 @@ from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
     RequisicaoCreateInputSerializer,
     RequisicaoDetailOutputSerializer,
+    RequisicaoFulfillInputSerializer,
     RequisicaoPendingApprovalOutputSerializer,
     RequisicaoPendingApprovalPaginatedSerializer,
+    RequisicaoPendingFulfillmentOutputSerializer,
+    RequisicaoPendingFulfillmentPaginatedSerializer,
     RequisicaoRefuseInputSerializer,
 )
 from apps.requisitions.services import (
     ItemAutorizacaoData,
     ItemRascunhoData,
+    atender_requisicao_completa,
     autorizar_requisicao,
     cancelar_pre_autorizacao,
     criar_rascunho_requisicao,
     descartar_rascunho_nunca_enviado,
     enviar_para_autorizacao,
+    listar_fila_atendimento,
     listar_fila_autorizacao,
     recusar_requisicao,
     retornar_para_rascunho,
@@ -190,6 +195,30 @@ class RequisicaoViewSet(GenericViewSet):
         return Response(RequisicaoDetailOutputSerializer(requisicao).data)
 
     @extend_schema(
+        operation_id="requisitions_fulfill",
+        tags=["requisitions"],
+        request=RequisicaoFulfillInputSerializer,
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            400: ErrorResponseSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="fulfill")
+    def fulfill(self, request, pk=None):
+        serializer = RequisicaoFulfillInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        requisicao = atender_requisicao_completa(
+            requisicao=self.get_object(),
+            ator=request.user,
+            retirante_fisico=serializer.validated_data["retirante_fisico"],
+            observacao_atendimento=serializer.validated_data["observacao_atendimento"],
+        )
+        return Response(RequisicaoDetailOutputSerializer(requisicao).data)
+
+    @extend_schema(
         operation_id="requisitions_pending_approvals",
         tags=["requisitions"],
         parameters=[
@@ -218,4 +247,35 @@ class RequisicaoViewSet(GenericViewSet):
         queryset = listar_fila_autorizacao(ator=request.user).annotate(total_itens=Count("itens"))
         page = self.paginate_queryset(queryset)
         serializer = RequisicaoPendingApprovalOutputSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
+
+    @extend_schema(
+        operation_id="requisitions_pending_fulfillments",
+        tags=["requisitions"],
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: RequisicaoPendingFulfillmentPaginatedSerializer(),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="pending-fulfillments")
+    def pending_fulfillments(self, request):
+        queryset = listar_fila_atendimento(ator=request.user).annotate(total_itens=Count("itens"))
+        page = self.paginate_queryset(queryset)
+        serializer = RequisicaoPendingFulfillmentOutputSerializer(page, many=True)
         return self.get_paginated_response(serializer.data)

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.api.serializers import ErrorResponseSerializer
+from apps.requisitions.models import Requisicao
 from apps.requisitions.policies import queryset_requisicoes_visiveis
 from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
@@ -211,7 +212,7 @@ class RequisicaoViewSet(GenericViewSet):
         serializer = RequisicaoFulfillInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         requisicao = atender_requisicao_completa(
-            requisicao=self.get_object(),
+            requisicao=get_object_or_404(Requisicao, pk=pk),
             ator=request.user,
             retirante_fisico=serializer.validated_data["retirante_fisico"],
             observacao_atendimento=serializer.validated_data["observacao_atendimento"],

--- a/apps/stock/models.py
+++ b/apps/stock/models.py
@@ -12,6 +12,10 @@ class TipoMovimentacao(models.TextChoices):
         "RESERVA_POR_AUTORIZACAO",
         "Reserva por autorização",
     )
+    SAIDA_POR_ATENDIMENTO = (
+        "SAIDA_POR_ATENDIMENTO",
+        "Saída por atendimento",
+    )
 
 
 class MovimentacaoEstoqueQuerySet(models.QuerySet):
@@ -176,6 +180,7 @@ class MovimentacaoEstoque(models.Model):
                     tipo__in=[
                         TipoMovimentacao.SALDO_INICIAL,
                         TipoMovimentacao.RESERVA_POR_AUTORIZACAO,
+                        TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
                     ]
                 ),
                 name="check_movimentacao_tipo_valido",
@@ -209,6 +214,23 @@ class MovimentacaoEstoque(models.Model):
                 | ~models.Q(tipo=TipoMovimentacao.RESERVA_POR_AUTORIZACAO),
                 name="check_movimentacao_reserva_por_autorizacao_coerente",
             ),
+            models.CheckConstraint(
+                condition=(
+                    models.Q(tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO)
+                    & models.Q(
+                        saldo_posterior=(models.F("saldo_anterior") - models.F("quantidade"))
+                    )
+                    & models.Q(
+                        saldo_reservado_posterior=(
+                            models.F("saldo_reservado_anterior") - models.F("quantidade")
+                        )
+                    )
+                    & models.Q(requisicao__isnull=False)
+                    & models.Q(item_requisicao__isnull=False)
+                )
+                | ~models.Q(tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO),
+                name="check_movimentacao_saida_atendimento_coerente",
+            ),
         ]
 
     def __str__(self):
@@ -239,6 +261,21 @@ class MovimentacaoEstoque(models.Model):
                 errors["requisicao"] = "Reserva por autorização exige requisição."
             if self.item_requisicao_id is None:
                 errors["item_requisicao"] = "Reserva por autorização exige item."
+            if self.item_requisicao_id is not None:
+                item = self.item_requisicao
+                if self.requisicao_id is not None and item.requisicao_id != self.requisicao_id:
+                    errors["requisicao"] = "Requisição deve ser a mesma do item da movimentação."
+                if self.material_id != item.material_id:
+                    errors["material"] = "Material deve ser o mesmo do item da movimentação."
+            if errors:
+                raise ValidationError(errors)
+
+        if self.tipo == TipoMovimentacao.SAIDA_POR_ATENDIMENTO:
+            errors = {}
+            if self.requisicao_id is None:
+                errors["requisicao"] = "Saída por atendimento exige requisição."
+            if self.item_requisicao_id is None:
+                errors["item_requisicao"] = "Saída por atendimento exige item."
             if self.item_requisicao_id is not None:
                 item = self.item_requisicao
                 if self.requisicao_id is not None and item.requisicao_id != self.requisicao_id:

--- a/apps/stock/services.py
+++ b/apps/stock/services.py
@@ -111,3 +111,68 @@ def registrar_reserva_por_autorizacao(
         )
 
     return estoque, movimentacao
+
+
+def registrar_saida_por_atendimento(
+    *,
+    requisicao: Requisicao,
+    item: ItemRequisicao,
+    quantidade: Decimal,
+) -> tuple[EstoqueMaterial, MovimentacaoEstoque]:
+    """Registra saída de estoque por atendimento e consome reserva."""
+    if quantidade <= 0:
+        raise DomainConflict(
+            "Quantidade atendida deve ser maior que zero.",
+            details={"quantidade": str(quantidade)},
+        )
+
+    with transaction.atomic():
+        estoque = (
+            EstoqueMaterial.objects.select_for_update()
+            .select_related("material")
+            .get(material_id=item.material_id)
+        )
+
+        if quantidade > estoque.saldo_fisico:
+            raise DomainConflict(
+                "Saldo físico insuficiente para atendimento.",
+                details={
+                    "quantidade": str(quantidade),
+                    "saldo_fisico": str(estoque.saldo_fisico),
+                    "material_id": item.material_id,
+                },
+            )
+
+        if quantidade > estoque.saldo_reservado:
+            raise DomainConflict(
+                "Saldo reservado insuficiente para atendimento.",
+                details={
+                    "quantidade": str(quantidade),
+                    "saldo_reservado": str(estoque.saldo_reservado),
+                    "material_id": item.material_id,
+                },
+            )
+
+        saldo_fisico_anterior = estoque.saldo_fisico
+        saldo_fisico_posterior = saldo_fisico_anterior - quantidade
+        saldo_reservado_anterior = estoque.saldo_reservado
+        saldo_reservado_posterior = saldo_reservado_anterior - quantidade
+
+        estoque.saldo_fisico = saldo_fisico_posterior
+        estoque.saldo_reservado = saldo_reservado_posterior
+        estoque.save(update_fields=["saldo_fisico", "saldo_reservado", "updated_at"])
+
+        movimentacao = MovimentacaoEstoque.objects.create(
+            requisicao=requisicao,
+            item_requisicao=item,
+            material=item.material,
+            tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+            quantidade=quantidade,
+            saldo_anterior=saldo_fisico_anterior,
+            saldo_posterior=saldo_fisico_posterior,
+            saldo_reservado_anterior=saldo_reservado_anterior,
+            saldo_reservado_posterior=saldo_reservado_posterior,
+            observacao="Saída por atendimento",
+        )
+
+    return estoque, movimentacao

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -724,3 +724,186 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 403
         assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fila_atendimento_lista_requisicoes_autorizadas_para_almoxarifado(self):
+        setor = self._criar_setor("Saneamento", "90030")
+        almoxarife = self._criar_usuario(
+            "10030",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        solicitante = self._criar_usuario("10031", "Solicitante Saneamento", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.001.030",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        autorizada = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000500",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        autorizada.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+        pendente = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000501",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        pendente.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.get(reverse("requisicao-pending-fulfillments"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == autorizada.id
+        assert response.data["results"][0]["numero_publico"] == "REQ-2026-000500"
+        assert response.data["results"][0]["chefe_autorizador"] is None
+        assert response.data["results"][0]["total_itens"] == 1
+        assert pendente.id not in [item["id"] for item in response.data["results"]]
+
+    def test_fila_atendimento_bloqueia_papel_sem_permissao(self):
+        setor = self._criar_setor("Apoio Operacional", "90031")
+        solicitante = self._criar_usuario("10032", "Solicitante Apoio", setor=setor)
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.get(reverse("requisicao-pending-fulfillments"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fulfill_atendimento_completo_baixa_estoque_e_registra_retirada(self):
+        setor = self._criar_setor("Manutencao", "90032")
+        solicitante = self._criar_usuario("10033", "Solicitante Manutencao", setor=setor)
+        almoxarife = self._criar_usuario(
+            "10034",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.031",
+            saldo_fisico=Decimal("7"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000502",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        item = requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("3"),
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(
+            reverse("requisicao-fulfill", args=[requisicao.id]),
+            {
+                "retirante_fisico": "Servidor Retirante",
+                "observacao_atendimento": "Entrega no balcão",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.ATENDIDA
+        assert response.data["responsavel_atendimento"]["id"] == almoxarife.id
+        assert response.data["retirante_fisico"] == "Servidor Retirante"
+        assert response.data["observacao_atendimento"] == "Entrega no balcão"
+        assert response.data["itens"][0]["quantidade_entregue"] == "3.000"
+        requisicao.refresh_from_db()
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.eventos.filter(tipo_evento=TipoEvento.ATENDIMENTO).exists()
+        assert item.quantidade_entregue == Decimal("3")
+        assert material.estoque.saldo_fisico == Decimal("4")
+        assert material.estoque.saldo_reservado == Decimal("0")
+
+    def test_fulfill_bloqueia_usuario_sem_permissao(self):
+        setor = self._criar_setor("Controle", "90033")
+        solicitante = self._criar_usuario("10035", "Solicitante Controle", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.001.032",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000503",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.post(reverse("requisicao-fulfill", args=[requisicao.id]), {})
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fulfill_bloqueia_status_invalido(self):
+        setor = self._criar_setor("Planejamento Campo", "90034")
+        solicitante = self._criar_usuario("10036", "Solicitante Campo", setor=setor)
+        almoxarife = self._criar_usuario(
+            "10037",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque("001.001.033")
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000504",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(reverse("requisicao-fulfill", args=[requisicao.id]), {})
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -839,6 +839,38 @@ class TestRequisicaoAPI:
         assert response.status_code == 403
         assert response.data["error"]["code"] == "permission_denied"
 
+    def test_fila_atendimento_bloqueia_superuser(self):
+        setor = self._criar_setor("Apoio Superuser", "90037")
+        superuser = self._criar_usuario(
+            "10042",
+            "Superuser Apoio",
+            setor=setor,
+            is_superuser=True,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        response = client.get(reverse("requisicao-pending-fulfillments"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fila_atendimento_bloqueia_usuario_inativo(self):
+        setor = self._criar_setor("Apoio Inativo", "90038")
+        usuario_inativo = self._criar_usuario(
+            "10043",
+            "Usuario Inativo Apoio",
+            setor=setor,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_inativo)
+        response = client.get(reverse("requisicao-pending-fulfillments"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
     def test_fulfill_atendimento_completo_baixa_estoque_e_registra_retirada(self):
         setor = self._criar_setor("Manutencao", "90032")
         solicitante = self._criar_usuario("10033", "Solicitante Manutencao", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -780,6 +780,52 @@ class TestRequisicaoAPI:
         assert response.data["results"][0]["total_itens"] == 1
         assert pendente.id not in [item["id"] for item in response.data["results"]]
 
+    def test_fila_atendimento_almoxarifado_ve_requisicoes_de_outros_setores(self):
+        setor_almoxarifado = self._criar_setor("Almoxarifado", "90035")
+        setor_obras = self._criar_setor("Obras", "90036")
+        almoxarife = self._criar_usuario(
+            "10038",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_almoxarifado,
+        )
+        solicitante_obras = self._criar_usuario(
+            "10039",
+            "Solicitante Obras",
+            setor=setor_obras,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.034",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        autorizada_outro_setor = Requisicao.objects.create(
+            criador=solicitante_obras,
+            beneficiario=solicitante_obras,
+            setor_beneficiario=setor_obras,
+            numero_publico="REQ-2026-000505",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        autorizada_outro_setor.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.get(reverse("requisicao-pending-fulfillments"))
+
+        # matriz-permissoes.md: Almoxarifado vê requisições de todos os setores
+        # e fila de atendimento; não há isolamento por setor nesta fila.
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == autorizada_outro_setor.id
+        assert response.data["results"][0]["setor_beneficiario"]["id"] == setor_obras.id
+
     def test_fila_atendimento_bloqueia_papel_sem_permissao(self):
         setor = self._criar_setor("Apoio Operacional", "90031")
         solicitante = self._criar_usuario("10032", "Solicitante Apoio", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -33,6 +33,7 @@ class TestRequisicaoAPI:
         papel=PapelChoices.SOLICITANTE,
         setor: Setor | None = None,
         is_active: bool = True,
+        is_superuser: bool = False,
     ) -> User:
         return User.objects.create(
             matricula_funcional=matricula,
@@ -40,6 +41,7 @@ class TestRequisicaoAPI:
             papel=papel,
             setor=setor,
             is_active=is_active,
+            is_superuser=is_superuser,
         )
 
     @staticmethod
@@ -918,6 +920,81 @@ class TestRequisicaoAPI:
 
         client = APIClient()
         client.force_authenticate(user=solicitante)
+        response = client.post(reverse("requisicao-fulfill", args=[requisicao.id]), {})
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fulfill_bloqueia_superuser(self):
+        setor = self._criar_setor("Controle Superior", "90035")
+        solicitante = self._criar_usuario("10038", "Solicitante Controle Superior", setor=setor)
+        superuser = self._criar_usuario(
+            "10039",
+            "Superuser Controle",
+            papel=PapelChoices.SOLICITANTE,
+            setor=setor,
+            is_superuser=True,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.034",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000505",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        response = client.post(reverse("requisicao-fulfill", args=[requisicao.id]), {})
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
+    def test_fulfill_bloqueia_usuario_inativo(self):
+        setor = self._criar_setor("Controle Inativo", "90036")
+        solicitante = self._criar_usuario("10040", "Solicitante Controle Inativo", setor=setor)
+        usuario_inativo = self._criar_usuario(
+            "10041",
+            "Usuario Inativo",
+            setor=setor,
+            is_active=False,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.035",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000506",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_inativo)
         response = client.post(reverse("requisicao-fulfill", args=[requisicao.id]), {})
 
         assert response.status_code == 403

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -4,7 +4,7 @@ from threading import Barrier
 
 import pytest
 from django.db import close_old_connections
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from apps.core.api.exceptions import DomainConflict
 from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
@@ -17,6 +17,7 @@ from apps.requisitions.models import (
 from apps.requisitions.services import (
     ItemAutorizacaoData,
     _gerar_numero_publico,
+    atender_requisicao_completa,
     autorizar_requisicao,
     recusar_requisicao,
 )
@@ -472,3 +473,307 @@ class TestAutorizacaoRequisicaoService:
             StatusRequisicao.AGUARDANDO_AUTORIZACAO,
             StatusRequisicao.AUTORIZADA,
         }
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAtendimentoRequisicaoService:
+    @staticmethod
+    def _criar_setor(nome: str, chefe_matricula: str) -> Setor:
+        chefe = User.objects.create(
+            matricula_funcional=chefe_matricula,
+            nome_completo=f"Chefe {nome}",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome=nome, chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        return setor
+
+    @staticmethod
+    def _criar_usuario(
+        matricula: str,
+        nome: str,
+        *,
+        papel=PapelChoices.SOLICITANTE,
+        setor: Setor | None = None,
+        is_active: bool = True,
+    ) -> User:
+        return User.objects.create(
+            matricula_funcional=matricula,
+            nome_completo=nome,
+            papel=papel,
+            setor=setor,
+            is_active=is_active,
+        )
+
+    @staticmethod
+    def _criar_material_com_estoque(
+        codigo: str,
+        *,
+        saldo_fisico: Decimal = Decimal("10"),
+        saldo_reservado: Decimal = Decimal("0"),
+    ) -> Material:
+        grupo_codigo, subgrupo_codigo, sequencial = codigo.split(".")
+        grupo, _ = GrupoMaterial.objects.get_or_create(
+            codigo_grupo=grupo_codigo,
+            defaults={"nome": f"Grupo {grupo_codigo}"},
+        )
+        subgrupo, _ = SubgrupoMaterial.objects.get_or_create(
+            grupo=grupo,
+            codigo_subgrupo=subgrupo_codigo,
+            defaults={"nome": f"Subgrupo {subgrupo_codigo}"},
+        )
+        material = Material.objects.create(
+            subgrupo=subgrupo,
+            codigo_completo=codigo,
+            sequencial=sequencial,
+            nome=f"Material {codigo}",
+            unidade_medida="UN",
+            is_active=True,
+        )
+        EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=saldo_fisico,
+            saldo_reservado=saldo_reservado,
+        )
+        return material
+
+    @staticmethod
+    def _criar_requisicao_autorizada(
+        *,
+        criador: User,
+        beneficiario: User,
+        numero_publico: str,
+        material: Material,
+        quantidade_autorizada: Decimal,
+    ) -> tuple[Requisicao, ItemRequisicao]:
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario,
+            setor_beneficiario=beneficiario.setor,
+            numero_publico=numero_publico,
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        item = requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=quantidade_autorizada,
+            quantidade_autorizada=quantidade_autorizada,
+        )
+        return requisicao, item
+
+    def test_atendimento_completo_baixa_fisico_consumindo_reserva_e_timeline(self):
+        setor = self._criar_setor("Operacional", "92001")
+        requisitante = self._criar_usuario("12001", "Solicitante Operacional", setor=setor)
+        atendente = self._criar_usuario(
+            "12002",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.001",
+            saldo_fisico=Decimal("10"),
+            saldo_reservado=Decimal("4"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200001",
+            material=material,
+            quantidade_autorizada=Decimal("4"),
+        )
+
+        atendida = atender_requisicao_completa(
+            requisicao=requisicao,
+            ator=atendente,
+            retirante_fisico="Servidor retirante",
+            observacao_atendimento="Retirada no balcão",
+        )
+
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert atendida.status == StatusRequisicao.ATENDIDA
+        assert atendida.responsavel_atendimento_id == atendente.id
+        assert atendida.retirante_fisico == "Servidor retirante"
+        assert atendida.observacao_atendimento == "Retirada no balcão"
+        assert atendida.eventos.filter(tipo_evento=TipoEvento.ATENDIMENTO).exists()
+        assert item.quantidade_entregue == Decimal("4")
+        assert material.estoque.saldo_fisico == Decimal("6")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert MovimentacaoEstoque.objects.filter(
+            requisicao=atendida,
+            item_requisicao=item,
+            tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+        ).exists()
+
+    def test_atendimento_completo_ignora_item_autorizado_zero(self):
+        setor = self._criar_setor("Oficina", "92002")
+        requisitante = self._criar_usuario("12003", "Solicitante Oficina", setor=setor)
+        atendente = self._criar_usuario(
+            "12004",
+            "Chefe Almoxarifado",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+            setor=setor,
+        )
+        material_a = self._criar_material_com_estoque(
+            "001.003.002",
+            saldo_fisico=Decimal("8"),
+            saldo_reservado=Decimal("3"),
+        )
+        material_b = self._criar_material_com_estoque("001.003.003", saldo_fisico=Decimal("8"))
+        requisicao, item_a = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200002",
+            material=material_a,
+            quantidade_autorizada=Decimal("3"),
+        )
+        item_b = requisicao.itens.create(
+            material=material_b,
+            unidade_medida=material_b.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("0"),
+            justificativa_autorizacao_parcial="Não autorizado",
+        )
+
+        atender_requisicao_completa(requisicao=requisicao, ator=atendente)
+
+        item_a.refresh_from_db()
+        item_b.refresh_from_db()
+        material_a.estoque.refresh_from_db()
+        material_b.estoque.refresh_from_db()
+        assert item_a.quantidade_entregue == Decimal("3")
+        assert item_b.quantidade_entregue == Decimal("0")
+        assert material_a.estoque.saldo_fisico == Decimal("5")
+        assert material_a.estoque.saldo_reservado == Decimal("0")
+        assert material_b.estoque.saldo_fisico == Decimal("8")
+        assert material_b.estoque.saldo_reservado == Decimal("0")
+
+    def test_atendimento_bloqueia_usuario_sem_permissao_e_status_invalido(self):
+        setor = self._criar_setor("Financeiro", "92003")
+        solicitante = self._criar_usuario("12005", "Solicitante Financeiro", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.003.004",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao, _ = self._criar_requisicao_autorizada(
+            criador=solicitante,
+            beneficiario=solicitante,
+            numero_publico="REQ-2026-200003",
+            material=material,
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        with pytest.raises(PermissionDenied):
+            atender_requisicao_completa(requisicao=requisicao, ator=solicitante)
+
+        atendente = self._criar_usuario(
+            "12006",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        requisicao.status = StatusRequisicao.ATENDIDA
+        requisicao.save(update_fields=["status", "updated_at"])
+
+        with pytest.raises(DomainConflict):
+            atender_requisicao_completa(requisicao=requisicao, ator=atendente)
+
+    def test_atendimento_bloqueia_saldo_fisico_insuficiente(self):
+        setor = self._criar_setor("Logistica", "92004")
+        requisitante = self._criar_usuario("12007", "Solicitante Logistica", setor=setor)
+        atendente = self._criar_usuario(
+            "12008",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.005",
+            saldo_fisico=Decimal("1"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200004",
+            material=material,
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        with pytest.raises(DomainConflict):
+            atender_requisicao_completa(requisicao=requisicao, ator=atendente)
+
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert item.quantidade_entregue == Decimal("0")
+        assert material.estoque.saldo_fisico == Decimal("1")
+        assert material.estoque.saldo_reservado == Decimal("3")
+        assert MovimentacaoEstoque.objects.count() == 0
+
+    @pytest.mark.postgres
+    def test_atendimentos_concorrentes_nao_duplicam_baixa(self):
+        setor = self._criar_setor("Almoxarifado", "92005")
+        requisitante = self._criar_usuario("12009", "Solicitante Almoxarifado", setor=setor)
+        atendente = self._criar_usuario(
+            "12010",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.006",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("5"),
+        )
+        requisicao, _ = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200005",
+            material=material,
+            quantidade_autorizada=Decimal("5"),
+        )
+
+        barrier = Barrier(2)
+
+        def atender(req_id: int):
+            close_old_connections()
+            try:
+                barrier.wait()
+                requisicao_atendimento = Requisicao.objects.get(pk=req_id)
+                atender_requisicao_completa(
+                    requisicao=requisicao_atendimento,
+                    ator=atendente,
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            resultado_a = executor.submit(atender, requisicao.id)
+            resultado_b = executor.submit(atender, requisicao.id)
+
+        resultados = {resultado_a.result(), resultado_b.result()}
+        close_old_connections()
+
+        material.estoque.refresh_from_db()
+        requisicao.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert requisicao.status == StatusRequisicao.ATENDIDA
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+            ).count()
+            == 1
+        )

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -716,6 +716,38 @@ class TestAtendimentoRequisicaoService:
         assert material.estoque.saldo_reservado == Decimal("3")
         assert MovimentacaoEstoque.objects.count() == 0
 
+    def test_atendimento_bloqueia_saldo_reservado_insuficiente(self):
+        setor = self._criar_setor("Logistica Reserva", "92006")
+        requisitante = self._criar_usuario("12011", "Solicitante Logistica Reserva", setor=setor)
+        atendente = self._criar_usuario(
+            "12012",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.007",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("1"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200006",
+            material=material,
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        with pytest.raises(DomainConflict):
+            atender_requisicao_completa(requisicao=requisicao, ator=atendente)
+
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert item.quantidade_entregue == Decimal("0")
+        assert material.estoque.saldo_fisico == Decimal("5")
+        assert material.estoque.saldo_reservado == Decimal("1")
+        assert MovimentacaoEstoque.objects.count() == 0
+
     @pytest.mark.postgres
     def test_atendimentos_concorrentes_nao_duplicam_baixa(self):
         setor = self._criar_setor("Almoxarifado", "92005")

--- a/tests/stock/test_services_estoque.py
+++ b/tests/stock/test_services_estoque.py
@@ -7,7 +7,11 @@ from apps.core.api.exceptions import DomainConflict
 from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
 from apps.requisitions.models import ItemRequisicao, Requisicao, StatusRequisicao
 from apps.stock.models import EstoqueMaterial, MovimentacaoEstoque, TipoMovimentacao
-from apps.stock.services import registrar_reserva_por_autorizacao, registrar_saldo_inicial
+from apps.stock.services import (
+    registrar_reserva_por_autorizacao,
+    registrar_saida_por_atendimento,
+    registrar_saldo_inicial,
+)
 from apps.users.models import PapelChoices, Setor, User
 
 
@@ -358,4 +362,97 @@ class TestRegistrarSaldoInicial:
 
         estoque.refresh_from_db()
         assert estoque.saldo_reservado == Decimal("3")
+        assert MovimentacaoEstoque.objects.count() == 0
+
+    def test_registrar_saida_por_atendimento_baixa_fisico_e_reserva(self):
+        chefe = User.objects.create(
+            matricula_funcional="99004",
+            nome_completo="Chefe Estoque 4",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome="Setor Estoque 4", chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        material = self._criar_material()
+        estoque = EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=Decimal("10"),
+            saldo_reservado=Decimal("4"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AUTORIZADA,
+        )
+        item = ItemRequisicao.objects.create(
+            requisicao=requisicao,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("4.000"),
+            quantidade_autorizada=Decimal("4.000"),
+        )
+
+        _, movimentacao = registrar_saida_por_atendimento(
+            requisicao=requisicao,
+            item=item,
+            quantidade=Decimal("4"),
+        )
+
+        estoque.refresh_from_db()
+        assert estoque.saldo_fisico == Decimal("6")
+        assert estoque.saldo_reservado == Decimal("0")
+        assert movimentacao.tipo == TipoMovimentacao.SAIDA_POR_ATENDIMENTO
+        assert movimentacao.saldo_anterior == Decimal("10")
+        assert movimentacao.saldo_posterior == Decimal("6")
+        assert movimentacao.saldo_reservado_anterior == Decimal("4")
+        assert movimentacao.saldo_reservado_posterior == Decimal("0")
+
+    def test_registrar_saida_rejeita_saldo_fisico_ou_reserva_insuficiente(self):
+        chefe = User.objects.create(
+            matricula_funcional="99005",
+            nome_completo="Chefe Estoque 5",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome="Setor Estoque 5", chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        material = self._criar_material()
+        estoque = EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=Decimal("3"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AUTORIZADA,
+        )
+        item = ItemRequisicao.objects.create(
+            requisicao=requisicao,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("4.000"),
+            quantidade_autorizada=Decimal("4.000"),
+        )
+
+        with pytest.raises(DomainConflict):
+            registrar_saida_por_atendimento(
+                requisicao=requisicao,
+                item=item,
+                quantidade=Decimal("4"),
+            )
+        with pytest.raises(DomainConflict):
+            registrar_saida_por_atendimento(
+                requisicao=requisicao,
+                item=item,
+                quantidade=Decimal("3"),
+            )
+
+        estoque.refresh_from_db()
+        assert estoque.saldo_fisico == Decimal("3")
+        assert estoque.saldo_reservado == Decimal("2")
         assert MovimentacaoEstoque.objects.count() == 0

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -66,4 +66,6 @@ class TestOpenAPISchema:
         assert "/api/v1/requisitions/{id}/cancel/" in content
         assert "/api/v1/requisitions/{id}/authorize/" in content
         assert "/api/v1/requisitions/{id}/refuse/" in content
+        assert "/api/v1/requisitions/{id}/fulfill/" in content
         assert "/api/v1/requisitions/pending-approvals/" in content
+        assert "/api/v1/requisitions/pending-fulfillments/" in content


### PR DESCRIPTION
# Contexto

## O que este PR faz
- Implementa a fila de atendimento do Almoxarifado para requisições `autorizada`.
- Adiciona o endpoint `POST /api/v1/requisitions/{id}/fulfill/` para atendimento completo.
- Registra responsável, data de finalização, retirante físico e observação de atendimento.
- Adiciona movimentação `SAIDA_POR_ATENDIMENTO`, baixando `saldo_fisico` e consumindo `saldo_reservado` sob lock.

## Por que esta mudança é necessária
Atende `PIL-BE-ATE-001`, `PIL-BE-ATE-003` e `PIL-BE-ATE-006`, fechando o caminho operacional de requisição autorizada/reservada até retirada integral no Almoxarifado.

---

# Checklist de impacto

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [x] altera model, migration, constraint ou integridade de dados
- [x] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [x] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
O risco principal é divergência entre status da requisição, itens entregues, saldo físico, saldo reservado e ledger de estoque durante atendimento concorrente ou saldo físico insuficiente.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: fila e atendimento exigem perfis de Almoxarifado via policies existentes.
- dados / migration / constraints: adiciona `observacao_atendimento` e novo tipo/constraint de `MovimentacaoEstoque`; migrations permanecem efêmeras conforme regra do repo.
- transação / concorrência / idempotência: atendimento usa `transaction.atomic()`, `select_for_update()` na requisição/itens/estoque e teste PostgreSQL concorrente.
- máquina de estados / aprovação / cotas / entregas: adiciona transição `autorizada` -> `atendida` para atendimento completo.
- configuração / CI / dependências: sem alteração.

---

# Testes e validação

## Cenários validados
1. Almoxarifado lista apenas requisições autorizadas na fila de atendimento.
2. Atendimento completo baixa físico, consome reserva, cria movimentação e marca a requisição como `atendida`.
3. Usuário sem permissão, status inválido, saldo físico insuficiente e concorrência PostgreSQL são bloqueados.

## Como validar manualmente
1. Criar/enviar/autorizar uma requisição com reserva positiva.
2. Acessar `GET /api/v1/requisitions/pending-fulfillments/` como Auxiliar ou Chefe de Almoxarifado.
3. Chamar `POST /api/v1/requisitions/{id}/fulfill/` e confirmar status `atendida`, responsável, metadados de retirada e saldos atualizados.

## Payloads / exemplos de uso

```json
{
  "retirante_fisico": "Servidor Retirante",
  "observacao_atendimento": "Entrega no balcão"
}
```

## Validação automatizada
- `rtk make setup`
- `rtk pytest tests/requisitions/test_api.py tests/requisitions/test_services.py tests/stock/test_services_estoque.py`
- `rtk pytest tests/test_api_schema.py::TestOpenAPISchema::test_schema_contem_rotas_de_requisicoes`
- `rtk ruff check apps/stock/models.py apps/stock/services.py apps/requisitions/models.py apps/requisitions/policies.py apps/requisitions/services.py apps/requisitions/serializers.py apps/requisitions/views.py tests/requisitions/test_services.py tests/requisitions/test_api.py tests/stock/test_services_estoque.py tests/test_api_schema.py`

Observação: `rtk pytest tests/test_api_schema.py` completo falhou localmente em dois testes antigos do Swagger UI por `AttributeError` durante renderização de template no test client; o teste de schema que valida as rotas novas passou.

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Objetivo da mudança
- Implementar fila de atendimento do Almoxarifado para requisições com status AUTORIZADA.
- Expor POST /api/v1/requisitions/{id}/fulfill/ para atendimento completo, registrando responsável, data de finalização, retirante_fisico e observacao_atendimento.
- Criar movimentação SAIDA_POR_ATENDIMENTO que decrementa saldo_fisico e consome saldo_reservado com lock e transação.

## Apps Django impactados
- apps/requisitions: models, policies, serializers, services, views, testes.
- apps/stock: models (TipoMovimentacao, contraintes), services (registrar_saida_por_atendimento), testes.
- apps/users: política pode_ver_fila_atendimento (uso).

## Risco funcional
- Crítico: ausência de filtro por setor em queryset_fila_atendimento → usuário de almoxarifado de Setor A pode listar/atender requisições de Setor B (visibilidade indevida).
- Risco de inconsistência em cenários concorrentes se locks/validações forem alterados; testes concorrentes existentes simulam e mitigam duplicação de baixa.

## Impacto em regras de negócio
- Nova transição de estado: AUTORIZADA → ATENDIDA via atender_total; registra evento TipoEvento.ATENDIMENTO.
- Itens com quantidade_autorizada <= 0 são ignorados.
- Exige autorização de operador de estoque (pode_operar_estoque) e checagens de status antes de executar atendimento.

## Autenticação, autorização, escopo por perfil e por setor
- Autorização por papel: listar/atender restrito a perfis de almoxarifado (AUXILIAR/CHEFE) via pode_ver_fila_atendimento / pode_operar_estoque.
- Falha: queryset_fila_atendimento não restringe por setor_beneficiario → quebra escopo por setor e permite visibilidade/intervenção entre setores.
- Permissões negativas cobertas por testes (403) — porém sem teste de isolamento por setor.

## Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
- Novos serializers:
  - RequisicaoFulfillInputSerializer (entrada: retirante_fisico, observacao_atendimento).
  - RequisicaoPendingFulfillmentOutputSerializer e paginado.
  - RequisicaoDetailOutputSerializer expõe responsavel_atendimento, retirante_fisico, observacao_atendimento.
- Endpoints adicionados:
  - GET /requisitions/pending-fulfillments/ (paginação: page, page_size).
  - POST /requisitions/{id}/fulfill/.
- OpenAPI: rotas incluídas e validadas em testes de schema.
- Erros de negócio resultam em DomainConflict/PermissionDenied conforme implementado.

## Integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
- Novo TipoMovimentacao.SAIDA_POR_ATENDIMENTO e constraint SQL check_movimentacao_saida_atendimento_coerente garantindo saldo_posterior = saldo_anterior - quantidade e saldo_reservado_posterior = saldo_reservado_anterior - quantidade, além de exigir requisicao_id e item_requisicao_id.
- MovimentacaoEstoque.clean() valida coerência de requisicao/item/material; movimentações gravam saldos anterior/posterior (snapshot).
- Timeline/evento ATENDIMENTO criado; responsavel_atendimento e observacao_atendimento persistidos.
- Imutabilidade prevista nas movimentações (evita updates indevidos).

## Transações, concorrência, idempotência, saldos
- Uso consistente de transaction.atomic() e select_for_update() em pontos críticos:
  - Atendimento trava ItemRequisicao e EstoqueMaterial antes de operar.
  - registrar_saida_por_atendimento faz lock de EstoqueMaterial e valida saldos.
- Testes PostgreSQL simulam concorrência: apenas uma das execuções simultâneas efetua baixa; outra falha com DomainConflict.
- Validações impedem saldo_fisico < quantidade ou saldo_reservado < quantidade; operações abortam sem criar movimentação.
- Operação não é idempotente (segunda tentativa falha se já atendida) — aceitável, mas sem mecanismo de retry seguro automático.

## Impacto em importação SCPI, dados de materiais ou divergência de estoque
- Sem alteração no fluxo de importação SCPI ou dados oficiais de materiais.
- Constraint e movimentações asseguram coerência entre ledger e saldos; risco residual se outros paths de movimentação ignorarem novas regras.

## Impacto em configuração, CI, dependências, lint, testes e ambiente efêmero
- Nenhuma mudança em CI, dependências ou lint.
- Migrations adicionam novo campo observacao_atendimento e constraint (migrations aplicáveis).
- Testes ampliados (API, services, stock) incluindo cenário concorrente; alguns testes locais antigos de Swagger UI falharam, mas novos endpoints cobertos.

## Como validar manualmente / comandos úteis
- Testes automatizados recomendados:
  - pytest tests/requisitions/test_services.py::TestRequisicaoAtendimento -v
  - pytest tests/requisitions/test_api.py -k "fulfill\|fila_atendimento" -v
  - pytest tests/stock/test_services_estoque.py -k "saida_por_atendimento" -v
  - pytest tests/test_api_schema.py::test_schema_contem_rotas_de_requisicoes -v
- Validação via API:
  - GET /api/v1/requisitions/pending-fulfillments/ (usuário com papel de almoxarifado) → só AUTORIZADA esperada.
  - POST /api/v1/requisitions/{id}/fulfill/ com payload {"retirante_fisico":"...", "observacao_atendimento":"..."} → requisicao vira ATENDIDA, cria MovimentacaoEstoque.SAIDA_POR_ATENDIMENTO, atualiza saldo_fisico e saldo_reservado, cria evento ATENDIMENTO; 403 para usuário sem papel.
- Checagens no admin/db:
  - Verificar MovimentacaoEstoque.tipo == SAIDA_POR_ATENDIMENTO e saldos anterior/posterior coerentes.
  - Conferir Requisicao.responsavel_atendimento, retirante_fisico, observacao_atendimento e evento de timeline.

## Recomendações e pontos críticos a corrigir
1. Corrigir isolamento por setor: aplicar filtro setor_beneficiario_id == user.setor_id em queryset_fila_atendimento (ou justificar acesso global) e adicionar testes cobrindo usuários de setores distintos.
2. Revisar acoplamento entre apps (stock ↔ requisitions) para evitar violações de direção de dependência; documentar/imports intencionais se necessário.
3. Garantir cobertura adicional contra regressões que possam permitir saldo negativo ou consumo indevido de reserva por outras rotas não auditadas.
4. Considerar mecanismo de idempotência/locking ao expor endpoint público para reduzir risco em retries automáticos de clientes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->