### PR TITLE
fix(api): align schema contracts and error envelopes

### DIFF
--- a/apps/core/api/exceptions.py
+++ b/apps/core/api/exceptions.py
@@ -36,36 +36,38 @@ def api_exception_handler(exc, context):
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
         )
 
-    if isinstance(exc, APIException):
-        details = getattr(exc, "details_payload", None)
-        if details is None and isinstance(response.data, dict) and "detail" not in response.data:
-            details = response.data
+    details = getattr(exc, "details_payload", None)
+    if details is None and isinstance(response.data, dict) and "detail" not in response.data:
+        details = response.data
 
-        trace_id = None
-        if isinstance(response.data, dict):
-            trace_id = response.data.get("trace_id")
-        if trace_id is None:
-            trace_id = getattr(exc, "trace_id", None)
-        if trace_id is None and request is not None:
-            trace_id = request.META.get("HTTP_X_TRACE_ID")
+    trace_id = None
+    if isinstance(response.data, dict):
+        trace_id = response.data.get("trace_id")
+    if trace_id is None:
+        trace_id = getattr(exc, "trace_id", None)
+    if trace_id is None and request is not None:
+        trace_id = request.META.get("HTTP_X_TRACE_ID")
 
-        if response.status_code == status.HTTP_400_BAD_REQUEST:
-            code = "validation_error"
-            message = "Dados inválidos."
-        else:
-            code = getattr(exc, "default_code", None) or getattr(exc, "code", "api_error")
-            if isinstance(response.data, dict):
-                message = str(response.data.get("detail", str(exc)))
-            else:
-                message = str(exc)
+    if response.status_code == status.HTTP_400_BAD_REQUEST:
+        code = "validation_error"
+        message = "Dados inválidos."
+    else:
+        detail = response.data.get("detail") if isinstance(response.data, dict) else None
+        code = (
+            getattr(exc, "default_code", None)
+            or getattr(exc, "code", None)
+            or getattr(detail, "code", None)
+            or "api_error"
+        )
+        message = str(detail or exc)
 
-        response.data = {
-            "error": {
-                "code": code,
-                "message": message,
-                "details": details,
-                "trace_id": trace_id,
-            }
+    response.data = {
+        "error": {
+            "code": code,
+            "message": message,
+            "details": details,
+            "trace_id": trace_id,
         }
+    }
 
     return response

--- a/apps/core/api/serializers.py
+++ b/apps/core/api/serializers.py
@@ -5,6 +5,7 @@ class ErrorDetailSerializer(serializers.Serializer):
     code = serializers.CharField()
     message = serializers.CharField()
     details = serializers.JSONField(required=False, allow_null=True)
+    trace_id = serializers.CharField(required=False, allow_null=True)
 
 
 class ErrorResponseSerializer(serializers.Serializer):

--- a/apps/materials/views.py
+++ b/apps/materials/views.py
@@ -1,6 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.openapi import OpenApiParameter
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import filters
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ReadOnlyModelViewSet
@@ -14,6 +14,18 @@ from apps.materials.serializers import (
 )
 
 
+@extend_schema_view(
+    retrieve=extend_schema(
+        operation_id="materials_retrieve",
+        tags=["materials"],
+        description="Detalha um material ativo pelo identificador, incluindo o saldo disponível calculado.",
+        responses={
+            200: MaterialListOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+        },
+    ),
+)
 class MaterialViewSet(ReadOnlyModelViewSet):
     """API de busca de materiais para seleção em requisições.
 

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -62,6 +62,7 @@ class RequisicaoViewSet(GenericViewSet):
             201: RequisicaoDetailOutputSerializer(),
             400: ErrorResponseSerializer(),
             403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
             409: ErrorResponseSerializer(),
         },
     )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -116,7 +116,7 @@ SPECTACULAR_SETTINGS = {
     "TITLE": "WMS-SAEP API",
     "DESCRIPTION": "API do Sistema de Requisição de Materiais",
     "VERSION": "0.1.0",
-    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAuthenticated"],
+    "SERVE_PERMISSIONS": ["rest_framework.permissions.IsAdminUser"],
     "CONTACT": {"email": "contato@saep.local"},
 }
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,12 @@
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework.permissions import AllowAny
+
+schema_view_kwargs = {}
+if settings.DEBUG:
+    schema_view_kwargs["permission_classes"] = [AllowAny]
 
 urlpatterns = [
     path("admin/", admin.site.urls),
@@ -9,12 +14,12 @@ urlpatterns = [
     path("api/v1/", include("apps.requisitions.urls")),
     path(
         "api/v1/schema/",
-        SpectacularAPIView.as_view(permission_classes=[AllowAny]),
+        SpectacularAPIView.as_view(**schema_view_kwargs),
         name="schema",
     ),
     path(
         "api/v1/docs/",
-        SpectacularSwaggerView.as_view(url_name="schema", permission_classes=[AllowAny]),
+        SpectacularSwaggerView.as_view(url_name="schema", **schema_view_kwargs),
         name="swagger-ui",
     ),
 ]

--- a/tests/materials/test_api_materials.py
+++ b/tests/materials/test_api_materials.py
@@ -1,4 +1,4 @@
-"""Tests for material list API endpoint."""
+"""Tests for materials API endpoints."""
 
 from decimal import Decimal
 
@@ -52,6 +52,7 @@ class TestMaterialListAPI:
         client = APIClient()
         response = client.get(reverse("material-list"))
         assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
 
     def test_lista_materiais_retorna_apenas_ativos(self):
         """Material inativo não deve aparecer na lista."""
@@ -260,3 +261,45 @@ class TestMaterialListAPI:
         assert response.data["page_size"] == 5
         assert response.data["total_pages"] == 2
         assert len(response.data["results"]) == 5
+
+    def test_retrieve_material_por_id(self):
+        """Busca de detalhe deve retornar o material ativo solicitado."""
+        usuario = self._criar_usuario()
+        subgrupo = self._criar_subgrupo()
+        material = self._criar_material(subgrupo)
+        EstoqueMaterial.objects.create(
+            material=material,
+            saldo_fisico=100,
+            saldo_reservado=25,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-detail", args=[material.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == material.id
+        assert response.data["codigo_completo"] == material.codigo_completo
+        assert Decimal(response.data["saldo_disponivel"]) == Decimal("75")
+
+    def test_retrieve_material_nao_encontrado(self):
+        """ID inexistente deve retornar 404 no envelope padronizado."""
+        usuario = self._criar_usuario()
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("material-detail", args=[999999]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
+    def test_retrieve_material_requer_autenticacao(self):
+        """Sem autenticação o detalhe também deve retornar 403."""
+        subgrupo = self._criar_subgrupo()
+        material = self._criar_material(subgrupo)
+
+        client = APIClient()
+        response = client.get(reverse("material-detail", args=[material.id]))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -215,6 +215,22 @@ class TestRequisicaoAPI:
         assert response.status_code == 409
         assert response.data["error"]["code"] == "domain_conflict"
 
+    def test_criacao_com_beneficiario_inexistente_retorna_not_found(self):
+        setor = self._criar_setor("Cadastro", "900071")
+        usuario = self._criar_usuario("100081", "Solicitante Cadastro", setor=setor)
+        material = self._criar_material_com_estoque("001.001.051")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("requisicao-list"),
+            self._payload_requisicao(beneficiario_id=999999, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
     def test_submit_gera_numero_publico_e_entrada_na_fila(self):
         setor = self._criar_setor("Planejamento", "90008")
         usuario = self._criar_usuario("10009", "Solicitante Planejamento", setor=setor)

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -1,27 +1,54 @@
 """Smoke tests for DRF/OpenAPI configuration."""
 
+import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
 
+from apps.users.models import Setor, User
 
+
+@pytest.mark.django_db
 class TestOpenAPISchema:
     """Test OpenAPI schema generation and accessibility."""
 
-    def test_schema_endpoint_is_accessible(self):
-        """Verify /api/v1/schema/ endpoint is accessible."""
+    @staticmethod
+    def _criar_staff():
+        usuario = User.objects.create(
+            matricula_funcional="990001",
+            nome_completo="Staff Schema",
+            is_active=True,
+            is_staff=True,
+        )
+        setor = Setor.objects.create(nome="Tecnologia", chefe_responsavel=usuario)
+        usuario.setor = setor
+        usuario.save()
+        return usuario
+
+    def test_schema_endpoint_requires_staff(self):
+        """Verify /api/v1/schema/ requires staff outside DEBUG override."""
         client = APIClient()
+        response = client.get(reverse("schema"))
+        assert response.status_code == 403
+
+    def test_schema_endpoint_staff_can_access(self):
+        """Verify staff users can access /api/v1/schema/."""
+        usuario = self._criar_staff()
+        client = APIClient()
+        client.force_authenticate(user=usuario)
         response = client.get(reverse("schema"))
         assert response.status_code == 200
 
-    def test_swagger_ui_is_accessible(self):
-        """Verify Swagger UI endpoint is accessible."""
+    def test_swagger_ui_requires_staff(self):
+        """Verify Swagger UI endpoint requires staff outside DEBUG override."""
         client = APIClient()
         response = client.get(reverse("swagger-ui"))
-        assert response.status_code == 200
+        assert response.status_code == 403
 
-    def test_swagger_ui_returns_html(self):
-        """Verify Swagger UI returns HTML content."""
+    def test_swagger_ui_returns_html_for_staff(self):
+        """Verify Swagger UI returns HTML content for staff users."""
+        usuario = self._criar_staff()
         client = APIClient()
+        client.force_authenticate(user=usuario)
         response = client.get(reverse("swagger-ui"))
         assert response.status_code == 200
         assert b"<!DOCTYPE html>" in response.content or b"<!DOCTYPE" in response.content
@@ -54,11 +81,14 @@ class TestOpenAPISchema:
 
     def test_schema_contem_rotas_de_requisicoes(self):
         """Verify requisitions routes are exposed in OpenAPI."""
+        usuario = self._criar_staff()
         client = APIClient()
+        client.force_authenticate(user=usuario)
         response = client.get(reverse("schema"))
 
         assert response.status_code == 200
         content = response.content.decode()
+        assert "/api/v1/materials/{id}/" in content
         assert "/api/v1/requisitions/" in content
         assert "/api/v1/requisitions/{id}/submit/" in content
         assert "/api/v1/requisitions/{id}/return-to-draft/" in content
@@ -69,6 +99,7 @@ class TestOpenAPISchema:
         assert "/api/v1/requisitions/{id}/fulfill/" in content
         assert "/api/v1/requisitions/pending-approvals/" in content
         assert "/api/v1/requisitions/pending-fulfillments/" in content
+        assert "materials_retrieve" in content
         assert "RequisicaoItemFulfillInput" in content
         assert "quantidade_entregue" in content
         assert "justificativa_atendimento_parcial" in content

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework.test import APIClient
 
@@ -27,6 +28,19 @@ class TestOpenAPISchema:
         return usuario
 
     @staticmethod
+    def _criar_usuario_nao_staff():
+        usuario = User.objects.create(
+            matricula_funcional="990002",
+            nome_completo="Usuario Schema",
+            is_active=True,
+            is_staff=False,
+        )
+        setor = Setor.objects.create(nome="Operacao", chefe_responsavel=usuario)
+        usuario.setor = setor
+        usuario.save()
+        return usuario
+
+    @staticmethod
     def _schema_json(response):
         return json.loads(response.content.decode())
 
@@ -38,10 +52,20 @@ class TestOpenAPISchema:
         assert response.status_code == 200
         return self._schema_json(response)
 
+    @override_settings(DEBUG=False)
     def test_schema_endpoint_requires_staff(self):
         """Verify /api/v1/schema/ requires staff outside DEBUG override."""
         client = APIClient()
         response = client.get(reverse("schema"))
+        assert response.status_code == 403
+
+    @override_settings(DEBUG=False)
+    def test_schema_endpoint_non_staff_is_denied(self):
+        """Verify authenticated non-staff users cannot access /api/v1/schema/."""
+        usuario = self._criar_usuario_nao_staff()
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("schema"), HTTP_ACCEPT="application/vnd.oai.openapi+json")
         assert response.status_code == 403
 
     def test_schema_endpoint_staff_can_access(self):
@@ -52,9 +76,19 @@ class TestOpenAPISchema:
         response = client.get(reverse("schema"), HTTP_ACCEPT="application/vnd.oai.openapi+json")
         assert response.status_code == 200
 
+    @override_settings(DEBUG=False)
     def test_swagger_ui_requires_staff(self):
         """Verify Swagger UI endpoint requires staff outside DEBUG override."""
         client = APIClient()
+        response = client.get(reverse("swagger-ui"))
+        assert response.status_code == 403
+
+    @override_settings(DEBUG=False)
+    def test_swagger_ui_non_staff_is_denied(self):
+        """Verify authenticated non-staff users cannot access Swagger UI."""
+        usuario = self._criar_usuario_nao_staff()
+        client = APIClient()
+        client.force_authenticate(user=usuario)
         response = client.get(reverse("swagger-ui"))
         assert response.status_code == 403
 

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -1,5 +1,7 @@
 """Smoke tests for DRF/OpenAPI configuration."""
 
+import json
+
 import pytest
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -24,6 +26,18 @@ class TestOpenAPISchema:
         usuario.save()
         return usuario
 
+    @staticmethod
+    def _schema_json(response):
+        return json.loads(response.content.decode())
+
+    def _get_schema(self):
+        usuario = self._criar_staff()
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("schema"), HTTP_ACCEPT="application/vnd.oai.openapi+json")
+        assert response.status_code == 200
+        return self._schema_json(response)
+
     def test_schema_endpoint_requires_staff(self):
         """Verify /api/v1/schema/ requires staff outside DEBUG override."""
         client = APIClient()
@@ -35,7 +49,7 @@ class TestOpenAPISchema:
         usuario = self._criar_staff()
         client = APIClient()
         client.force_authenticate(user=usuario)
-        response = client.get(reverse("schema"))
+        response = client.get(reverse("schema"), HTTP_ACCEPT="application/vnd.oai.openapi+json")
         assert response.status_code == 200
 
     def test_swagger_ui_requires_staff(self):
@@ -81,25 +95,135 @@ class TestOpenAPISchema:
 
     def test_schema_contem_rotas_de_requisicoes(self):
         """Verify requisitions routes are exposed in OpenAPI."""
-        usuario = self._criar_staff()
-        client = APIClient()
-        client.force_authenticate(user=usuario)
-        response = client.get(reverse("schema"))
+        schema = self._get_schema()
+        paths = schema["paths"]
 
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "/api/v1/materials/{id}/" in content
-        assert "/api/v1/requisitions/" in content
-        assert "/api/v1/requisitions/{id}/submit/" in content
-        assert "/api/v1/requisitions/{id}/return-to-draft/" in content
-        assert "/api/v1/requisitions/{id}/discard/" in content
-        assert "/api/v1/requisitions/{id}/cancel/" in content
-        assert "/api/v1/requisitions/{id}/authorize/" in content
-        assert "/api/v1/requisitions/{id}/refuse/" in content
-        assert "/api/v1/requisitions/{id}/fulfill/" in content
-        assert "/api/v1/requisitions/pending-approvals/" in content
-        assert "/api/v1/requisitions/pending-fulfillments/" in content
-        assert "materials_retrieve" in content
-        assert "RequisicaoItemFulfillInput" in content
-        assert "quantidade_entregue" in content
-        assert "justificativa_atendimento_parcial" in content
+        assert "/api/v1/materials/{id}/" in paths
+        assert "/api/v1/requisitions/" in paths
+        assert "/api/v1/requisitions/{id}/submit/" in paths
+        assert "/api/v1/requisitions/{id}/return-to-draft/" in paths
+        assert "/api/v1/requisitions/{id}/discard/" in paths
+        assert "/api/v1/requisitions/{id}/cancel/" in paths
+        assert "/api/v1/requisitions/{id}/authorize/" in paths
+        assert "/api/v1/requisitions/{id}/refuse/" in paths
+        assert "/api/v1/requisitions/{id}/fulfill/" in paths
+        assert "/api/v1/requisitions/pending-approvals/" in paths
+        assert "/api/v1/requisitions/pending-fulfillments/" in paths
+        assert paths["/api/v1/materials/{id}/"]["get"]["operationId"] == "materials_retrieve"
+
+        components = schema["components"]["schemas"]
+        assert "RequisicaoItemFulfillInput" in components
+        item_schema = components["RequisicaoItemFulfillInput"]["properties"]
+        assert "quantidade_entregue" in item_schema
+        assert "justificativa_atendimento_parcial" in item_schema
+
+    def test_error_response_schema_declara_trace_id(self):
+        """Verify the standard error envelope includes trace_id in OpenAPI."""
+        schema = self._get_schema()
+        error_detail = schema["components"]["schemas"]["ErrorDetail"]
+
+        assert "trace_id" in error_detail["properties"]
+        assert error_detail["properties"]["trace_id"]["type"] == "string"
+        assert "trace_id" not in error_detail.get("required", [])
+
+    def test_requisicao_actions_declaram_requests_and_responses_esperados(self):
+        """Verify requisition actions expose explicit schema contracts."""
+        schema = self._get_schema()
+        paths = schema["paths"]
+
+        expected_operations = {
+            ("/api/v1/requisitions/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoCreateInput",
+                "success_codes": {"201"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/submit/", "post"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/return-to-draft/", "post"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/discard/", "delete"): {
+                "request_body": False,
+                "success_codes": {"204"},
+                "success_ref": None,
+                "error_codes": {"403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/cancel/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoCancelInput",
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/authorize/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoAuthorizeInput",
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/refuse/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoRefuseInput",
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/fulfill/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoFulfillInput",
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/pending-approvals/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoPendingApprovalPaginated",
+                "error_codes": {"403"},
+            },
+            ("/api/v1/requisitions/pending-fulfillments/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/RequisicaoPendingFulfillmentPaginated",
+                "error_codes": {"403"},
+            },
+        }
+
+        error_ref = "#/components/schemas/ErrorResponse"
+
+        for (path, method), expectation in expected_operations.items():
+            operation = paths[path][method]
+            responses = operation["responses"]
+
+            if expectation["request_body"]:
+                assert "requestBody" in operation
+                assert (
+                    operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+                    == expectation["request_ref"]
+                )
+            else:
+                assert "requestBody" not in operation
+
+            for code in expectation["success_codes"]:
+                assert code in responses
+                if expectation["success_ref"] is None:
+                    assert "content" not in responses[code]
+                else:
+                    assert (
+                        responses[code]["content"]["application/json"]["schema"]["$ref"]
+                        == expectation["success_ref"]
+                    )
+
+            for code in expectation["error_codes"]:
+                assert code in responses
+                assert responses[code]["content"]["application/json"]["schema"]["$ref"] == error_ref


### PR DESCRIPTION
# Contexto

## O que este PR faz
- documenta explicitamente o endpoint `GET /api/v1/materials/{id}/` no OpenAPI
- corrige o `api_exception_handler` para envelopar tambem `Http404` e outros erros tratados pelo DRF
- restringe `/api/v1/schema/` e `/api/v1/docs/` para staff fora de `DEBUG`, preservando `AllowAny` apenas no ambiente de desenvolvimento
- amplia a cobertura de testes para detalhe de materiais e acesso ao schema/swagger

## Por que esta mudança é necessária
O relatorio de auditoria apontou uma lacuna real no contrato de `materials.retrieve`, uma exposicao indevida das rotas de documentacao fora de desenvolvimento e um desvio de runtime no envelope de erro para `404` tratados pelo DRF.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [ ] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [x] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Restringir schema/swagger para staff pode quebrar algum fluxo local que estivesse assumindo acesso irrestrito fora de `DEBUG`.

## Impactos adicionais (somente se houver)
Preencha de forma curta e objetiva apenas o que se aplicar:

- permissões / perfil / setor: schema e swagger agora exigem staff fora de `DEBUG`
- configuração / CI / dependências: `SPECTACULAR_SETTINGS["SERVE_PERMISSIONS"]` passa a exigir `IsAdminUser`

---

# Testes e validação

## Cenários validados
1. `rtk uv run pytest tests/materials/test_api_materials.py tests/test_api_schema.py -q`
2. `rtk uv run pytest tests/requisitions/test_api.py -q`
3. verificação do schema com a rota `/api/v1/materials/{id}/` e `operation_id` `materials_retrieve`

## Como validar manualmente
1. Em `DEBUG=True`, acessar `/api/v1/schema/` e `/api/v1/docs/` sem autenticação.
2. Em ambiente sem override de debug, confirmar `403` para usuário anônimo e `200` para staff nas duas rotas.
3. Chamar `GET /api/v1/materials/{id}/` autenticado, sem autenticação e com id inexistente, verificando contrato e envelope de erro.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->