### PR TITLE
fix(requisitions): harden postgres concurrency paths

### DIFF
--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -471,7 +471,11 @@ def _gerar_numero_publico(*, ano: int | None = None) -> str:
             sequencia = SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
         except SequenciaNumeroRequisicao.DoesNotExist:
             try:
-                sequencia = SequenciaNumeroRequisicao.objects.create(ano=ano, ultimo_numero=0)
+                with transaction.atomic():
+                    sequencia = SequenciaNumeroRequisicao.objects.create(
+                        ano=ano,
+                        ultimo_numero=0,
+                    )
             except IntegrityError:
                 sequencia = SequenciaNumeroRequisicao.objects.select_for_update().get(ano=ano)
 
@@ -792,7 +796,7 @@ def autorizar_requisicao(
             ItemRequisicao.objects.select_for_update()
             .select_related("material")
             .filter(requisicao=requisicao)
-            .order_by("id")
+            .order_by("material_id", "id")
         )
         itens_por_id = _validar_itens_autorizacao(itens_requisicao=itens_requisicao, itens=itens)
         estoque_por_material_id = {

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -572,6 +572,8 @@ class TestAutorizacaoRequisicaoService:
                     ],
                 )
                 return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
             finally:
                 close_old_connections()
 
@@ -587,6 +589,7 @@ class TestAutorizacaoRequisicaoService:
         material_a.estoque.refresh_from_db()
         material_b.estoque.refresh_from_db()
 
+        # Both authorizations should succeed because each material has stock for both requests.
         assert resultados == {"ok"}
         assert requisicao_a.status == StatusRequisicao.AUTORIZADA
         assert requisicao_b.status == StatusRequisicao.AUTORIZADA

--- a/tests/requisitions/test_services.py
+++ b/tests/requisitions/test_services.py
@@ -11,6 +11,7 @@ from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
 from apps.requisitions.models import (
     ItemRequisicao,
     Requisicao,
+    SequenciaNumeroRequisicao,
     StatusRequisicao,
     TipoEvento,
 )
@@ -44,6 +45,30 @@ class TestSequenciaNumeroRequisicaoService:
 
         assert numero_2026 == "REQ-2026-000001"
         assert numero_2027 == "REQ-2027-000001"
+
+    @pytest.mark.postgres
+    def test_gera_numeros_distintos_quando_duas_threads_criam_mesmo_ano_inaugural(self):
+        barrier = Barrier(2)
+
+        def gerar():
+            close_old_connections()
+            try:
+                barrier.wait()
+                return _gerar_numero_publico(ano=2028)
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(gerar)
+            futuro_b = executor.submit(gerar)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        sequencia = SequenciaNumeroRequisicao.objects.get(ano=2028)
+
+        assert resultados == {"REQ-2028-000001", "REQ-2028-000002"}
+        assert sequencia.ultimo_numero == 2
 
 
 @pytest.mark.django_db(transaction=True)
@@ -477,6 +502,96 @@ class TestAutorizacaoRequisicaoService:
             StatusRequisicao.AGUARDANDO_AUTORIZACAO,
             StatusRequisicao.AUTORIZADA,
         }
+
+    @pytest.mark.postgres
+    def test_autorizacoes_concorrentes_multi_item_respeitam_lock_order_canonico(self):
+        setor = self._criar_setor("Lock Order", "91010")
+        chefe = setor.chefe_responsavel
+        requisitante_a = self._criar_usuario("11010", "Solicitante Lock A", setor=setor)
+        requisitante_b = self._criar_usuario("11011", "Solicitante Lock B", setor=setor)
+        material_a = self._criar_material_com_estoque("001.002.010", saldo_fisico=Decimal("4"))
+        material_b = self._criar_material_com_estoque("001.002.011", saldo_fisico=Decimal("4"))
+
+        requisicao_a = Requisicao.objects.create(
+            criador=requisitante_a,
+            beneficiario=requisitante_a,
+            setor_beneficiario=requisitante_a.setor,
+            numero_publico="REQ-2026-100010",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        item_a1 = requisicao_a.itens.create(
+            material=material_b,
+            unidade_medida=material_b.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+        item_a2 = requisicao_a.itens.create(
+            material=material_a,
+            unidade_medida=material_a.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+
+        requisicao_b = Requisicao.objects.create(
+            criador=requisitante_b,
+            beneficiario=requisitante_b,
+            setor_beneficiario=requisitante_b.setor,
+            numero_publico="REQ-2026-100011",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        item_b1 = requisicao_b.itens.create(
+            material=material_a,
+            unidade_medida=material_a.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+        item_b2 = requisicao_b.itens.create(
+            material=material_b,
+            unidade_medida=material_b.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+        )
+
+        barrier = Barrier(2)
+
+        def autorizar(req_id: int, item_ids: tuple[int, int]):
+            close_old_connections()
+            try:
+                barrier.wait()
+                requisicao = Requisicao.objects.get(pk=req_id)
+                autorizar_requisicao(
+                    requisicao=requisicao,
+                    ator=chefe,
+                    itens=[
+                        ItemAutorizacaoData(
+                            item_id=item_ids[0],
+                            quantidade_autorizada=Decimal("2"),
+                        ),
+                        ItemAutorizacaoData(
+                            item_id=item_ids[1],
+                            quantidade_autorizada=Decimal("2"),
+                        ),
+                    ],
+                )
+                return "ok"
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(autorizar, requisicao_a.id, (item_a1.id, item_a2.id))
+            futuro_b = executor.submit(autorizar, requisicao_b.id, (item_b1.id, item_b2.id))
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        requisicao_a.refresh_from_db()
+        requisicao_b.refresh_from_db()
+        material_a.estoque.refresh_from_db()
+        material_b.estoque.refresh_from_db()
+
+        assert resultados == {"ok"}
+        assert requisicao_a.status == StatusRequisicao.AUTORIZADA
+        assert requisicao_b.status == StatusRequisicao.AUTORIZADA
+        assert material_a.estoque.saldo_reservado == Decimal("4")
+        assert material_b.estoque.saldo_reservado == Decimal("4")
 
 
 @pytest.mark.django_db(transaction=True)
@@ -1320,6 +1435,166 @@ class TestAtendimentoRequisicaoService:
                 item_requisicao=item,
                 tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
                 quantidade=Decimal("4"),
+            ).count()
+            == 1
+        )
+
+    @pytest.mark.postgres
+    def test_atendimentos_parciais_concorrentes_nao_duplicam_saida_ou_liberacao(self):
+        setor = self._criar_setor("Atendimento Parcial", "92048")
+        requisitante = self._criar_usuario("12048", "Solicitante Parcial", setor=setor)
+        atendente = self._criar_usuario(
+            "12049",
+            "Atendente Parcial",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.046",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("5"),
+        )
+        requisicao, item = self._criar_requisicao_autorizada(
+            criador=requisitante,
+            beneficiario=requisitante,
+            numero_publico="REQ-2026-200046",
+            material=material,
+            quantidade_autorizada=Decimal("5"),
+        )
+
+        barrier = Barrier(2)
+
+        def atender(req_id: int, item_id: int):
+            close_old_connections()
+            try:
+                barrier.wait()
+                requisicao_atendimento = Requisicao.objects.get(pk=req_id)
+                atender_requisicao_com_itens(
+                    requisicao=requisicao_atendimento,
+                    ator=atendente,
+                    itens=[
+                        ItemAtendimentoData(
+                            item_id=item_id,
+                            quantidade_entregue=Decimal("3"),
+                            justificativa_atendimento_parcial="Saldo parcial liberado",
+                        )
+                    ],
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(atender, requisicao.id, item.id)
+            futuro_b = executor.submit(atender, requisicao.id, item.id)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        requisicao.refresh_from_db()
+        item.refresh_from_db()
+        material.estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert requisicao.status == StatusRequisicao.ATENDIDA_PARCIALMENTE
+        assert item.quantidade_entregue == Decimal("3")
+        assert material.estoque.saldo_fisico == Decimal("2")
+        assert material.estoque.saldo_reservado == Decimal("0")
+        assert material.estoque.saldo_fisico >= 0
+        assert material.estoque.saldo_reservado >= 0
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                item_requisicao=item,
+                tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+                quantidade=Decimal("3"),
+            ).count()
+            == 1
+        )
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                item_requisicao=item,
+                tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
+                quantidade=Decimal("2"),
+            ).count()
+            == 1
+        )
+
+    @pytest.mark.postgres
+    def test_atendimentos_concorrentes_de_requisicoes_distintas_nao_dividem_mesmo_saldo(self):
+        setor = self._criar_setor("Atendimento Distinto", "92049")
+        requisitante_a = self._criar_usuario("12050", "Solicitante Distinto A", setor=setor)
+        requisitante_b = self._criar_usuario("12051", "Solicitante Distinto B", setor=setor)
+        atendente = self._criar_usuario(
+            "12052",
+            "Atendente Distinto",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque(
+            "001.003.047",
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("10"),
+        )
+        requisicao_a, _ = self._criar_requisicao_autorizada(
+            criador=requisitante_a,
+            beneficiario=requisitante_a,
+            numero_publico="REQ-2026-200047",
+            material=material,
+            quantidade_autorizada=Decimal("5"),
+        )
+        requisicao_b, _ = self._criar_requisicao_autorizada(
+            criador=requisitante_b,
+            beneficiario=requisitante_b,
+            numero_publico="REQ-2026-200048",
+            material=material,
+            quantidade_autorizada=Decimal("5"),
+        )
+
+        barrier = Barrier(2)
+
+        def atender(req_id: int):
+            close_old_connections()
+            try:
+                barrier.wait()
+                requisicao_atendimento = Requisicao.objects.get(pk=req_id)
+                atender_requisicao_completa(
+                    requisicao=requisicao_atendimento,
+                    ator=atendente,
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(atender, requisicao_a.id)
+            futuro_b = executor.submit(atender, requisicao_b.id)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        requisicao_a.refresh_from_db()
+        requisicao_b.refresh_from_db()
+        material.estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert {requisicao_a.status, requisicao_b.status} == {
+            StatusRequisicao.AUTORIZADA,
+            StatusRequisicao.ATENDIDA,
+        }
+        assert material.estoque.saldo_fisico == Decimal("0")
+        assert material.estoque.saldo_reservado == Decimal("5")
+        assert material.estoque.saldo_fisico >= 0
+        assert material.estoque.saldo_reservado >= 0
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                material=material,
+                tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
             ).count()
             == 1
         )

--- a/tests/stock/test_services_estoque.py
+++ b/tests/stock/test_services_estoque.py
@@ -1,7 +1,10 @@
+from concurrent.futures import ThreadPoolExecutor
 from decimal import Decimal
+from threading import Barrier
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.db import close_old_connections
 
 from apps.core.api.exceptions import DomainConflict
 from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
@@ -633,3 +636,229 @@ class TestRegistrarSaldoInicial:
         assert estoque.saldo_fisico == Decimal("3")
         assert estoque.saldo_reservado == Decimal("5")
         assert MovimentacaoEstoque.objects.count() == 0
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.postgres
+    def test_registrar_reserva_por_autorizacao_concorrente_nao_duplica_saldo_reservado(self):
+        chefe = User.objects.create(
+            matricula_funcional="99010",
+            nome_completo="Chefe Estoque 10",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome="Setor Estoque 10", chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        material = self._criar_material()
+        estoque = EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("0"),
+        )
+        requisicao_a = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+        )
+        requisicao_b = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+        )
+        item_a = ItemRequisicao.objects.create(
+            requisicao=requisicao_a,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("5"),
+            quantidade_autorizada=Decimal("5"),
+        )
+        item_b = ItemRequisicao.objects.create(
+            requisicao=requisicao_b,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("5"),
+            quantidade_autorizada=Decimal("5"),
+        )
+
+        barrier = Barrier(2)
+
+        def reservar(requisicao_id: int, item_id: int):
+            close_old_connections()
+            try:
+                barrier.wait()
+                registrar_reserva_por_autorizacao(
+                    requisicao=Requisicao.objects.get(pk=requisicao_id),
+                    item=ItemRequisicao.objects.get(pk=item_id),
+                    quantidade=Decimal("5"),
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(reservar, requisicao_a.id, item_a.id)
+            futuro_b = executor.submit(reservar, requisicao_b.id, item_b.id)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert estoque.saldo_fisico == Decimal("5")
+        assert estoque.saldo_reservado == Decimal("5")
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                material=material,
+                tipo=TipoMovimentacao.RESERVA_POR_AUTORIZACAO,
+            ).count()
+            == 1
+        )
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.postgres
+    def test_registrar_saida_por_atendimento_concorrente_nao_duplica_baixa(self):
+        chefe = User.objects.create(
+            matricula_funcional="99011",
+            nome_completo="Chefe Estoque 11",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome="Setor Estoque 11", chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        material = self._criar_material()
+        estoque = EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=Decimal("5"),
+            saldo_reservado=Decimal("5"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AUTORIZADA,
+        )
+        item = ItemRequisicao.objects.create(
+            requisicao=requisicao,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("5"),
+            quantidade_autorizada=Decimal("5"),
+        )
+
+        barrier = Barrier(2)
+
+        def registrar_saida():
+            close_old_connections()
+            try:
+                barrier.wait()
+                registrar_saida_por_atendimento(
+                    requisicao=Requisicao.objects.get(pk=requisicao.id),
+                    item=ItemRequisicao.objects.get(pk=item.id),
+                    quantidade=Decimal("5"),
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(registrar_saida)
+            futuro_b = executor.submit(registrar_saida)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert estoque.saldo_fisico == Decimal("0")
+        assert estoque.saldo_reservado == Decimal("0")
+        assert estoque.saldo_fisico >= 0
+        assert estoque.saldo_reservado >= 0
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                item_requisicao=item,
+                tipo=TipoMovimentacao.SAIDA_POR_ATENDIMENTO,
+            ).count()
+            == 1
+        )
+
+    @pytest.mark.django_db(transaction=True)
+    @pytest.mark.postgres
+    def test_registrar_liberacao_reserva_concorrente_nao_duplica_movimentacao(self):
+        chefe = User.objects.create(
+            matricula_funcional="99012",
+            nome_completo="Chefe Estoque 12",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome="Setor Estoque 12", chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        material = self._criar_material()
+        estoque = EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=Decimal("10"),
+            saldo_reservado=Decimal("4"),
+        )
+        requisicao = Requisicao.objects.create(
+            criador=chefe,
+            beneficiario=chefe,
+            setor_beneficiario=setor,
+            status=StatusRequisicao.AUTORIZADA,
+        )
+        item = ItemRequisicao.objects.create(
+            requisicao=requisicao,
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("4"),
+            quantidade_autorizada=Decimal("4"),
+        )
+
+        barrier = Barrier(2)
+
+        def liberar():
+            close_old_connections()
+            try:
+                barrier.wait()
+                registrar_liberacao_reserva_por_atendimento(
+                    requisicao=Requisicao.objects.get(pk=requisicao.id),
+                    item=ItemRequisicao.objects.get(pk=item.id),
+                    quantidade=Decimal("4"),
+                )
+                return "ok"
+            except Exception as exc:  # noqa: BLE001
+                return type(exc).__name__
+            finally:
+                close_old_connections()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futuro_a = executor.submit(liberar)
+            futuro_b = executor.submit(liberar)
+
+        resultados = {futuro_a.result(), futuro_b.result()}
+        close_old_connections()
+
+        estoque.refresh_from_db()
+
+        assert resultados == {"ok", "DomainConflict"}
+        assert estoque.saldo_fisico == Decimal("10")
+        assert estoque.saldo_reservado == Decimal("0")
+        assert estoque.saldo_fisico >= 0
+        assert estoque.saldo_reservado >= 0
+        assert (
+            MovimentacaoEstoque.objects.filter(
+                requisicao=requisicao,
+                item_requisicao=item,
+                tipo=TipoMovimentacao.LIBERACAO_RESERVA_ATENDIMENTO,
+            ).count()
+            == 1
+        )


### PR DESCRIPTION
# Contexto

## O que este PR faz
- corrige o lock order de `autorizar_requisicao` para usar `material_id, id`
- corrige `_gerar_numero_publico` para sobreviver ao `IntegrityError` concorrente no ano inaugural
- adiciona cobertura PostgreSQL para concorrência em numeração pública, autorização, atendimento parcial e serviços de estoque

## Por que esta mudança é necessária
O relatório `docs/code-reviews/2026-05-02-concorrencia-postgresql.md` identificou um bug real no retry da sequência pública sob corrida concorrente e lacunas de cobertura nos caminhos críticos de saldo/reserva. Sem isso, colisões de numeração e regressões de lock/consistência poderiam passar sem detecção.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [x] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Cobertura concorrente pode expor falsa suposição sobre estado final ou ordenação de locks; o risco funcional direto é regressão em fluxos de autorização/atendimento se alguma premissa de estoque/reserva estiver incorreta.

## Impactos adicionais (somente se houver)

- transação / concorrência / idempotência: `_gerar_numero_publico` agora isola a criação inaugural em savepoint interno; `autorizar_requisicao` passa a usar o lock order canônico já adotado nos demais fluxos

---

# Testes e validação

## Cenários validados

1. duas threads gerando `numero_publico` para o mesmo ano inaugural retornam números distintos e finalizam `ultimo_numero == 2`
2. autorizações e atendimentos concorrentes não duplicam reservas/baixas/liberações e preservam status/saldos finais esperados
3. serviços de estoque isolados rejeitam a segunda thread concorrente sem deixar saldo físico ou reservado negativo

## Como validar manualmente
Executar:

`rtk proxy pytest tests/requisitions/test_services.py tests/stock/test_services_estoque.py -q`

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Resumo do PR: Hardening de caminhos de concorrência PostgreSQL

## Objetivo
Corrigir e endurecer caminhos críticos de concorrência em requisições e estoque para evitar deadlocks, duplicação de números públicos, e reprocessamento indevido de movimentações de estoque sob colisão de threads.

## Apps Django impactados
- `apps/requisitions` — geração de número público, autorização, atendimento
- `apps/stock` — reserva, saída e liberação de reserva por movimentações

## Mudanças técnicas

### `apps/requisitions/services.py` (+6/-2)
- **`_gerar_numero_publico`**: Isolamento de criação inaugural em `transaction.atomic()` aninhado + `savepoint` para sobreviver a `IntegrityError` concorrente quando múltiplas threads criam o mesmo `SequenciaNumeroRequisicao.ano`
- **`autorizar_requisicao`**: Mudança de ordering de `ItemRequisicao` de apenas `"id"` para `("material_id", "id")` para estabelecer lock order canonical (eliminando deadlock potencial em autorizações multi-material concorrentes)

### `tests/requisitions/test_services.py` (+278 linhas)
- `test_gera_numeros_distintos_quando_duas_threads_criam_mesmo_ano_inaugural`: Valida que threads simultâneas no ano inaugural geram números distintos (REQ-2028-000001, REQ-2028-000002) e `ultimo_numero == 2`
- `test_autorizacoes_concorrentes_multi_item_respeitam_lock_order_canonico`: Dois threads autorizando requisições com materiais em ordem invertida; assert ambas autorizam sem deadlock com saldos reservados corretos
- `test_atendimentos_parciais_concorrentes_nao_duplicam_saida_ou_liberacao`: Um thread entrega 3 un, o outro falha com `DomainConflict`; assert exatamente uma `SAIDA_POR_ATENDIMENTO` e uma `LIBERACAO_RESERVA_ATENDIMENTO`
- `test_atendimentos_concorrentes_de_requisicoes_distintas_nao_dividem_mesmo_saldo`: Dois threads atendendo requisições distintas do mesmo material; assert um entrega, outro falha, saldos finais corretos (saldo_fisico=0, saldo_reservado=5)

### `tests/stock/test_services_estoque.py` (+229 linhas)
- `test_registrar_reserva_por_autorizacao_concorrente_nao_duplica_saldo_reservado`: Dois threads reservando simultaneamente; assert saldo_reservado incremente apenas uma vez, exatamente um movimento
- `test_registrar_saida_por_atendimento_concorrente_nao_duplica_baixa`: Dois threads baixando o mesmo material; assert saldo_fisico decremente uma vez, exatamente um movimento
- `test_registrar_liberacao_reserva_concorrente_nao_duplica_movimentacao`: Dois threads liberando reserva; assert exatamente um movimento de liberação

## Risco funcional
**Alto** — Lock order canonical é pré-condição para ausência de deadlock. Invertir ordering em qualquer query de lock na autorização ou atendimento pode causar travamento cruzado. Reprocessamento indevido de números públicos ou movimentações pode deixar saldos negativos ou duplicar registros de estoque.

## Impacto em regras de negócio
Nenhum visível ao usuário. Comportamento funcional (status, quantidade autorizada/entregue) permanece idêntico.

## Impacto em autorização, autenticação, escopo
Nenhum — sem mudança em políticas de acesso (`policies.py`), papéis ou visibilidade por setor.

## Impacto em contratos DRF, serializers, paginação, filtros, OpenAPI
Nenhum — mudanças restritas a `services.py` e testes.

## Impacto em integridade de dados, constraints, auditoria, rastreabilidade
- ✅ Snapshot histórico (`EventoTimeline`, `MovimentacaoEstoque`) preservado
- ✅ Constraints `CheckConstraint` em saldos respeitados
- ✅ Números públicos único por ano mantido (tratamento de concorrência aprimorado)
- ✅ Movimentações registradas exatamente uma vez por operação (garantido por transação + lock)

## Impacto em transações, concorrência, idempotência, saldo físico/reservado/disponível
- **Transações**: `select_for_update()` com ordering canônico previne deadlock
- **Concorrência**: Savepoint aninhado isola criação inaugural; retry automático para `IntegrityError`
- **Idempotência**: Saldo reservado e saída só incrementam/decrementam uma vez mesmo com threads simultâneas
- **Saldos**: Validações `saldo_fisico >= 0`, `saldo_reservado >= 0` mantidas; movimentações atomicamente replicam estado
- **Disponível** (`saldo_fisico - saldo_reservado`): Correto sob concorrência via lock on `EstoqueMaterial`

## Impacto em importação SCPI, dados oficiais de materiais
Nenhum — sem alteração em importadores ou modelos de materiais.

## Impacto em configuração, CI, dependências, lint, testes, ambiente efêmero
- ✅ Testes marcados com `@pytest.mark.postgres` — rodam apenas em PostgreSQL (evita divergência SQLite)
- ✅ `ThreadPoolExecutor` + `Barrier` + `close_old_connections()` — padrão válido para ambientes efêmeros
- ✅ Sem nova dependência; sem mudança em config
- ✅ Sem migração obrigatória (dev efêmero)

## Como validar manualmente
```bash
rtk proxy pytest tests/requisitions/test_services.py::TestSequenciaNumeroRequisicaoService::test_gera_numeros_distintos_quando_duas_threads_criam_mesmo_ano_inaugural -xvs
rtk proxy pytest tests/requisitions/test_services.py::TestAutorizacaoRequisicaoService::test_autorizacoes_concorrentes_multi_item_respeitam_lock_order_canonico -xvs
rtk proxy pytest tests/requisitions/test_services.py::TestAtendimentoRequisicaoService::test_atendimentos_parciais_concorrentes_nao_duplicam_saida_ou_liberacao -xvs
rtk proxy pytest tests/requisitions/test_services.py::TestAtendimentoRequisicaoService::test_atendimentos_concorrentes_de_requisicoes_distintas_nao_dividem_mesmo_saldo -xvs
rtk proxy pytest tests/stock/test_services_estoque.py -k "concorrente" -xvs
```

## Observações críticas
1. **Lock order é transversal**: Qualquer novo `select_for_update()` em autorização/atendimento deve seguir `order_by("material_id", "id")` para `ItemRequisicao` ou `order_by("material_id")` para `EstoqueMaterial`
2. **Savepoint em ano inaugural**: Padrão defensivo contra race condition, não remove a necessidade de `unique_together` ou constraint no banco — apenas torna o retry automático
3. **Testes de concorrência são frágeis**: Usar `@pytest.mark.postgres` previne execução em SQLite; usar `Barrier` sincroniza threads antes da operação crítica

<!-- end of auto-generated comment: release notes by coderabbit.ai -->