### PR TITLE
feat(requisitions): cancel authorized request without stock

### DIFF
--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -69,6 +69,10 @@ def pode_manipular_pre_autorizacao(user, requisicao: Requisicao) -> bool:
     )
 
 
+def pode_cancelar_autorizada(user, requisicao: Requisicao) -> bool:
+    return pode_manipular_pre_autorizacao(user, requisicao) or pode_operar_estoque(user)
+
+
 def pode_autorizar_requisicao(user, requisicao: Requisicao) -> bool:
     return _usuario_operacional_ativo(user) and pode_autorizar_setor(
         user, requisicao.setor_beneficiario

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -64,6 +64,7 @@ class RequisicaoRefuseInputSerializer(serializers.Serializer):
 
 
 class RequisicaoCancelInputSerializer(serializers.Serializer):
+    # O requisito de motivo nao e global: so o cancelamento pos-autorizacao exige texto nao vazio.
     motivo_cancelamento = serializers.CharField(required=False, allow_blank=True, default="")
 
 

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -63,6 +63,10 @@ class RequisicaoRefuseInputSerializer(serializers.Serializer):
     motivo_recusa = serializers.CharField(allow_blank=False)
 
 
+class RequisicaoCancelInputSerializer(serializers.Serializer):
+    motivo_cancelamento = serializers.CharField(required=False, allow_blank=True, default="")
+
+
 class RequisicaoItemFulfillInputSerializer(serializers.Serializer):
     item_id = serializers.IntegerField()
     quantidade_entregue = serializers.DecimalField(
@@ -129,6 +133,7 @@ class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
             "data_envio_autorizacao",
             "data_autorizacao_ou_recusa",
             "motivo_recusa",
+            "motivo_cancelamento",
             "data_finalizacao",
             "retirante_fisico",
             "observacao",

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -96,6 +96,22 @@ def _side_effect_reservar_itens_autorizados(
         )
 
 
+def _side_effect_liberar_reservas_cancelamento(
+    requisicao: Requisicao, payload: dict[str, object]
+) -> None:
+    estoques_por_material_id = payload["estoques_por_material_id"]
+    for item_requisicao in payload["itens_requisicao"]:
+        quantidade_liberada = item_requisicao.quantidade_autorizada
+        if quantidade_liberada <= 0:
+            continue
+        registrar_liberacao_reserva_por_atendimento(
+            requisicao=requisicao,
+            item=item_requisicao,
+            quantidade=quantidade_liberada,
+            estoque_travado=estoques_por_material_id[item_requisicao.material_id],
+        )
+
+
 TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
     "autorizar_total": {
         "from_status": (StatusRequisicao.AGUARDANDO_AUTORIZACAO,),
@@ -156,6 +172,18 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
+    },
+    "cancelar_pos_autorizacao_sem_saldo": {
+        "from_status": (StatusRequisicao.AUTORIZADA,),
+        "to_status": StatusRequisicao.CANCELADA,
+        "timeline_event_type": TipoEvento.CANCELAMENTO,
+        "audit_fields_to_set": (
+            "responsavel_atendimento",
+            "data_finalizacao",
+            "motivo_cancelamento",
+            "status",
+        ),
+        "side_effects": (_side_effect_liberar_reservas_cancelamento,),
     },
 }
 
@@ -635,6 +663,75 @@ def cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisica
             "setor_beneficiario",
         )
         .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
+def cancelar_autorizada_sem_saldo(
+    *, requisicao: Requisicao, ator: User, motivo_cancelamento: str
+) -> Requisicao:
+    motivo_cancelamento = motivo_cancelamento.strip()
+    if not motivo_cancelamento:
+        raise ValidationError({"motivo_cancelamento": ["Motivo do cancelamento é obrigatório."]})
+
+    with transaction.atomic():
+        requisicao = _recarregar_requisicao_para_atendimento(requisicao)
+        if not pode_atender_requisicao(ator, requisicao):
+            raise PermissionDenied("Usuário sem permissão para cancelar esta requisição.")
+
+        if requisicao.status != StatusRequisicao.AUTORIZADA:
+            raise DomainConflict(
+                "Somente requisições autorizadas podem ser canceladas no atendimento.",
+                details={"status_atual": requisicao.status},
+            )
+
+        itens_requisicao = list(
+            ItemRequisicao.objects.select_for_update()
+            .select_related("material")
+            .filter(requisicao=requisicao)
+            .order_by("material_id", "id")
+        )
+        itens_autorizados = [item for item in itens_requisicao if item.quantidade_autorizada > 0]
+        if not itens_autorizados:
+            raise DomainConflict(
+                "Requisição autorizada não possui itens com quantidade autorizada.",
+                details={"requisicao_id": requisicao.id},
+            )
+
+        estoques_por_material_id = _travar_estoques_dos_itens(itens_autorizados)
+        itens_com_saldo_fisico = [
+            item.id
+            for item in itens_autorizados
+            if estoques_por_material_id[item.material_id].saldo_fisico > 0
+        ]
+        if itens_com_saldo_fisico:
+            raise DomainConflict(
+                "Ainda há saldo físico para atendimento parcial da requisição.",
+                details={"item_ids": itens_com_saldo_fisico},
+            )
+
+        _apply_requisicao_transition(
+            requisicao=requisicao,
+            transition_name="cancelar_pos_autorizacao_sem_saldo",
+            actor=ator,
+            payload={
+                "responsavel_atendimento": ator,
+                "data_finalizacao": timezone.now(),
+                "motivo_cancelamento": motivo_cancelamento,
+                "itens_requisicao": itens_autorizados,
+                "estoques_por_material_id": estoques_por_material_id,
+            },
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "chefe_autorizador",
+            "responsavel_atendimento",
+        )
+        .prefetch_related("itens__material__estoque", "eventos__usuario")
         .get(pk=requisicao.pk)
     )
 

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -19,6 +19,7 @@ from apps.requisitions.models import (
 from apps.requisitions.policies import (
     pode_atender_requisicao,
     pode_autorizar_requisicao,
+    pode_cancelar_autorizada,
     pode_manipular_pre_autorizacao,
     queryset_fila_atendimento,
     queryset_fila_autorizacao,
@@ -184,6 +185,19 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (_side_effect_liberar_reservas_cancelamento,),
+    },
+    "cancelar_pre_autorizacao": {
+        "from_status": (
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+        ),
+        "to_status": StatusRequisicao.CANCELADA,
+        "timeline_event_type": TipoEvento.CANCELAMENTO,
+        "audit_fields_to_set": (
+            "data_finalizacao",
+            "status",
+        ),
+        "side_effects": (),
     },
 }
 
@@ -639,15 +653,14 @@ def _cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisic
             details={"status_atual": requisicao.status},
         )
 
-    requisicao.status = StatusRequisicao.CANCELADA
-    requisicao.data_finalizacao = timezone.now()
-    requisicao.save(update_fields=["status", "data_finalizacao", "updated_at"])
-    EventoTimeline.objects.create(
+    return _apply_requisicao_transition(
         requisicao=requisicao,
-        tipo_evento=TipoEvento.CANCELAMENTO,
-        usuario=ator,
+        transition_name="cancelar_pre_autorizacao",
+        actor=ator,
+        payload={
+            "data_finalizacao": timezone.now(),
+        },
     )
-    return requisicao
 
 
 def _cancelar_autorizada_sem_saldo(
@@ -657,7 +670,7 @@ def _cancelar_autorizada_sem_saldo(
     if not motivo_cancelamento:
         raise ValidationError({"motivo_cancelamento": ["Motivo do cancelamento é obrigatório."]})
 
-    if not pode_atender_requisicao(ator, requisicao):
+    if not pode_cancelar_autorizada(ator, requisicao):
         raise PermissionDenied("Usuário sem permissão para cancelar esta requisição.")
 
     if requisicao.status != StatusRequisicao.AUTORIZADA:
@@ -711,13 +724,13 @@ def cancelar_requisicao(
     with transaction.atomic():
         requisicao = _recarregar_requisicao_para_atendimento(requisicao)
         if requisicao.status == StatusRequisicao.AUTORIZADA:
-            _cancelar_autorizada_sem_saldo(
+            requisicao = _cancelar_autorizada_sem_saldo(
                 requisicao=requisicao,
                 ator=ator,
                 motivo_cancelamento=motivo_cancelamento,
             )
         else:
-            _cancelar_pre_autorizacao(requisicao=requisicao, ator=ator)
+            requisicao = _cancelar_pre_autorizacao(requisicao=requisicao, ator=ator)
 
     return (
         Requisicao.objects.select_related(

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -623,105 +623,101 @@ def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> N
         requisicao.delete()
 
 
-def cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
+def _cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
     if not pode_manipular_pre_autorizacao(ator, requisicao):
         raise PermissionDenied("Apenas criador ou beneficiário podem cancelar a requisição.")
 
-    with transaction.atomic():
-        requisicao = (
-            Requisicao.objects.select_for_update()
-            .select_related("criador", "beneficiario", "setor_beneficiario")
-            .prefetch_related("itens__material", "eventos__usuario")
-            .get(pk=requisicao.pk)
-        )
-
-        if requisicao.status == StatusRequisicao.RASCUNHO:
-            if not requisicao.numero_publico:
-                raise DomainConflict(
-                    "Rascunho nunca enviado deve ser descartado, não cancelado logicamente.",
-                    details={"status_atual": requisicao.status},
-                )
-        elif requisicao.status != StatusRequisicao.AGUARDANDO_AUTORIZACAO:
+    if requisicao.status == StatusRequisicao.RASCUNHO:
+        if not requisicao.numero_publico:
             raise DomainConflict(
-                "Somente rascunhos já formalizados ou requisições aguardando autorização podem ser cancelados.",
+                "Rascunho nunca enviado deve ser descartado, não cancelado logicamente.",
                 details={"status_atual": requisicao.status},
             )
-
-        requisicao.status = StatusRequisicao.CANCELADA
-        requisicao.data_finalizacao = timezone.now()
-        requisicao.save(update_fields=["status", "data_finalizacao", "updated_at"])
-        EventoTimeline.objects.create(
-            requisicao=requisicao,
-            tipo_evento=TipoEvento.CANCELAMENTO,
-            usuario=ator,
+    elif requisicao.status != StatusRequisicao.AGUARDANDO_AUTORIZACAO:
+        raise DomainConflict(
+            "Somente rascunhos já formalizados ou requisições aguardando autorização podem ser cancelados.",
+            details={"status_atual": requisicao.status},
         )
 
-    return (
-        Requisicao.objects.select_related(
-            "criador",
-            "beneficiario",
-            "setor_beneficiario",
-        )
-        .prefetch_related("itens__material", "eventos__usuario")
-        .get(pk=requisicao.pk)
+    requisicao.status = StatusRequisicao.CANCELADA
+    requisicao.data_finalizacao = timezone.now()
+    requisicao.save(update_fields=["status", "data_finalizacao", "updated_at"])
+    EventoTimeline.objects.create(
+        requisicao=requisicao,
+        tipo_evento=TipoEvento.CANCELAMENTO,
+        usuario=ator,
     )
+    return requisicao
 
 
-def cancelar_autorizada_sem_saldo(
+def _cancelar_autorizada_sem_saldo(
     *, requisicao: Requisicao, ator: User, motivo_cancelamento: str
 ) -> Requisicao:
     motivo_cancelamento = motivo_cancelamento.strip()
     if not motivo_cancelamento:
         raise ValidationError({"motivo_cancelamento": ["Motivo do cancelamento é obrigatório."]})
 
+    if not pode_atender_requisicao(ator, requisicao):
+        raise PermissionDenied("Usuário sem permissão para cancelar esta requisição.")
+
+    if requisicao.status != StatusRequisicao.AUTORIZADA:
+        raise DomainConflict(
+            "Somente requisições autorizadas podem ser canceladas no atendimento.",
+            details={"status_atual": requisicao.status},
+        )
+
+    itens_requisicao = list(
+        ItemRequisicao.objects.select_for_update()
+        .select_related("material")
+        .filter(requisicao=requisicao)
+        .order_by("material_id", "id")
+    )
+    itens_autorizados = [item for item in itens_requisicao if item.quantidade_autorizada > 0]
+    if not itens_autorizados:
+        raise DomainConflict(
+            "Requisição autorizada não possui itens com quantidade autorizada.",
+            details={"requisicao_id": requisicao.id},
+        )
+
+    estoques_por_material_id = _travar_estoques_dos_itens(itens_autorizados)
+    itens_com_saldo_fisico = [
+        item.id
+        for item in itens_autorizados
+        if estoques_por_material_id[item.material_id].saldo_fisico > 0
+    ]
+    if itens_com_saldo_fisico:
+        raise DomainConflict(
+            "Ainda há saldo físico para atendimento parcial da requisição.",
+            details={"item_ids": itens_com_saldo_fisico},
+        )
+
+    return _apply_requisicao_transition(
+        requisicao=requisicao,
+        transition_name="cancelar_pos_autorizacao_sem_saldo",
+        actor=ator,
+        payload={
+            "responsavel_atendimento": ator,
+            "data_finalizacao": timezone.now(),
+            "motivo_cancelamento": motivo_cancelamento,
+            "itens_requisicao": itens_autorizados,
+            "estoques_por_material_id": estoques_por_material_id,
+        },
+    )
+
+
+def cancelar_requisicao(
+    *, requisicao: Requisicao, ator: User, motivo_cancelamento: str
+) -> Requisicao:
     with transaction.atomic():
         requisicao = _recarregar_requisicao_para_atendimento(requisicao)
-        if not pode_atender_requisicao(ator, requisicao):
-            raise PermissionDenied("Usuário sem permissão para cancelar esta requisição.")
-
-        if requisicao.status != StatusRequisicao.AUTORIZADA:
-            raise DomainConflict(
-                "Somente requisições autorizadas podem ser canceladas no atendimento.",
-                details={"status_atual": requisicao.status},
+        if requisicao.status == StatusRequisicao.AUTORIZADA:
+            _cancelar_autorizada_sem_saldo(
+                requisicao=requisicao,
+                ator=ator,
+                motivo_cancelamento=motivo_cancelamento,
             )
-
-        itens_requisicao = list(
-            ItemRequisicao.objects.select_for_update()
-            .select_related("material")
-            .filter(requisicao=requisicao)
-            .order_by("material_id", "id")
-        )
-        itens_autorizados = [item for item in itens_requisicao if item.quantidade_autorizada > 0]
-        if not itens_autorizados:
-            raise DomainConflict(
-                "Requisição autorizada não possui itens com quantidade autorizada.",
-                details={"requisicao_id": requisicao.id},
-            )
-
-        estoques_por_material_id = _travar_estoques_dos_itens(itens_autorizados)
-        itens_com_saldo_fisico = [
-            item.id
-            for item in itens_autorizados
-            if estoques_por_material_id[item.material_id].saldo_fisico > 0
-        ]
-        if itens_com_saldo_fisico:
-            raise DomainConflict(
-                "Ainda há saldo físico para atendimento parcial da requisição.",
-                details={"item_ids": itens_com_saldo_fisico},
-            )
-
-        _apply_requisicao_transition(
-            requisicao=requisicao,
-            transition_name="cancelar_pos_autorizacao_sem_saldo",
-            actor=ator,
-            payload={
-                "responsavel_atendimento": ator,
-                "data_finalizacao": timezone.now(),
-                "motivo_cancelamento": motivo_cancelamento,
-                "itens_requisicao": itens_autorizados,
-                "estoques_por_material_id": estoques_por_material_id,
-            },
-        )
+        else:
+            _cancelar_pre_autorizacao(requisicao=requisicao, ator=ator)
 
     return (
         Requisicao.objects.select_related(

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -10,9 +10,11 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.api.serializers import ErrorResponseSerializer
+from apps.requisitions.models import StatusRequisicao
 from apps.requisitions.policies import queryset_requisicoes_visiveis
 from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
+    RequisicaoCancelInputSerializer,
     RequisicaoCreateInputSerializer,
     RequisicaoDetailOutputSerializer,
     RequisicaoFulfillInputSerializer,
@@ -27,6 +29,7 @@ from apps.requisitions.services import (
     ItemRascunhoData,
     atender_requisicao,
     autorizar_requisicao,
+    cancelar_autorizada_sem_saldo,
     cancelar_pre_autorizacao,
     criar_rascunho_requisicao,
     descartar_rascunho_nunca_enviado,
@@ -131,11 +134,12 @@ class RequisicaoViewSet(GenericViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
     @extend_schema(
-        operation_id="requisitions_cancel_pre_approval",
+        operation_id="requisitions_cancel",
         tags=["requisitions"],
-        request=None,
+        request=RequisicaoCancelInputSerializer,
         responses={
             200: RequisicaoDetailOutputSerializer(),
+            400: ErrorResponseSerializer(),
             403: ErrorResponseSerializer(),
             404: ErrorResponseSerializer(),
             409: ErrorResponseSerializer(),
@@ -143,7 +147,17 @@ class RequisicaoViewSet(GenericViewSet):
     )
     @action(detail=True, methods=["post"], url_path="cancel")
     def cancel(self, request, pk=None):
-        requisicao = cancelar_pre_autorizacao(requisicao=self.get_object(), ator=request.user)
+        serializer = RequisicaoCancelInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        requisicao = self.get_object()
+        if requisicao.status == StatusRequisicao.AUTORIZADA:
+            requisicao = cancelar_autorizada_sem_saldo(
+                requisicao=requisicao,
+                ator=request.user,
+                motivo_cancelamento=serializer.validated_data["motivo_cancelamento"],
+            )
+        else:
+            requisicao = cancelar_pre_autorizacao(requisicao=requisicao, ator=request.user)
         return Response(RequisicaoDetailOutputSerializer(requisicao).data)
 
     @extend_schema(

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -10,7 +10,6 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.api.serializers import ErrorResponseSerializer
-from apps.requisitions.models import StatusRequisicao
 from apps.requisitions.policies import queryset_requisicoes_visiveis
 from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
@@ -29,8 +28,7 @@ from apps.requisitions.services import (
     ItemRascunhoData,
     atender_requisicao,
     autorizar_requisicao,
-    cancelar_autorizada_sem_saldo,
-    cancelar_pre_autorizacao,
+    cancelar_requisicao,
     criar_rascunho_requisicao,
     descartar_rascunho_nunca_enviado,
     enviar_para_autorizacao,
@@ -149,15 +147,11 @@ class RequisicaoViewSet(GenericViewSet):
     def cancel(self, request, pk=None):
         serializer = RequisicaoCancelInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        requisicao = self.get_object()
-        if requisicao.status == StatusRequisicao.AUTORIZADA:
-            requisicao = cancelar_autorizada_sem_saldo(
-                requisicao=requisicao,
-                ator=request.user,
-                motivo_cancelamento=serializer.validated_data["motivo_cancelamento"],
-            )
-        else:
-            requisicao = cancelar_pre_autorizacao(requisicao=requisicao, ator=request.user)
+        requisicao = cancelar_requisicao(
+            requisicao=self.get_object(),
+            ator=request.user,
+            motivo_cancelamento=serializer.validated_data["motivo_cancelamento"],
+        )
         return Response(RequisicaoDetailOutputSerializer(requisicao).data)
 
     @extend_schema(

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1425,6 +1425,59 @@ class TestRequisicaoAPI:
         assert requisicao.status == StatusRequisicao.AUTORIZADA
         assert material.estoque.saldo_reservado == Decimal("2")
 
+    def test_cancel_autorizada_sem_saldo_unauthenticated(self):
+        setor = self._criar_setor("Cancelamento Auth", "90059")
+        solicitante = self._criar_usuario("10075", "Solicitante Auth", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.001.061",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000519",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "Sem credenciais"},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_cancel_autorizada_sem_saldo_not_found(self):
+        setor = self._criar_setor("Cancelamento Not Found", "90060")
+        almoxarife = self._criar_usuario(
+            "10076",
+            "Auxiliar Almoxarifado Not Found",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(
+            reverse("requisicao-cancel", args=[999999]),
+            {"motivo_cancelamento": "Requisição inexistente"},
+            format="json",
+        )
+
+        assert response.status_code == 404
+
     def test_fulfill_payload_incompleto_retorna_validation_error(self):
         setor = self._criar_setor("Manutencao Payload", "90054")
         solicitante = self._criar_usuario("10066", "Solicitante Payload", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1242,6 +1242,189 @@ class TestRequisicaoAPI:
         assert material.estoque.saldo_reservado == Decimal("3")
         assert not MovimentacaoEstoque.objects.filter(requisicao=requisicao).exists()
 
+    def test_cancel_autorizada_sem_saldo_libera_reserva(self):
+        setor = self._criar_setor("Cancelamento Operacional", "90055")
+        solicitante = self._criar_usuario("10068", "Solicitante Cancelamento", setor=setor)
+        almoxarife = self._criar_usuario(
+            "10069",
+            "Auxiliar Almoxarifado Cancelamento",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.057",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000515",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        item = requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("3"),
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "Saldo físico zerado no momento da retirada"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.CANCELADA
+        assert response.data["motivo_cancelamento"] == "Saldo físico zerado no momento da retirada"
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.responsavel_atendimento_id == almoxarife.id
+        assert requisicao.eventos.filter(tipo_evento=TipoEvento.CANCELAMENTO).exists()
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert MovimentacaoEstoque.objects.filter(
+            requisicao=requisicao,
+            item_requisicao=item,
+            tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
+            quantidade=Decimal("3"),
+        ).exists()
+
+    def test_cancel_autorizada_sem_saldo_exige_motivo(self):
+        setor = self._criar_setor("Cancelamento Motivo", "90056")
+        solicitante = self._criar_usuario("10070", "Solicitante Motivo", setor=setor)
+        almoxarife = self._criar_usuario(
+            "10071",
+            "Auxiliar Almoxarifado Motivo",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.058",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000516",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "   "},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data["error"]["code"] == "validation_error"
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.status == StatusRequisicao.AUTORIZADA
+        assert material.estoque.saldo_reservado == Decimal("2")
+
+    def test_cancel_autorizada_sem_saldo_bloqueia_quando_ainda_ha_saldo_fisico(self):
+        setor = self._criar_setor("Cancelamento Parcial", "90057")
+        solicitante = self._criar_usuario("10072", "Solicitante Parcial", setor=setor)
+        almoxarife = self._criar_usuario(
+            "10073",
+            "Auxiliar Almoxarifado Parcial",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.001.059",
+            saldo_fisico=Decimal("1"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000517",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("3"),
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "Tentativa de cancelar com saldo restante"},
+            format="json",
+        )
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.status == StatusRequisicao.AUTORIZADA
+        assert material.estoque.saldo_reservado == Decimal("3")
+
+    def test_cancel_autorizada_sem_saldo_bloqueia_usuario_sem_permissao(self):
+        setor = self._criar_setor("Cancelamento Permissao", "90058")
+        solicitante = self._criar_usuario("10074", "Solicitante Permissao", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.001.060",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000518",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "Sem saldo físico"},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.status == StatusRequisicao.AUTORIZADA
+        assert material.estoque.saldo_reservado == Decimal("2")
+
     def test_fulfill_payload_incompleto_retorna_validation_error(self):
         setor = self._criar_setor("Manutencao Payload", "90054")
         solicitante = self._criar_usuario("10066", "Solicitante Payload", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1296,6 +1296,45 @@ class TestRequisicaoAPI:
             quantidade=Decimal("3"),
         ).exists()
 
+    def test_cancel_autorizada_sem_saldo_permite_criador(self):
+        setor = self._criar_setor("Cancelamento Criador", "90061")
+        solicitante = self._criar_usuario("10077", "Solicitante Criador", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.001.062",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=solicitante,
+            beneficiario=solicitante,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000520",
+            status=StatusRequisicao.AUTORIZADA,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+            data_autorizacao_ou_recusa="2026-04-30T11:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=solicitante)
+        response = client.post(
+            reverse("requisicao-cancel", args=[requisicao.id]),
+            {"motivo_cancelamento": "Sem saldo fisico para retirada"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.CANCELADA
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        assert requisicao.responsavel_atendimento_id == solicitante.id
+        assert material.estoque.saldo_reservado == Decimal("0")
+
     def test_cancel_autorizada_sem_saldo_exige_motivo(self):
         setor = self._criar_setor("Cancelamento Motivo", "90056")
         solicitante = self._criar_usuario("10070", "Solicitante Motivo", setor=setor)
@@ -1389,6 +1428,7 @@ class TestRequisicaoAPI:
     def test_cancel_autorizada_sem_saldo_bloqueia_usuario_sem_permissao(self):
         setor = self._criar_setor("Cancelamento Permissao", "90058")
         solicitante = self._criar_usuario("10074", "Solicitante Permissao", setor=setor)
+        chefe_setor = setor.chefe_responsavel
         material = self._criar_material_com_estoque(
             "001.001.060",
             saldo_fisico=Decimal("0"),
@@ -1411,7 +1451,7 @@ class TestRequisicaoAPI:
         )
 
         client = APIClient()
-        client.force_authenticate(user=solicitante)
+        client.force_authenticate(user=chefe_setor)
         response = client.post(
             reverse("requisicao-cancel", args=[requisicao.id]),
             {"motivo_cancelamento": "Sem saldo físico"},

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -911,6 +911,35 @@ class TestAtendimentoRequisicaoService:
             quantidade=Decimal("3"),
         ).exists()
 
+    def test_cancelamento_autorizada_sem_saldo_permite_criador(self):
+        setor = self._criar_setor("Cancelamento Criador", "92041")
+        requisitante = self._criar_usuario("12045", "Solicitante Cancelamento", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.003.043",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200043",
+            material=material,
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        cancelada = cancelar_requisicao(
+            requisicao=requisicao,
+            ator=requisitante,
+            motivo_cancelamento="Sem saldo fisico para retirada",
+        )
+
+        material.estoque.refresh_from_db()
+        item.refresh_from_db()
+        assert cancelada.status == StatusRequisicao.CANCELADA
+        assert cancelada.responsavel_atendimento_id == requisitante.id
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("0")
+
     def test_cancelamento_autorizada_sem_saldo_bloqueia_se_ainda_ha_saldo_fisico(self):
         setor = self._criar_setor("Cancelamento Com Saldo", "92042")
         requisitante = self._criar_usuario("12042", "Solicitante Com Saldo", setor=setor)
@@ -949,7 +978,7 @@ class TestAtendimentoRequisicaoService:
         assert material.estoque.saldo_reservado == Decimal("3")
         assert MovimentacaoEstoque.objects.count() == 0
 
-    def test_cancelamento_autorizada_sem_saldo_exige_motivo_e_permissao_operacional(self):
+    def test_cancelamento_autorizada_sem_saldo_exige_motivo(self):
         setor = self._criar_setor("Cancelamento Permissao", "92044")
         solicitante = self._criar_usuario("12044", "Solicitante Permissao", setor=setor)
         material = self._criar_material_com_estoque(
@@ -971,10 +1000,28 @@ class TestAtendimentoRequisicaoService:
                 ator=solicitante,
                 motivo_cancelamento="   ",
             )
+
+    def test_cancelamento_autorizada_sem_saldo_bloqueia_usuario_visivel_sem_permissao(self):
+        setor = self._criar_setor("Cancelamento Sem Permissao", "92046")
+        solicitante = self._criar_usuario("12046", "Solicitante Sem Permissao", setor=setor)
+        chefe_setor = setor.chefe_responsavel
+        material = self._criar_material_com_estoque(
+            "001.003.044",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao, _ = self._criar_requisicao_autorizada(
+            criador=solicitante,
+            beneficiario=solicitante,
+            numero_publico="REQ-2026-200044",
+            material=material,
+            quantidade_autorizada=Decimal("2"),
+        )
+
         with pytest.raises(PermissionDenied):
             cancelar_requisicao(
                 requisicao=requisicao,
-                ator=solicitante,
+                ator=chefe_setor,
                 motivo_cancelamento="Sem saldo físico",
             )
 
@@ -1213,6 +1260,66 @@ class TestAtendimentoRequisicaoService:
             MovimentacaoEstoque.objects.filter(
                 requisicao=requisicao,
                 tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+            ).count()
+            == 1
+        )
+
+    @pytest.mark.postgres
+    def test_cancelamentos_concorrentes_nao_duplicam_liberacao_reserva(self):
+        setor = self._criar_setor("Cancelamento Concorrente", "92047")
+        requisitante = self._criar_usuario("12047", "Solicitante Concorrente", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.003.045",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("4"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200045",
+            material=material,
+            quantidade_autorizada=Decimal("4"),
+        )
+
+        barrier = Barrier(2)
+
+        def cancelar(req_id: int):
+            close_old_connections()
+            try:
+                barrier.wait()
+                requisicao_cancelamento = Requisicao.objects.get(pk=req_id)
+                cancelar_requisicao(
+                    requisicao=requisicao_cancelamento,
+                    ator=requisitante,
+                    motivo_cancelamento="Sem saldo fisico",
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            resultado_a = executor.submit(cancelar, requisicao.id)
+            resultado_b = executor.submit(cancelar, requisicao.id)
+
+        resultados = {resultado_a.result(), resultado_b.result()}
+        close_old_connections()
+
+        requisicao.refresh_from_db()
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert requisicao.status == StatusRequisicao.CANCELADA
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                item_requisicao=item,
+                tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
+                quantidade=Decimal("4"),
             ).count()
             == 1
         )

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -22,7 +22,7 @@ from apps.requisitions.services import (
     atender_requisicao_com_itens,
     atender_requisicao_completa,
     autorizar_requisicao,
-    cancelar_autorizada_sem_saldo,
+    cancelar_requisicao,
     recusar_requisicao,
 )
 from apps.stock.models import EstoqueMaterial, MovimentacaoEstoque, TipoMovimentacao
@@ -889,7 +889,7 @@ class TestAtendimentoRequisicaoService:
             quantidade_autorizada=Decimal("3"),
         )
 
-        cancelada = cancelar_autorizada_sem_saldo(
+        cancelada = cancelar_requisicao(
             requisicao=requisicao,
             ator=atendente,
             motivo_cancelamento="Divergência física total no atendimento",
@@ -934,7 +934,7 @@ class TestAtendimentoRequisicaoService:
         )
 
         with pytest.raises(DomainConflict):
-            cancelar_autorizada_sem_saldo(
+            cancelar_requisicao(
                 requisicao=requisicao,
                 ator=atendente,
                 motivo_cancelamento="Ainda existe saldo",
@@ -966,13 +966,13 @@ class TestAtendimentoRequisicaoService:
         )
 
         with pytest.raises(ValidationError):
-            cancelar_autorizada_sem_saldo(
+            cancelar_requisicao(
                 requisicao=requisicao,
                 ator=solicitante,
                 motivo_cancelamento="   ",
             )
         with pytest.raises(PermissionDenied):
-            cancelar_autorizada_sem_saldo(
+            cancelar_requisicao(
                 requisicao=requisicao,
                 ator=solicitante,
                 motivo_cancelamento="Sem saldo físico",

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -22,6 +22,7 @@ from apps.requisitions.services import (
     atender_requisicao_com_itens,
     atender_requisicao_completa,
     autorizar_requisicao,
+    cancelar_autorizada_sem_saldo,
     recusar_requisicao,
 )
 from apps.stock.models import EstoqueMaterial, MovimentacaoEstoque, TipoMovimentacao
@@ -865,6 +866,117 @@ class TestAtendimentoRequisicaoService:
         assert material.estoque.saldo_fisico == Decimal("6")
         assert material.estoque.saldo_reservado == Decimal("2")
         assert MovimentacaoEstoque.objects.count() == 0
+
+    def test_cancelamento_autorizada_sem_saldo_libera_reserva_e_registra_motivo(self):
+        setor = self._criar_setor("Cancelamento Sem Saldo", "92040")
+        requisitante = self._criar_usuario("12040", "Solicitante Sem Saldo", setor=setor)
+        atendente = self._criar_usuario(
+            "12041",
+            "Auxiliar Almoxarifado Sem Saldo",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.040",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200040",
+            material=material,
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        cancelada = cancelar_autorizada_sem_saldo(
+            requisicao=requisicao,
+            ator=atendente,
+            motivo_cancelamento="Divergência física total no atendimento",
+        )
+
+        material.estoque.refresh_from_db()
+        item.refresh_from_db()
+        assert cancelada.status == StatusRequisicao.CANCELADA
+        assert cancelada.motivo_cancelamento == "Divergência física total no atendimento"
+        assert cancelada.responsavel_atendimento_id == atendente.id
+        assert cancelada.eventos.filter(tipo_evento=TipoEvento.CANCELAMENTO).exists()
+        assert item.quantidade_entregue == Decimal("0")
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert MovimentacaoEstoque.objects.filter(
+            requisicao=cancelada,
+            item_requisicao=item,
+            tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
+            quantidade=Decimal("3"),
+        ).exists()
+
+    def test_cancelamento_autorizada_sem_saldo_bloqueia_se_ainda_ha_saldo_fisico(self):
+        setor = self._criar_setor("Cancelamento Com Saldo", "92042")
+        requisitante = self._criar_usuario("12042", "Solicitante Com Saldo", setor=setor)
+        atendente = self._criar_usuario(
+            "12043",
+            "Auxiliar Almoxarifado Com Saldo",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.041",
+            saldo_fisico=Decimal("1"),
+            saldo_reservado=Decimal("3"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200041",
+            material=material,
+            quantidade_autorizada=Decimal("3"),
+        )
+
+        with pytest.raises(DomainConflict):
+            cancelar_autorizada_sem_saldo(
+                requisicao=requisicao,
+                ator=atendente,
+                motivo_cancelamento="Ainda existe saldo",
+            )
+
+        requisicao.refresh_from_db()
+        material.estoque.refresh_from_db()
+        item.refresh_from_db()
+        assert requisicao.status == StatusRequisicao.AUTORIZADA
+        assert requisicao.motivo_cancelamento == ""
+        assert item.quantidade_entregue == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("3")
+        assert MovimentacaoEstoque.objects.count() == 0
+
+    def test_cancelamento_autorizada_sem_saldo_exige_motivo_e_permissao_operacional(self):
+        setor = self._criar_setor("Cancelamento Permissao", "92044")
+        solicitante = self._criar_usuario("12044", "Solicitante Permissao", setor=setor)
+        material = self._criar_material_com_estoque(
+            "001.003.042",
+            saldo_fisico=Decimal("0"),
+            saldo_reservado=Decimal("2"),
+        )
+        requisicao, _ = self._criar_requisicao_autorizada(
+            criador=solicitante,
+            beneficiario=solicitante,
+            numero_publico="REQ-2026-200042",
+            material=material,
+            quantidade_autorizada=Decimal("2"),
+        )
+
+        with pytest.raises(ValidationError):
+            cancelar_autorizada_sem_saldo(
+                requisicao=requisicao,
+                ator=solicitante,
+                motivo_cancelamento="   ",
+            )
+        with pytest.raises(PermissionDenied):
+            cancelar_autorizada_sem_saldo(
+                requisicao=requisicao,
+                ator=solicitante,
+                motivo_cancelamento="Sem saldo físico",
+            )
 
     def test_atendimento_com_itens_rejeita_payload_incompleto_duplicado_ou_excessivo(self):
         setor = self._criar_setor("Atendimento Payload", "92026")


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Implementa cancelamento operacional de requisição `AUTORIZADA` quando nenhum item autorizado possui saldo físico disponível para retirada.
- Exige `motivo_cancelamento` nesse caminho pós-autorização.
- Registra `responsavel_atendimento`, `data_finalizacao`, evento de timeline de cancelamento e o motivo no detalhe da requisição.
- Libera a reserva de estoque usando o movimento existente `LIBERACAO_RESERVA_ATENDIMENTO`.
- Mantém o cancelamento pré-autorização no mesmo endpoint `POST /cancel/`, sem exigir justificativa para rascunho formalizado ou requisição aguardando autorização.

## Por que esta mudança é necessária
`PIL-BE-ATE-005` já cobria atendimento completo/parcial e bloqueio de atendimento zerado, mas ainda faltava fechar o caminho operacional quando a retirada não pode entregar nenhum item por falta total de saldo físico. Sem este fluxo, a requisição autorizada poderia ficar presa com reserva em aberto, mesmo quando o Almoxarifado precisa cancelar a operação com justificativa.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [x] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [x] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
O principal risco é liberar reserva indevidamente quando ainda existe saldo físico que permitiria atendimento parcial. O service bloqueia esse caso com `domain_conflict` e só cancela quando todos os itens autorizados estão com saldo físico zerado.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: cancelamento pós-autorização usa a mesma política operacional de atendimento (`pode_atender_requisicao`), portanto solicitante comum não pode executar esse caminho.
- dados / migration / constraints: sem mudança de schema e sem migration.
- transação / concorrência / idempotência: requisição, itens e estoques são travados em transação antes de validar saldo físico e liberar reservas.
- máquina de estados / aprovação / cotas / entregas: adiciona transição de `AUTORIZADA` para `CANCELADA` no caminho operacional sem entrega possível.
- configuração / CI / dependências: sem impacto.

---

# Testes e validação

## Cenários validados
1. Cancela requisição autorizada sem saldo físico, grava motivo/responsável/timeline e zera reserva.
2. Rejeita cancelamento pós-autorização sem `motivo_cancelamento`.
3. Rejeita cancelamento quando ainda existe saldo físico para atendimento parcial.
4. Rejeita usuário sem permissão operacional.
5. Mantém cancelamento pré-autorização funcionando no mesmo endpoint.

## Como validar manualmente
1. Criar uma requisição autorizada com item autorizado e reserva em estoque.
2. Ajustar o estoque do material para `saldo_fisico = 0` e manter `saldo_reservado > 0`.
3. Autenticar como `AUXILIAR_ALMOXARIFADO` ou `CHEFE_ALMOXARIFADO`.
4. Chamar `POST /api/v1/requisitions/{id}/cancel/` com `motivo_cancelamento` preenchido.
5. Confirmar que a resposta retorna `status = cancelada`, `motivo_cancelamento` preenchido e que o estoque ficou com `saldo_reservado = 0`.

## Payloads / exemplos de uso

```json
{
  "motivo_cancelamento": "Saldo físico zerado no momento da retirada"
}
```

## Comandos executados
- `rtk proxy pytest tests/requisitions/test_services.py tests/requisitions/test_api.py -q`
- `rtk proxy pytest tests/test_api_schema.py -q -k 'not swagger_ui'`
- `rtk uv run ruff check apps/requisitions tests/requisitions`
- `git diff --check`
- `rtk make test`

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Objetivo
  - Adicionar caminho operacional para cancelar requisições em status AUTORIZADA quando nenhum item autorizado possui saldo físico (saldo_fisico = 0), liberando reservas via movimentação LIBERACAO_RESERVA_ATENDIMENTO e registrando motivo/responsável/data/evento.

- Apps Django impactados
  - apps/requisitions: serializers, services, views, policies, testes.
  - apps/stock: side-effect via registrar_liberacao_reserva_por_atendimento (movimentação de liberação de reserva).

- Risco funcional
  - Médio — lógica sensível a concorrência e permissões. Commit posterior alinhou permissão para permitir Criador/Beneficiário e perfis de Almoxarifado (pode_cancelar_autorizada), reduzindo divergência inicial com design.
  - Concurrency test cobre concorrência (dois cancela simultâneos) garantindo apenas uma liberação de reserva criada.

- Impacto em regras de negócio
  - Novo fluxo: AUTORIZADA → CANCELADA válido somente se para todos os itens autorizados saldo_fisico == 0.
  - Motivo de cancelamento obrigatório apenas para pós-autorização; pré-autorização continua sem obrigação de motivo.
  - Bloqueio com domain_conflict se qualquer item autorizado tiver saldo_fisico > 0 (impede liberar reserva quando atendimento parcial é possível).

- Impacto em autenticação, autorização, escopo por perfil e por setor
  - Nova policy pode_cancelar_autorizada(user, requisicao) permite quem pode manipular pré-autorização ou operar estoque; commit corrige autorização para alinhar com matriz (criador/beneficiário & Almoxarifado).
  - Validações de usuário ativo e permissões aplicadas no serviço; superusuário não substitui o fluxo cotidiano.

- Impacto em contratos DRF, serializers, OpenAPI
  - RequisicaoCancelInputSerializer adicionado (motivo_cancelamento: allow_blank=True, default=""); endpoint /requisicao/{id}/cancel/ agora aceita body e valida motivo condicionalmente.
  - RequisicaoDetailOutputSerializer expõe motivo_cancelamento.
  - extend_schema atualizado (operation_id e request schema).
  - Não há mudanças em paginação, filtros ou envelope de erro além dos códigos 200/400/403/404/409 já usados.

- Impacto em integridade de dados, constraints, snapshots históricos e auditoria
  - Persistência de motivo_cancelamento, responsavel_atendimento e data_finalizacao; timeline cria evento TipoEvento.CANCELAMENTO.
  - Transição declarativa adicionada em TRANSICOES_REQUISICAO, aplicada via _apply_requisicao_transition — mantém rastreabilidade e histórico.
  - Nenhuma migration necessária (campo existente).

- Impacto em transações, concorrência, idempotência e saldos
  - Operação envolvida em transaction.atomic() com select_for_update() em requisição, itens e estoques (ordem determinística por ids) para evitar races.
  - Validação de saldo_fisico feita com locks; side effect de liberação de reserva executado dentro da transação.
  - Saldo_reservado é reduzido pela liberação; saldo_fisico não é alterado.
  - Concurrency test assegura que reprocessamentos simultâneos não gerem duplicação da movimentação (uma LIBERACAO_RESERVA_ATENDIMENTO criada; outra tentativa recebe DomainConflict).

- Impacto em importação SCPI / dados oficiais / divergência de estoque
  - Sem impacto direto em importação ou dados oficiais.
  - Não cria divergências de estoque; libera reservas sem alterar saldo físico.

- Impacto em configuração, CI, dependências, lint e testes
  - Sem migrations; ruff/lint ok conforme relatório.
  - Testes adicionados: API e services (incluindo teste concorrência). Reportado: 75 testes passam para suites indicadas.
  - Alterações de alto impacto concentradas em services.py, views e policies — atenção a cobertura e revisão de chamadas externas.

- Como validar manualmente
  - API:
    - POST /api/requisicao/{id}/cancel/ com JSON {"motivo_cancelamento":"..."} por usuário com permissão (almoxarife ou criador/beneficiário conforme policy).
    - Casos esperados:
      - sucesso (200): requisicao.status = CANCELADA, motivo preenchido, responsavel_atendimento setado, evento CANCELAMENTO criado, saldo_reservado zerado, MovimentacaoEstoque tipo LIBERACAO_RESERVA_ATENDIMENTO criada.
      - 400: motivo em branco/whitespace quando obrigatório (pós-autorização).
      - 409: domain_conflict quando existe saldo_fisico > 0.
      - 403: usuário sem permissão.
  - Pytest:
    - pytest tests/requisitions/test_api.py::TestRequisicaoAPI::test_cancel_autorizada_sem_saldo_libera_reserva -v
    - pytest tests/requisitions/test_services.py::... (coberturas de sucesso, permissão, validação e concorrência)
  - Verificações DB:
    - requisicao.motivo_cancelamento preenchido; requisicao.responsavel_atendimento = ator; evento timeline criado; MovimentacaoEstoque criada; saldo_reservado dos estoques envolvidos = 0; saldo_fisico inalterado.

- Pontos de atenção / riscos remanescentes
  - Confirmar que a policy pode_cancelar_autorizada aplicada em todas as ramificações e em pontos de chamada externos (nenhum caminho fora de services.py executando side effects sem locks).
  - Revisar select_related/prefetch onde aplicável para evitar N+1 ao carregar itens e materiais em ambientes com muitas requisições.
  - Garantir que RequisicaoCancelInputSerializer.keep allow_blank=True não permita submissão de whitespace sem validação adicional — validação de whitespace já implementada somente para pós-autorização.
  - Monitorar logs e métricas após deploy para capturar tentativas concorrentes/erros 409 em picos operacionais.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

