### PR TITLE
[codex] add SPA session auth endpoints

### DIFF
--- a/apps/users/authentication.py
+++ b/apps/users/authentication.py
@@ -1,0 +1,6 @@
+from rest_framework.authentication import SessionAuthentication
+
+
+class SessionAuthentication401(SessionAuthentication):
+    def authenticate_header(self, request):
+        return "Session"

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -21,4 +21,4 @@ class CsrfTokenOutputSerializer(serializers.Serializer):
 
 class AuthLoginInputSerializer(serializers.Serializer):
     matricula_funcional = serializers.CharField()
-    password = serializers.CharField()
+    password = serializers.CharField(write_only=True)

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+
+
+class AuthSetorOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    nome = serializers.CharField(read_only=True)
+
+
+class AuthSessionOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    matricula_funcional = serializers.CharField(read_only=True)
+    nome_completo = serializers.CharField(read_only=True)
+    papel = serializers.CharField(read_only=True)
+    setor = AuthSetorOutputSerializer(read_only=True, allow_null=True)
+    is_authenticated = serializers.BooleanField(read_only=True)
+
+
+class CsrfTokenOutputSerializer(serializers.Serializer):
+    csrf_token = serializers.CharField(read_only=True)
+
+
+class AuthLoginInputSerializer(serializers.Serializer):
+    matricula_funcional = serializers.CharField()
+    password = serializers.CharField()

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from apps.users.views import AuthCsrfView, AuthLoginView, AuthLogoutView, AuthMeView
+
+urlpatterns = [
+    path("auth/csrf/", AuthCsrfView.as_view(), name="auth-csrf"),
+    path("auth/login/", AuthLoginView.as_view(), name="auth-login"),
+    path("auth/logout/", AuthLogoutView.as_view(), name="auth-logout"),
+    path("auth/me/", AuthMeView.as_view(), name="auth-me"),
+]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,0 +1,121 @@
+from django.contrib.auth import authenticate, login, logout
+from django.middleware.csrf import get_token
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import ensure_csrf_cookie
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.api.serializers import ErrorResponseSerializer
+from apps.users.authentication import SessionAuthentication401
+from apps.users.serializers import (
+    AuthLoginInputSerializer,
+    AuthSessionOutputSerializer,
+    CsrfTokenOutputSerializer,
+)
+
+
+def _session_payload(user):
+    return {
+        "id": user.id,
+        "matricula_funcional": user.matricula_funcional,
+        "nome_completo": user.nome_completo,
+        "papel": user.papel,
+        "setor": user.setor,
+        "is_authenticated": user.is_authenticated,
+    }
+
+
+def _enforce_csrf(request):
+    SessionAuthentication().enforce_csrf(request)
+
+
+@method_decorator(ensure_csrf_cookie, name="dispatch")
+class AuthCsrfView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        operation_id="auth_csrf",
+        tags=["auth"],
+        responses={200: CsrfTokenOutputSerializer()},
+    )
+    def get(self, request):
+        return Response({"csrf_token": get_token(request)})
+
+
+class AuthLoginView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        operation_id="auth_login",
+        tags=["auth"],
+        request=AuthLoginInputSerializer,
+        responses={
+            200: AuthSessionOutputSerializer(),
+            401: ErrorResponseSerializer(),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    def post(self, request):
+        _enforce_csrf(request)
+        serializer = AuthLoginInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = authenticate(
+            request=request,
+            username=serializer.validated_data["matricula_funcional"],
+            password=serializer.validated_data["password"],
+        )
+        if user is None:
+            return Response(
+                {
+                    "error": {
+                        "code": "authentication_failed",
+                        "message": "Matrícula funcional ou senha inválidas.",
+                        "details": None,
+                        "trace_id": request.META.get("HTTP_X_TRACE_ID"),
+                    }
+                },
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        login(request, user)
+        return Response(AuthSessionOutputSerializer(_session_payload(user)).data)
+
+
+class AuthLogoutView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        operation_id="auth_logout",
+        tags=["auth"],
+        request=None,
+        responses={
+            204: None,
+            403: ErrorResponseSerializer(),
+        },
+    )
+    def post(self, request):
+        _enforce_csrf(request)
+        logout(request)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class AuthMeView(APIView):
+    authentication_classes = [SessionAuthentication401]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        operation_id="auth_me",
+        tags=["auth"],
+        responses={
+            200: AuthSessionOutputSerializer(),
+            401: ErrorResponseSerializer(),
+        },
+    )
+    def get(self, request):
+        serializer = AuthSessionOutputSerializer(_session_payload(request.user))
+        return Response(serializer.data)

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ if settings.DEBUG:
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("api/v1/", include("apps.users.urls")),
     path("api/v1/", include("apps.materials.urls")),
     path("api/v1/", include("apps.requisitions.urls")),
     path(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "django-cors-headers>=4.9,<5",
     "django-filter>=25,<26",
     "djangorestframework>=3.17,<4",
+    "djangorestframework-stubs>=3.16.9",
     "drf-spectacular>=0.29,<1",
     "psycopg[binary]>=3.3,<4",
     "python-dotenv>=1.2,<2",

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -132,6 +132,10 @@ class TestOpenAPISchema:
         schema = self._get_schema()
         paths = schema["paths"]
 
+        assert "/api/v1/auth/csrf/" in paths
+        assert "/api/v1/auth/login/" in paths
+        assert "/api/v1/auth/logout/" in paths
+        assert "/api/v1/auth/me/" in paths
         assert "/api/v1/materials/{id}/" in paths
         assert "/api/v1/requisitions/" in paths
         assert "/api/v1/requisitions/{id}/submit/" in paths
@@ -150,6 +154,68 @@ class TestOpenAPISchema:
         item_schema = components["RequisicaoItemFulfillInput"]["properties"]
         assert "quantidade_entregue" in item_schema
         assert "justificativa_atendimento_parcial" in item_schema
+
+    def test_auth_endpoints_declaram_requests_responses_e_status_esperados(self):
+        """Verify auth endpoints expose explicit schema contracts."""
+        schema = self._get_schema()
+        paths = schema["paths"]
+
+        expected_operations = {
+            ("/api/v1/auth/csrf/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/CsrfTokenOutput",
+                "error_codes": set(),
+            },
+            ("/api/v1/auth/login/", "post"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/AuthLoginInput",
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/AuthSessionOutput",
+                "error_codes": {"401", "403"},
+            },
+            ("/api/v1/auth/logout/", "post"): {
+                "request_body": False,
+                "success_codes": {"204"},
+                "success_ref": None,
+                "error_codes": {"403"},
+            },
+            ("/api/v1/auth/me/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/AuthSessionOutput",
+                "error_codes": {"401"},
+            },
+        }
+
+        error_ref = "#/components/schemas/ErrorResponse"
+
+        for (path, method), expectation in expected_operations.items():
+            operation = paths[path][method]
+            responses = operation["responses"]
+
+            if expectation["request_body"]:
+                assert "requestBody" in operation
+                assert (
+                    operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+                    == expectation["request_ref"]
+                )
+            else:
+                assert "requestBody" not in operation
+
+            for code in expectation["success_codes"]:
+                assert code in responses
+                if expectation["success_ref"] is None:
+                    assert "content" not in responses[code]
+                else:
+                    assert (
+                        responses[code]["content"]["application/json"]["schema"]["$ref"]
+                        == expectation["success_ref"]
+                    )
+
+            for code in expectation["error_codes"]:
+                assert code in responses
+                assert responses[code]["content"]["application/json"]["schema"]["$ref"] == error_ref
 
     def test_error_response_schema_declara_trace_id(self):
         """Verify the standard error envelope includes trace_id in OpenAPI."""

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -180,3 +180,16 @@ class TestAuthAPI:
         response = client.post(reverse("auth-logout"), format="json")
 
         assert response.status_code == 403
+
+    def test_login_sem_campos_obrigatorios_retorna_400(self):
+        client, csrf_token = self._csrf_client()
+
+        response = client.post(
+            reverse("auth-login"),
+            {},  # payload vazio
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert response.status_code == 400
+        assert response.data["error"]["code"] == "validation_error"

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -1,0 +1,182 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.users.models import PapelChoices, Setor, User
+
+
+@pytest.mark.django_db
+class TestAuthAPI:
+    @staticmethod
+    def _criar_usuario_com_setor(*, matricula: str = "10001") -> User:
+        user = User.objects.create_user(
+            matricula_funcional=matricula,
+            password="senha-segura-123",
+            nome_completo="Usuario Auth",
+            papel=PapelChoices.CHEFE_SETOR,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome=f"Setor {matricula}", chefe_responsavel=user)
+        user.setor = setor
+        user.save(update_fields=["setor"])
+        return user
+
+    @staticmethod
+    def _csrf_client():
+        client = APIClient(enforce_csrf_checks=True)
+        csrf_response = client.get(reverse("auth-csrf"))
+        return client, csrf_response.data["csrf_token"]
+
+    def test_me_sem_sessao_valida_retorna_401(self):
+        client = APIClient()
+
+        response = client.get(reverse("auth-me"))
+
+        assert response.status_code == 401
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_me_com_sessao_valida_retorna_payload_canonico(self):
+        user = self._criar_usuario_com_setor()
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(reverse("auth-me"))
+
+        assert response.status_code == 200
+        assert response.data == {
+            "id": user.id,
+            "matricula_funcional": "10001",
+            "nome_completo": "Usuario Auth",
+            "papel": PapelChoices.CHEFE_SETOR,
+            "setor": {
+                "id": user.setor_id,
+                "nome": "Setor 10001",
+            },
+            "is_authenticated": True,
+        }
+
+    def test_csrf_retorna_token_e_cookie(self):
+        client = APIClient()
+
+        response = client.get(reverse("auth-csrf"))
+
+        assert response.status_code == 200
+        assert response.data["csrf_token"]
+        assert "csrftoken" in response.cookies
+
+    def test_login_com_matricula_e_senha_validas_cria_sessao_e_retorna_payload(self):
+        user = self._criar_usuario_com_setor()
+        client, csrf_token = self._csrf_client()
+
+        response = client.post(
+            reverse("auth-login"),
+            {
+                "matricula_funcional": "10001",
+                "password": "senha-segura-123",
+            },
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert response.status_code == 200
+        assert response.data["id"] == user.id
+        assert response.data["matricula_funcional"] == "10001"
+        assert response.data["is_authenticated"] is True
+
+        me_response = client.get(reverse("auth-me"))
+        assert me_response.status_code == 200
+        assert me_response.data["id"] == user.id
+
+    def test_login_com_credenciais_invalidas_retorna_401(self):
+        self._criar_usuario_com_setor()
+        client, csrf_token = self._csrf_client()
+
+        response = client.post(
+            reverse("auth-login"),
+            {
+                "matricula_funcional": "10001",
+                "password": "senha-invalida",
+            },
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert response.status_code == 401
+        assert response.data["error"]["code"] == "authentication_failed"
+
+    def test_login_com_usuario_inativo_retorna_401(self):
+        user = self._criar_usuario_com_setor()
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+        client, csrf_token = self._csrf_client()
+
+        response = client.post(
+            reverse("auth-login"),
+            {
+                "matricula_funcional": "10001",
+                "password": "senha-segura-123",
+            },
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert response.status_code == 401
+        assert response.data["error"]["code"] == "authentication_failed"
+
+    def test_login_sem_csrf_valido_retorna_403(self):
+        self._criar_usuario_com_setor()
+        client = APIClient(enforce_csrf_checks=True)
+
+        response = client.post(
+            reverse("auth-login"),
+            {
+                "matricula_funcional": "10001",
+                "password": "senha-segura-123",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 403
+
+    def test_logout_com_sessao_valida_retorna_204_e_invalida_sessao(self):
+        self._criar_usuario_com_setor()
+        client, csrf_token = self._csrf_client()
+        login_response = client.post(
+            reverse("auth-login"),
+            {
+                "matricula_funcional": "10001",
+                "password": "senha-segura-123",
+            },
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+        assert login_response.status_code == 200
+        csrf_token = client.cookies["csrftoken"].value
+
+        logout_response = client.post(
+            reverse("auth-logout"),
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert logout_response.status_code == 204
+        me_response = client.get(reverse("auth-me"))
+        assert me_response.status_code == 401
+
+    def test_logout_sem_sessao_valida_retorna_204(self):
+        client, csrf_token = self._csrf_client()
+
+        response = client.post(
+            reverse("auth-logout"),
+            format="json",
+            HTTP_X_CSRFTOKEN=csrf_token,
+        )
+
+        assert response.status_code == 204
+
+    def test_logout_sem_csrf_valido_retorna_403(self):
+        client = APIClient(enforce_csrf_checks=True)
+
+        response = client.post(reverse("auth-logout"), format="json")
+
+        assert response.status_code == 403

--- a/uv.lock
+++ b/uv.lock
@@ -139,6 +139,34 @@ wheels = [
 ]
 
 [[package]]
+name = "django-stubs"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-stubs-ext" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/0c/8d0d875af79bf774c1c3997c84aa118dba3a77be12086b9c14e130e8ec72/django_stubs-6.0.3.tar.gz", hash = "sha256:ee895f403c373608eeb50822f0733f9d9ec5ab12731d4ab58956053bb95fdd9e", size = 278214, upload-time = "2026-04-18T15:11:22.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/a3/6751b7684d20fc4f228bdd3dd8341d382ab3faaf65d3d050c0d59ab0a1b0/django_stubs-6.0.3-py3-none-any.whl", hash = "sha256:5fee22bcbbad59a78c727a820b6f4e68ff442ca76a922b7002e57c25dd7cb390", size = 541570, upload-time = "2026-04-18T15:11:20.711Z" },
+]
+
+[[package]]
+name = "django-stubs-ext"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/e6/5dcdaa785ec3eed5fc196c7e68fb7ad9d9fe6d5acccea4690e65f2546417/django_stubs_ext-6.0.3.tar.gz", hash = "sha256:3307d42132bc295d5744de6276bc5fdf6896efc70f891e21c0ae8bdf529d2762", size = 6663, upload-time = "2026-04-18T15:10:53.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/fa/0a3a05c29d6295dbd52fa3cb4047a95de11ba4f2696072d6f3f2c1e6f370/django_stubs_ext-6.0.3-py3-none-any.whl", hash = "sha256:9e4105955419ae310d7da9cfd808e039d4dae3092c628f021057bb4f2c237f8f", size = 10354, upload-time = "2026-04-18T15:10:52.395Z" },
+]
+
+[[package]]
 name = "djangorestframework"
 version = "3.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -148,6 +176,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/d7/c016e69fac19ff8afdc89db9d31d9ae43ae031e4d1993b20aca179b8301a/djangorestframework-3.17.1.tar.gz", hash = "sha256:a6def5f447fe78ff853bff1d47a3c59bf38f5434b031780b351b0c73a62db1a5", size = 905742, upload-time = "2026-03-24T16:58:33.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/e1/2c516bdc83652b1a60c6119366ac2c0607b479ed05cd6093f916ca8928f8/djangorestframework-3.17.1-py3-none-any.whl", hash = "sha256:c3c74dd3e83a5a3efc37b3c18d92bd6f86a6791c7b7d4dff62bb068500e76457", size = 898844, upload-time = "2026-03-24T16:58:31.845Z" },
+]
+
+[[package]]
+name = "djangorestframework-stubs"
+version = "3.16.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django-stubs" },
+    { name = "types-pyyaml" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/84/fa0e31f763ee35152a418c2a456efdd8047a9da0f5909110147b70382191/djangorestframework_stubs-3.16.9.tar.gz", hash = "sha256:b1abb97490c90c85eabcd09b8ecbadae1b9360f21ad3021abf830227c0129697", size = 32798, upload-time = "2026-03-31T22:40:23.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/be/e53e3b89eaa30c21e036ae4d2ee88a92ef8cb43678400901748ddad870c5/djangorestframework_stubs-3.16.9-py3-none-any.whl", hash = "sha256:27b3e245d5f9c22ff6988d9e54388249f98f88608cc2b365b71e9f39dd096958", size = 57239, upload-time = "2026-03-31T22:40:22.314Z" },
 ]
 
 [[package]]
@@ -165,53 +207,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/0e/a4f50d83e76cbe797eda88fc0083c8ca970cfa362b5586359ef06ec6f70a/drf_spectacular-0.29.0.tar.gz", hash = "sha256:0a069339ea390ce7f14a75e8b5af4a0860a46e833fd4af027411a3e94fc1a0cc", size = 241722, upload-time = "2025-11-02T03:40:26.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d9/502c56fc3ca960075d00956283f1c44e8cafe433dada03f9ed2821f3073b/drf_spectacular-0.29.0-py3-none-any.whl", hash = "sha256:d1ee7c9535d89848affb4427347f7c4a22c5d22530b8842ef133d7b72e19b41a", size = 105433, upload-time = "2025-11-02T03:40:24.823Z" },
-]
-
-[[package]]
-name = "wms-saep-v2"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "django" },
-    { name = "django-allauth" },
-    { name = "django-cors-headers" },
-    { name = "django-filter" },
-    { name = "djangorestframework" },
-    { name = "drf-spectacular" },
-    { name = "psycopg", extra = ["binary"] },
-    { name = "python-dotenv" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "coverage" },
-    { name = "factory-boy" },
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "pytest-django" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "django", specifier = ">=6.0,<7" },
-    { name = "django-allauth", specifier = ">=65,<66" },
-    { name = "django-cors-headers", specifier = ">=4.9,<5" },
-    { name = "django-filter", specifier = ">=25,<26" },
-    { name = "djangorestframework", specifier = ">=3.17,<4" },
-    { name = "drf-spectacular", specifier = ">=0.29,<1" },
-    { name = "psycopg", extras = ["binary"], specifier = ">=3.3,<4" },
-    { name = "python-dotenv", specifier = ">=1.2,<2" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "coverage", specifier = ">=7.13,<8" },
-    { name = "factory-boy", specifier = ">=3.3,<4" },
-    { name = "pre-commit", specifier = ">=4.6,<5" },
-    { name = "pytest", specifier = ">=9,<10" },
-    { name = "pytest-django", specifier = ">=4.12,<5" },
-    { name = "ruff", specifier = ">=0.15,<1" },
 ]
 
 [[package]]
@@ -558,6 +553,24 @@ wheels = [
 ]
 
 [[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
 name = "tzdata"
 version = "2026.2"
 source = { registry = "https://pypi.org/simple" }
@@ -588,4 +601,53 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3f/8b/6331f7a7fe70131c301106ec1e7cf23e2501bf7d4ca3636805801ca191bb/virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e", size = 7614069, upload-time = "2026-04-27T17:05:58.927Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/eb/03bfb1299d4c4510329e470f13f9a4ce793df7fcb5a2fd3510f911066f61/virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7", size = 7594690, upload-time = "2026-04-27T17:05:55.468Z" },
+]
+
+[[package]]
+name = "wms-saep-v2"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "django" },
+    { name = "django-allauth" },
+    { name = "django-cors-headers" },
+    { name = "django-filter" },
+    { name = "djangorestframework" },
+    { name = "djangorestframework-stubs" },
+    { name = "drf-spectacular" },
+    { name = "psycopg", extra = ["binary"] },
+    { name = "python-dotenv" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "coverage" },
+    { name = "factory-boy" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "pytest-django" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "django", specifier = ">=6.0,<7" },
+    { name = "django-allauth", specifier = ">=65,<66" },
+    { name = "django-cors-headers", specifier = ">=4.9,<5" },
+    { name = "django-filter", specifier = ">=25,<26" },
+    { name = "djangorestframework", specifier = ">=3.17,<4" },
+    { name = "djangorestframework-stubs", specifier = ">=3.16.9" },
+    { name = "drf-spectacular", specifier = ">=0.29,<1" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.3,<4" },
+    { name = "python-dotenv", specifier = ">=1.2,<2" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "coverage", specifier = ">=7.13,<8" },
+    { name = "factory-boy", specifier = ">=3.3,<4" },
+    { name = "pre-commit", specifier = ">=4.6,<5" },
+    { name = "pytest", specifier = ">=9,<10" },
+    { name = "pytest-django", specifier = ">=4.12,<5" },
+    { name = "ruff", specifier = ">=0.15,<1" },
 ]


### PR DESCRIPTION
# Contexto

## O que este PR faz
- adiciona os endpoints `GET /api/v1/auth/csrf/`, `POST /api/v1/auth/login/`, `POST /api/v1/auth/logout/` e `GET /api/v1/auth/me/`
- expõe payload canônico de sessão para a SPA com `id`, `matricula_funcional`, `nome_completo`, `papel`, `setor` e `is_authenticated`
- aplica validação explícita de CSRF em `login/logout` e mantém `logout` idempotente
- adiciona testes de API e asserts de OpenAPI para o slice de autenticação/sessão

## Por que esta mudança é necessária
A issue #31 abre o bloco 0 de APIs habilitadoras da SPA do piloto. Sem essa superfície de sessão Django com CSRF, a SPA não consegue autenticar por matrícula, bootstrapar a sessão atual nem encerrar a sessão de forma explícita.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Configurar incorretamente o fluxo de sessão/CSRF e bloquear login/logout da SPA ou devolver status HTTP divergentes do contrato esperado.

## Impactos adicionais (somente se houver)
Preencha de forma curta e objetiva apenas o que se aplicar:

- permissões / perfil / setor: `auth/me` retorna o papel operacional atual e `setor` mínimo (`id`, `nome`) para guards e menu da SPA.
- dados / migration / constraints:
- transação / concorrência / idempotência: `logout` permanece idempotente e retorna `204` mesmo sem sessão válida.
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `auth/me` retorna `401` sem sessão e `200` com payload canônico quando autenticado.
2. `auth/csrf` emite cookie + token, `auth/login` autentica por matrícula/senha e aplica CSRF.
3. `auth/logout` invalida sessão autenticada, é idempotente sem sessão e os 4 endpoints entram no OpenAPI com request/response/status explícitos.

## Como validar manualmente
1. `GET /api/v1/auth/csrf/` e capture o cookie/token retornado.
2. Faça `POST /api/v1/auth/login/` com `matricula_funcional`, `password` e `X-CSRFToken`; confirme `200` e payload de sessão.
3. Faça `GET /api/v1/auth/me/`; confirme `200` com o mesmo usuário autenticado.
4. Faça `POST /api/v1/auth/logout/` com `X-CSRFToken`; confirme `204` e depois `GET /api/v1/auth/me/` retornando `401`.

## Payloads / exemplos de uso
```json
{
  "matricula_funcional": "10001",
  "password": "senha-segura-123"
}
```

Checks executados:
- `rtk ruff check apps/users/serializers.py apps/users/authentication.py apps/users/urls.py apps/users/views.py tests/users/test_auth_api.py tests/test_api_schema.py`
- `rtk proxy pytest tests/users/test_auth_api.py tests/test_api_schema.py::TestOpenAPISchema::test_schema_contem_rotas_de_requisicoes tests/test_api_schema.py::TestOpenAPISchema::test_auth_endpoints_declaram_requests_responses_e_status_esperados -q`

Observação: `tests/test_api_schema.py` ainda tem 3 falhas antigas de Swagger UI fora deste slice, ligadas ao render/template do stack atual.

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumo do PR #45 – Endpoints de Autenticação de Sessão para SPA

### Objetivo
Habilitar autenticação por matrícula/senha, bootstrap de sessão Django e logout explícito para a SPA do piloto via endpoints REST com CSRF obrigatório.

### Apps Django Impactados
- **apps.users**: novo arquivo `views.py` (4 endpoints), `serializers.py` (4 serializers), `authentication.py` (SessionAuthentication401), `urls.py` (roteamento)
- **config.urls**: include("apps.users.urls") sob api/v1/

### Riscos Funcionais Identificados
- **Potencial N+1 Query crítico**: `_session_payload(user)` acessa `user.setor` (objeto relacional) sem `select_related`. AuthMeView e AuthLoginView retornam setor aninhado, causando query extra se setor não estiver pré-carregado. MatriculaBackend.authenticate() também não otimiza a carga de setor.
  - **Validação**: Executar teste com `django-debug-toolbar` ou `django-silk` em `/api/v1/auth/login/` e `/api/v1/auth/me/` verificando número de queries.
- **Erro CSRF (403) não segue contrato**: enforce_csrf dispara PermissionDenied nativa que retorna 403 sem seguir ErrorResponseSerializer. Diverge do contrato padrão da API.
  - **Validação**: POST `/api/v1/auth/login/` sem CSRF token e comparar resposta com erro de autenticação (401).

### Impactos em Autenticação, Autorização e Escopo
- **Autenticação**: SessionAuthentication401 apenas normaliza header → "Session"; fluxo delegado ao Django nativo (matricula_funcional + password via MatriculaBackend).
- **Autorização por papel**: Nenhuma. Endpoints AllowAny (csrf, login) ou apenas IsAuthenticated (me). Sem validação de papel operacional ou visibilidade contextual por setor.
- **Escopo por setor**: setor retornado na sessão (id + nome) mas sem políticas de filtragem/proteção. Usuário pode acessar me/ sem restrição de setor.
- **Regra USR-03 (inativo)**: Aplicada via MatriculaBackend.user_can_authenticate(user) → login rejeita is_active=False (401).

### Contratos DRF, Serializers, OpenAPI
- **Serializers**: AuthSessionOutputSerializer (read_only, setor aninhado allow_null=True), CsrfTokenOutputSerializer, AuthLoginInputSerializer (matricula_funcional, password obrigatórios).
- **OpenAPI**: 4 endpoints documentados com operationId, tags, responses esperadas (200/401/204/403). **Divergência**: 403 CSRF não é documentado com ErrorResponseSerializer; retorna resposta padrão Django.
- **Paginação/Filtros**: N/A (endpoints de autenticação).
- **Envelope de erro**: Login retorna erro com formato canônico {error: {code, message, details, trace_id}} em 401. **Mas**: 403 CSRF usa resposta Django padrão.

### Integridade, Auditoria e Rastreabilidade
- **Sem logging/auditoria**: Nenhum evento de login/logout registrado. Violação de rastreabilidade operacional em requisições futuras (quem fez login quando).
  - **Validação**: Buscar se existe middleware ou signal que registra auth events (não encontrado).
- **Setor null**: User.setor pode ser null (blank=True, null=True). Serializer permite but retorna {id: null, nome: null} se user.setor é None. Potencial confusão no cliente.

### Transações, Idempotência e Transições de Estado
- **Logout idempotente**: Sem sessão válida retorna 204 (ok). `logout(request)` nativa é idempotente.
- **Login sem @transaction.atomic**: Not critical (nenhum side effect além de criar/atualizar sessão Django).
- **CSRF no logout**: Obrigatório via enforce_csrf; se falhar retorna 403.

### Impacto em Importação SCPI, Dados Oficiais, Saldo de Estoque
N/A (endpoints de autenticação, não operacionais).

### Configuração, CI, Dependências, Lint, Testes, Ambiente
- **Migrations**: Nenhuma (apenas roteamento/serializers). Ambiente efêmero não requer versionamento.
- **Testes**: 12 testes em `tests/users/test_auth_api.py` cobrindo me (401/200), csrf (token+cookie), login (válido/inválido/inativo/sem CSRF), logout (com/sem sessão/CSRF). Sem assertions de query count.
- **Lint/Pre-commit**: Arquivo ruff/pytest passam (conforme PR description).

### Validação Manual Recomendada

1. **N+1 Query (crítico)**:
   ```bash
   # Terminal 1: django-shell com debug
   python manage.py runserver --settings=config.settings.test
   # Terminal 2: curl com trace
   curl -X POST http://localhost:8000/api/v1/auth/login/ \
     -H "Content-Type: application/json" \
     -H "X-CSRFToken: <token-from-csrf-endpoint>" \
     -d '{"matricula_funcional":"10001","password":"senha-segura-123"}'
   # Verificar Django Debug Toolbar: SQL count ≤ 3 (user + session + setor)
   ```

2. **CSRF 403 Error Format**:
   ```bash
   # Sem CSRF token
   curl -X POST http://localhost:8000/api/v1/auth/login/ \
     -H "Content-Type: application/json" \
     -d '{"matricula_funcional":"10001","password":"senha-segura-123"}'
   # Comparar resposta com 401 auth_failed (deve ser ErrorResponseSerializer)
   ```

3. **Setor null handling**:
   ```bash
   # Criar user sem setor
   python manage.py shell
   >>> user = User.objects.create_user(matricula_funcional='10002', password='x', papel='solicitante')
   >>> # Login e chamar auth/me
   # Verificar se resposta é {setor: null} ou {setor: {id: null, nome: null}}
   ```

4. **Audit trail**:
   ```bash
   # Verificar se existem logs de login/logout
   tail -f logs/django.log | grep -i "login\|logout"
   # Verificar se há entrada no admin de autenticação (não existente)
   ```

### Pontos de Prioridade
- **BLOQUEADOR**: Potencial N+1 query em AuthMeView/AuthLoginView via setor lazy-loaded
- **IMPORTANTE**: 403 CSRF não segue contrato ErrorResponseSerializer
- **IMPORTANTE**: Ausência de auditoria de eventos de autenticação (rastreabilidade)
- **MENOR**: Setor null semantics (documentar ou validar no serializador)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->