### PR TITLE
[codex] add beneficiary lookup endpoint

### DIFF
--- a/apps/users/policies.py
+++ b/apps/users/policies.py
@@ -7,7 +7,9 @@ para garantir que a mesma lógica seja aplicada em ambas as camadas
 (invariante PER-08).
 """
 
-from .models import PapelChoices
+from django.db.models import QuerySet
+
+from .models import PapelChoices, User
 
 
 def _user_ativo_nao_superuser(user) -> bool:
@@ -51,6 +53,39 @@ def pode_criar_requisicao_para(criador, beneficiario) -> bool:
         return setor_responsavel.pk == beneficiario.setor_id
 
     return False
+
+
+def queryset_beneficiarios_lookup_para(criador) -> QuerySet[User]:
+    queryset = User.objects.select_related("setor").filter(
+        is_active=True,
+        is_superuser=False,
+        setor__isnull=False,
+        setor__is_active=True,
+    )
+
+    if not _user_ativo_nao_superuser(criador):
+        return queryset.none()
+
+    papel = criador.papel
+
+    if papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+        return queryset
+
+    if papel == PapelChoices.SOLICITANTE:
+        return queryset.filter(pk=criador.pk)
+
+    if papel == PapelChoices.AUXILIAR_SETOR:
+        if criador.setor_id is None:
+            return queryset.none()
+        return queryset.filter(setor_id=criador.setor_id)
+
+    if papel == PapelChoices.CHEFE_SETOR:
+        setor_responsavel = getattr(criador, "setor_responsavel", None)
+        if setor_responsavel is None:
+            return queryset.none()
+        return queryset.filter(setor=setor_responsavel)
+
+    return queryset.none()
 
 
 def pode_autorizar_setor(autorizador, setor) -> bool:

--- a/apps/users/policies.py
+++ b/apps/users/policies.py
@@ -63,8 +63,11 @@ def queryset_beneficiarios_lookup_para(criador) -> QuerySet[User]:
         setor__is_active=True,
     )
 
-    if not _user_ativo_nao_superuser(criador):
+    if not criador.is_active:
         return queryset.none()
+
+    if criador.is_superuser:
+        return queryset
 
     papel = criador.papel
 

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -22,3 +22,14 @@ class CsrfTokenOutputSerializer(serializers.Serializer):
 class AuthLoginInputSerializer(serializers.Serializer):
     matricula_funcional = serializers.CharField()
     password = serializers.CharField(write_only=True)
+
+
+class BeneficiaryLookupQuerySerializer(serializers.Serializer):
+    q = serializers.CharField(min_length=3, trim_whitespace=True)
+
+
+class BeneficiaryLookupOutputSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    matricula_funcional = serializers.CharField(read_only=True)
+    nome_completo = serializers.CharField(read_only=True)
+    setor = AuthSetorOutputSerializer(read_only=True, allow_null=True)

--- a/apps/users/serializers.py
+++ b/apps/users/serializers.py
@@ -32,4 +32,4 @@ class BeneficiaryLookupOutputSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     matricula_funcional = serializers.CharField(read_only=True)
     nome_completo = serializers.CharField(read_only=True)
-    setor = AuthSetorOutputSerializer(read_only=True, allow_null=True)
+    setor = AuthSetorOutputSerializer(read_only=True)

--- a/apps/users/urls.py
+++ b/apps/users/urls.py
@@ -1,10 +1,21 @@
 from django.urls import path
 
-from apps.users.views import AuthCsrfView, AuthLoginView, AuthLogoutView, AuthMeView
+from apps.users.views import (
+    AuthCsrfView,
+    AuthLoginView,
+    AuthLogoutView,
+    AuthMeView,
+    BeneficiaryLookupView,
+)
 
 urlpatterns = [
     path("auth/csrf/", AuthCsrfView.as_view(), name="auth-csrf"),
     path("auth/login/", AuthLoginView.as_view(), name="auth-login"),
     path("auth/logout/", AuthLogoutView.as_view(), name="auth-logout"),
     path("auth/me/", AuthMeView.as_view(), name="auth-me"),
+    path(
+        "users/beneficiary-lookup/",
+        BeneficiaryLookupView.as_view(),
+        name="user-beneficiary-lookup",
+    ),
 ]

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -3,7 +3,7 @@ from django.db.models import Case, IntegerField, Value, When
 from django.middleware.csrf import get_token
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -134,7 +134,14 @@ class BeneficiaryLookupView(APIView):
         tags=["users"],
         parameters=[BeneficiaryLookupQuerySerializer],
         responses={
-            200: BeneficiaryLookupOutputSerializer(many=True),
+            200: OpenApiResponse(
+                response={
+                    "type": "array",
+                    "items": {"$ref": "#/components/schemas/BeneficiaryLookupOutput"},
+                    "maxItems": 10,
+                },
+                description="Lista curta de beneficiários elegíveis, limitada a 10 resultados.",
+            ),
             400: ErrorResponseSerializer(),
             401: ErrorResponseSerializer(),
         },

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import authenticate, login, logout
+from django.db.models import Case, IntegerField, Value, When
 from django.middleware.csrf import get_token
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -11,9 +12,12 @@ from rest_framework.views import APIView
 
 from apps.core.api.serializers import ErrorResponseSerializer
 from apps.users.authentication import SessionAuthentication401
+from apps.users.policies import queryset_beneficiarios_lookup_para
 from apps.users.serializers import (
     AuthLoginInputSerializer,
     AuthSessionOutputSerializer,
+    BeneficiaryLookupOutputSerializer,
+    BeneficiaryLookupQuerySerializer,
     CsrfTokenOutputSerializer,
 )
 
@@ -118,4 +122,40 @@ class AuthMeView(APIView):
     )
     def get(self, request):
         serializer = AuthSessionOutputSerializer(_session_payload(request.user))
+        return Response(serializer.data)
+
+
+class BeneficiaryLookupView(APIView):
+    authentication_classes = [SessionAuthentication401]
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        operation_id="users_beneficiary_lookup",
+        tags=["users"],
+        parameters=[BeneficiaryLookupQuerySerializer],
+        responses={
+            200: BeneficiaryLookupOutputSerializer(many=True),
+            400: ErrorResponseSerializer(),
+            401: ErrorResponseSerializer(),
+        },
+    )
+    def get(self, request):
+        query_serializer = BeneficiaryLookupQuerySerializer(data=request.query_params)
+        query_serializer.is_valid(raise_exception=True)
+
+        query = query_serializer.validated_data["q"]
+        queryset = (
+            queryset_beneficiarios_lookup_para(request.user)
+            .filter(nome_completo__icontains=query)
+            .annotate(
+                nome_match_rank=Case(
+                    When(nome_completo__istartswith=query, then=Value(0)),
+                    default=Value(1),
+                    output_field=IntegerField(),
+                )
+            )
+            .order_by("nome_match_rank", "nome_completo", "matricula_funcional")[:10]
+        )
+
+        serializer = BeneficiaryLookupOutputSerializer(queryset, many=True)
         return Response(serializer.data)

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -136,6 +136,7 @@ class TestOpenAPISchema:
         assert "/api/v1/auth/login/" in paths
         assert "/api/v1/auth/logout/" in paths
         assert "/api/v1/auth/me/" in paths
+        assert "/api/v1/users/beneficiary-lookup/" in paths
         assert "/api/v1/materials/{id}/" in paths
         assert "/api/v1/requisitions/" in paths
         assert "/api/v1/requisitions/{id}/submit/" in paths
@@ -186,6 +187,12 @@ class TestOpenAPISchema:
                 "success_ref": "#/components/schemas/AuthSessionOutput",
                 "error_codes": {"401"},
             },
+            ("/api/v1/users/beneficiary-lookup/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_items_ref": "#/components/schemas/BeneficiaryLookupOutput",
+                "error_codes": {"400", "401"},
+            },
         }
 
         error_ref = "#/components/schemas/ErrorResponse"
@@ -203,10 +210,21 @@ class TestOpenAPISchema:
             else:
                 assert "requestBody" not in operation
 
+            if path == "/api/v1/users/beneficiary-lookup/":
+                assert operation["parameters"][0]["name"] == "q"
+                assert operation["parameters"][0]["required"] is True
+
             for code in expectation["success_codes"]:
                 assert code in responses
-                if expectation["success_ref"] is None:
+                if (
+                    expectation.get("success_ref") is None
+                    and expectation.get("success_items_ref") is None
+                ):
                     assert "content" not in responses[code]
+                elif expectation.get("success_items_ref"):
+                    schema = responses[code]["content"]["application/json"]["schema"]
+                    assert schema["type"] == "array"
+                    assert schema["items"]["$ref"] == expectation["success_items_ref"]
                 else:
                     assert (
                         responses[code]["content"]["application/json"]["schema"]["$ref"]

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -213,6 +213,9 @@ class TestOpenAPISchema:
             if path == "/api/v1/users/beneficiary-lookup/":
                 assert operation["parameters"][0]["name"] == "q"
                 assert operation["parameters"][0]["required"] is True
+                assert operation["parameters"][0]["schema"]["minLength"] == 3, (
+                    "beneficiary lookup query param must document minLength=3"
+                )
 
             for code in expectation["success_codes"]:
                 assert code in responses
@@ -225,6 +228,7 @@ class TestOpenAPISchema:
                     schema = responses[code]["content"]["application/json"]["schema"]
                     assert schema["type"] == "array"
                     assert schema["items"]["$ref"] == expectation["success_items_ref"]
+                    assert schema["maxItems"] == 10
                 else:
                     assert (
                         responses[code]["content"]["application/json"]["schema"]["$ref"]

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -321,6 +321,60 @@ class TestAuthAPI:
             }
         ]
 
+    def test_beneficiary_lookup_para_chefe_setor_filtra_por_setor_responsavel(self):
+        chefe_ti = self._criar_usuario(
+            matricula="21501",
+            nome_completo="Chefe TI Lookup",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_ti = self._criar_setor(nome="TI Lookup", chefe=chefe_ti)
+        chefe_ti.setor = setor_ti
+        chefe_ti.save(update_fields=["setor"])
+
+        chefe_rh = self._criar_usuario(
+            matricula="21502",
+            nome_completo="Chefe RH Lookup",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_rh = self._criar_setor(nome="RH Lookup", chefe=chefe_rh)
+        chefe_rh.setor = setor_rh
+        chefe_rh.save(update_fields=["setor"])
+
+        beneficiario_mesmo_setor = self._criar_usuario(
+            matricula="21503",
+            nome_completo="Bruno TI",
+            setor=setor_ti,
+        )
+        self._criar_usuario(
+            matricula="21504",
+            nome_completo="Bruno RH",
+            setor=setor_rh,
+        )
+        self._criar_usuario(
+            matricula="21505",
+            nome_completo="Bruno TI Inativo",
+            setor=setor_ti,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_ti)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Bruno"})
+
+        assert response.status_code == 200
+        assert response.data == [
+            {
+                "id": beneficiario_mesmo_setor.id,
+                "nome_completo": "Bruno TI",
+                "matricula_funcional": "21503",
+                "setor": {
+                    "id": setor_ti.id,
+                    "nome": "TI Lookup",
+                },
+            }
+        ]
+
     def test_beneficiary_lookup_para_almoxarifado_ordenado_por_relevancia_simples(self):
         chefe_alm = self._criar_usuario(
             matricula="22001",
@@ -379,6 +433,59 @@ class TestAuthAPI:
         assert [item["nome_completo"] for item in response.data] == [
             "Ana Paula",
             "Mariana Obras",
+        ]
+
+    def test_beneficiary_lookup_para_superusuario_retorna_visibilidade_ampla_elegivel(self):
+        chefe_ti = self._criar_usuario(
+            matricula="22501",
+            nome_completo="Chefe TI Super",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_ti = self._criar_setor(nome="TI Super", chefe=chefe_ti)
+        chefe_ti.setor = setor_ti
+        chefe_ti.save(update_fields=["setor"])
+
+        chefe_rh = self._criar_usuario(
+            matricula="22502",
+            nome_completo="Chefe RH Super",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_rh = self._criar_setor(nome="RH Super", chefe=chefe_rh)
+        chefe_rh.setor = setor_rh
+        chefe_rh.save(update_fields=["setor"])
+
+        superuser = User.objects.create_superuser(
+            matricula_funcional="99901",
+            password="senha-segura-123",
+            nome_completo="Super Admin Lookup",
+        )
+
+        self._criar_usuario(
+            matricula="22503",
+            nome_completo="Carla TI",
+            setor=setor_ti,
+        )
+        self._criar_usuario(
+            matricula="22504",
+            nome_completo="Carla RH",
+            setor=setor_rh,
+        )
+        self._criar_usuario(
+            matricula="22505",
+            nome_completo="Carla Inativa",
+            setor=setor_ti,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Carla"})
+
+        assert response.status_code == 200
+        assert [item["nome_completo"] for item in response.data] == [
+            "Carla RH",
+            "Carla TI",
         ]
 
     def test_beneficiary_lookup_sem_autenticacao_retorna_401(self):

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -27,6 +27,32 @@ class TestAuthAPI:
         csrf_response = client.get(reverse("auth-csrf"))
         return client, csrf_response.data["csrf_token"]
 
+    @staticmethod
+    def _criar_setor(*, nome: str, chefe: User, is_active: bool = True) -> Setor:
+        return Setor.objects.create(nome=nome, chefe_responsavel=chefe, is_active=is_active)
+
+    @classmethod
+    def _criar_usuario(
+        cls,
+        *,
+        matricula: str,
+        nome_completo: str,
+        papel: str = PapelChoices.SOLICITANTE,
+        setor: Setor | None = None,
+        is_active: bool = True,
+        is_superuser: bool = False,
+    ) -> User:
+        user = User.objects.create_user(
+            matricula_funcional=matricula,
+            password="senha-segura-123",
+            nome_completo=nome_completo,
+            papel=papel,
+            setor=setor,
+            is_active=is_active,
+            is_superuser=is_superuser,
+        )
+        return user
+
     def test_me_sem_sessao_valida_retorna_401(self):
         client = APIClient()
 
@@ -190,6 +216,185 @@ class TestAuthAPI:
             format="json",
             HTTP_X_CSRFTOKEN=csrf_token,
         )
+
+        assert response.status_code == 400
+        assert response.data["error"]["code"] == "validation_error"
+
+    def test_beneficiary_lookup_para_auxiliar_setor_retorna_apenas_mesmo_setor_ativo(self):
+        chefe_ti = self._criar_usuario(
+            matricula="20001",
+            nome_completo="Chefe TI",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_ti = self._criar_setor(nome="TI", chefe=chefe_ti)
+        chefe_ti.setor = setor_ti
+        chefe_ti.save(update_fields=["setor"])
+
+        chefe_rh = self._criar_usuario(
+            matricula="20002",
+            nome_completo="Chefe RH",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_rh = self._criar_setor(nome="RH", chefe=chefe_rh)
+        chefe_rh.setor = setor_rh
+        chefe_rh.save(update_fields=["setor"])
+
+        ator = self._criar_usuario(
+            matricula="20003",
+            nome_completo="Auxiliar TI",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor_ti,
+        )
+        beneficiario_mesmo_setor = self._criar_usuario(
+            matricula="20004",
+            nome_completo="Ana TI",
+            setor=setor_ti,
+        )
+        self._criar_usuario(
+            matricula="20005",
+            nome_completo="Ana RH",
+            setor=setor_rh,
+        )
+        self._criar_usuario(
+            matricula="20006",
+            nome_completo="Ana TI Inativa",
+            setor=setor_ti,
+            is_active=False,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=ator)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 200
+        assert response.data == [
+            {
+                "id": beneficiario_mesmo_setor.id,
+                "nome_completo": "Ana TI",
+                "matricula_funcional": "20004",
+                "setor": {
+                    "id": setor_ti.id,
+                    "nome": "TI",
+                },
+            }
+        ]
+
+    def test_beneficiary_lookup_para_solicitante_retorna_apenas_o_proprio_usuario(self):
+        chefe_ti = self._criar_usuario(
+            matricula="21001",
+            nome_completo="Chefe TI 2",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_ti = self._criar_setor(nome="TI 2", chefe=chefe_ti)
+        chefe_ti.setor = setor_ti
+        chefe_ti.save(update_fields=["setor"])
+
+        ator = self._criar_usuario(
+            matricula="21002",
+            nome_completo="Ana Solicitante",
+            papel=PapelChoices.SOLICITANTE,
+            setor=setor_ti,
+        )
+        self._criar_usuario(
+            matricula="21003",
+            nome_completo="Ana Colega",
+            papel=PapelChoices.SOLICITANTE,
+            setor=setor_ti,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=ator)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 200
+        assert response.data == [
+            {
+                "id": ator.id,
+                "nome_completo": "Ana Solicitante",
+                "matricula_funcional": "21002",
+                "setor": {
+                    "id": setor_ti.id,
+                    "nome": "TI 2",
+                },
+            }
+        ]
+
+    def test_beneficiary_lookup_para_almoxarifado_ordenado_por_relevancia_simples(self):
+        chefe_alm = self._criar_usuario(
+            matricula="22001",
+            nome_completo="Chefe Almox",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        setor_alm = self._criar_setor(nome="Almoxarifado", chefe=chefe_alm)
+        chefe_alm.setor = setor_alm
+        chefe_alm.save(update_fields=["setor"])
+
+        chefe_obras = self._criar_usuario(
+            matricula="22002",
+            nome_completo="Chefe Obras",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_obras = self._criar_setor(nome="Obras", chefe=chefe_obras)
+        chefe_obras.setor = setor_obras
+        chefe_obras.save(update_fields=["setor"])
+
+        ator = self._criar_usuario(
+            matricula="22003",
+            nome_completo="Auxiliar Almox",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_alm,
+        )
+        self._criar_usuario(
+            matricula="22004",
+            nome_completo="Mariana Obras",
+            setor=setor_obras,
+        )
+        self._criar_usuario(
+            matricula="22005",
+            nome_completo="Ana Paula",
+            setor=setor_obras,
+        )
+        self._criar_usuario(
+            matricula="22006",
+            nome_completo="Ana Setor Inativo",
+            setor=self._criar_setor(
+                nome="Setor Inativo",
+                chefe=self._criar_usuario(
+                    matricula="22007",
+                    nome_completo="Chefe Inativo",
+                    papel=PapelChoices.CHEFE_SETOR,
+                ),
+                is_active=False,
+            ),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=ator)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 200
+        assert [item["nome_completo"] for item in response.data] == [
+            "Ana Paula",
+            "Mariana Obras",
+        ]
+
+    def test_beneficiary_lookup_sem_autenticacao_retorna_401(self):
+        client = APIClient()
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 401
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_beneficiary_lookup_com_query_curta_retorna_400(self):
+        user = self._criar_usuario_com_setor()
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "An"})
 
         assert response.status_code == 400
         assert response.data["error"]["code"] == "validation_error"

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -321,6 +321,22 @@ class TestAuthAPI:
             }
         ]
 
+    def test_beneficiary_lookup_para_solicitante_sem_setor_retorna_lista_vazia(self):
+        ator = self._criar_usuario(
+            matricula="21101",
+            nome_completo="Ana Sem Setor",
+            papel=PapelChoices.SOLICITANTE,
+            setor=None,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=ator)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 200
+        assert response.data == []
+
     def test_beneficiary_lookup_para_chefe_setor_filtra_por_setor_responsavel(self):
         chefe_ti = self._criar_usuario(
             matricula="21501",
@@ -374,6 +390,22 @@ class TestAuthAPI:
                 },
             }
         ]
+
+    def test_beneficiary_lookup_para_chefe_setor_sem_setor_responsavel_retorna_lista_vazia(self):
+        chefe_sem_setor = self._criar_usuario(
+            matricula="21601",
+            nome_completo="Chefe Sem Setor",
+            papel=PapelChoices.CHEFE_SETOR,
+            setor=None,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_sem_setor)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Bruno"})
+
+        assert response.status_code == 200
+        assert response.data == []
 
     def test_beneficiary_lookup_para_almoxarifado_ordenado_por_relevancia_simples(self):
         chefe_alm = self._criar_usuario(
@@ -434,6 +466,22 @@ class TestAuthAPI:
             "Ana Paula",
             "Mariana Obras",
         ]
+
+    def test_beneficiary_lookup_para_auxiliar_setor_sem_setor_retorna_lista_vazia(self):
+        auxiliar_sem_setor = self._criar_usuario(
+            matricula="22101",
+            nome_completo="Auxiliar Sem Setor",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=None,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=auxiliar_sem_setor)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Ana"})
+
+        assert response.status_code == 200
+        assert response.data == []
 
     def test_beneficiary_lookup_para_superusuario_retorna_visibilidade_ampla_elegivel(self):
         chefe_ti = self._criar_usuario(


### PR DESCRIPTION
@coderabbitai ignore
Closes #32

# Contexto

## O que este PR faz
- adiciona `GET /api/v1/users/beneficiary-lookup/?q=...` para o bloco 0 da SPA
- valida `q` com mínimo de 3 caracteres e retorna payload curto com `id`, `nome_completo`, `matricula_funcional` e `setor`
- aplica escopo por papel no lookup e ordenação simples por relevância de nome
- documenta o contrato no OpenAPI e cobre cenários de auth/escopo/ordenação em testes

## Por que esta mudança é necessária
A SPA do piloto depende de um lookup assistido de beneficiário para criação de requisição em nome de terceiros. Sem esse endpoint, o bloco 0 de APIs habilitadoras do frontend permanece incompleto.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Lookup retornar usuários fora do escopo do ator autenticado ou incluir beneficiários não elegíveis ao fluxo.

## Impactos adicionais (somente se houver)
- permissões / perfil / setor: `solicitante` vê só a si; `auxiliar_setor` vê só próprio setor; `chefe_setor` vê só setor sob responsabilidade; Almoxarifado vê usuários elegíveis de qualquer setor.
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. lookup para `auxiliar_setor` retorna apenas usuários ativos do mesmo setor ativo
2. lookup para `solicitante` retorna apenas o próprio usuário; lookup sem autenticação/`q` curto falha com envelope esperado
3. lookup para Almoxarifado ordena por relevância simples e o schema OpenAPI expõe rota, parâmetro e respostas

## Como validar manualmente
1. autenticar com um usuário operacional
2. chamar `GET /api/v1/users/beneficiary-lookup/?q=Ana`
3. confirmar que a resposta respeita o escopo do papel autenticado e exclui usuários inativos, superusuários e setores inativos

## Payloads / exemplos de uso

```json
[
  {
    "id": 12,
    "matricula_funcional": "20004",
    "nome_completo": "Ana TI",
    "setor": {
      "id": 3,
      "nome": "TI"
    }
  }
]
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumo de Mudanças — Endpoint de Lookup de Beneficiários

**Objetivo:**  
Adicionar endpoint de busca assistida `GET /api/v1/users/beneficiary-lookup/?q=...` para apoiar seleção de beneficiários na SPA do piloto (bloco 0), integrando o formulário de criação de requisições com lookup interativo por nome.

---

**Apps Django Impactados:**
- `apps.users` (policies, serializers, views, urls)
- `apps.requisitions` (sem alterações neste PR; mantém importação das policies existentes)
- `tests.users` (novos casos de teste para scoping e validação)

---

**Lógica de Negócio & Autorização:**
- Nova função de policy `queryset_beneficiarios_lookup_para(criador) → QuerySet[User]` centraliza escopo por papel:
  - **Solicitante**: vê apenas a si mesmo.
  - **Auxiliar de Setor**: vê apenas usuários do próprio setor ativo.
  - **Chefe de Setor**: vê apenas usuários do setor pelo qual é responsável.
  - **Almoxarifado** (auxiliar/chefe): vê todos os usuários ativos de qualquer setor.
  - **Superusuário, inativo ou sem setor**: retorna queryset vazio.
- Filtra apenas usuários ativos, não-superuser, com setor ativo atribuído.
- Utiliza `select_related("setor")` para evitar N+1 queries.

---

**Riscos Funcionais & Autorização:**
- **Risco mitigado**: leaking de usuários fora do escopo da autorização, pois cada papel tem sua restrição explícita.
- **Risco mitigado**: inclusão de usuários inativos ou sem setor — filtering em nível de queryset.
- Implementação não quebra invariante **PER-06** (superusuário não opera fluxo operacional) nem **PER-08** (autorização contextual centralizada).

---

**Impacto em Regras de Negócio & Escopo por Perfil/Setor:**
- Não altera regras existentes de criação de requisição (`pode_criar_requisicao_para`); apenas expõe lookup para facilitar seleção de beneficiários na UI.
- Scoping aplicado de forma coerente com matriz-permissoes.md.
- Ordenação simples: prefere matches que começam com a query (`istartswith`), depois ordena por nome completo e matrícula.

---

**Impacto em Contratos DRF, Serializers & OpenAPI:**
- Novos serializers:
  - `BeneficiaryLookupQuerySerializer`: input com `q` (min_length=3, trim_whitespace=True).
  - `BeneficiaryLookupOutputSerializer`: output com `id`, `nome_completo`, `matricula_funcional`, `setor` (aninhado via `AuthSetorOutputSerializer`, nullable).
- Nova view `BeneficiaryLookupView` retorna lista (até 10 resultados) sem envelope global.
- Resposta 200 com array de objetos beneficiário; 400 para query curta (validation_error); 401 para não-autenticado.
- OpenAPI documentado com `operation_id="users_beneficiary_lookup"`, parameter `q` obrigatório, success schema referenciando `BeneficiaryLookupOutput` como array.
- Sem paginação (limit hardcoded a 10); sem filtros adicionais; sem ordenação customizável pelo cliente.

---

**Integridade de Dados & Auditoria:**
- Sem mutações (apenas leitura via GET).
- Sem transações, constraints, snapshots históricos ou rastreabilidade afetados.
- Sem impacto em saldos físico/reservado/disponível.

---

**Concorrência & Idempotência:**
- Operação read-only; sem conflitos de concorrência ou efeitos colaterais.
- Segura para reexecução em retry.

---

**Configuração, CI & Testes:**
- Sem migration versionada necessária (apenas API nova, sem model changes).
- Sem dependências novas ou alterações de lint.
- Cobertura de testes: 5 novos casos em `test_auth_api.py` (auxiliar_setor com mesmo setor, solicitante vendo a si mesmo, almoxarifado ordenado por relevância, erro 401 sem autenticação, erro 400 com query curta).
- Helper methods adicionados: `_criar_setor()` e `_criar_usuario()` refatoram factory test para reutilização.

---

**Validação Manual:**
- Via API: `curl -b cookies.txt "http://localhost:8000/api/v1/users/beneficiary-lookup/?q=Ana"` (após autenticação de sessão).
- Via admin: não há interface de admin para este endpoint.
- Via testes: `pytest tests/users/test_auth_api.py::TestAuthAPI::test_beneficiary_lookup_*`.
- OpenAPI: acessar `/api/v1/schema/swagger/` e verificar presença de `/api/v1/users/beneficiary-lookup/` com contrato declarado.

---

**Observação Importante:**  
O raw_summary fornecido contém **informação enganosa**: afirma que as funções `pode_autorizar_setor`, `pode_ver_fila_atendimento`, `pode_operar_estoque` e `pode_operar_estoque_chefia` foram **removidas** de `apps/users/policies.py`. Em realidade, **todas continuam presentes** no arquivo e sendo importadas/usadas por `apps/requisitions/policies.py`. Nenhuma função de authorization foi removida neste PR — apenas uma nova função de policy foi adicionada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->