### PR TITLE
feat: add canonical requisition reads for pilot SPA

### DIFF
--- a/apps/requisitions/filters.py
+++ b/apps/requisitions/filters.py
@@ -1,0 +1,16 @@
+import django_filters
+from django_filters import FilterSet
+
+from apps.requisitions.models import Requisicao
+
+
+class RequisicaoFilter(FilterSet):
+    status = django_filters.CharFilter(
+        field_name="status",
+        lookup_expr="exact",
+        help_text="Filtrar por status da requisição.",
+    )
+
+    class Meta:
+        model = Requisicao
+        fields = []

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -31,17 +31,23 @@ def pode_visualizar_requisicao(user, requisicao: Requisicao) -> bool:
     )
 
 
-def queryset_requisicoes_visiveis(user) -> QuerySet[Requisicao]:
+def queryset_requisicoes_visiveis(
+    user,
+    *,
+    skip_prefetch: bool = False,
+) -> QuerySet[Requisicao]:
     queryset = Requisicao.objects.select_related(
         "criador",
         "beneficiario",
         "setor_beneficiario",
         "chefe_autorizador",
         "responsavel_atendimento",
-    ).prefetch_related(
-        "itens__material",
-        "eventos__usuario",
     )
+    if not skip_prefetch:
+        queryset = queryset.prefetch_related(
+            "itens__material",
+            "eventos__usuario",
+        )
 
     if not user.is_authenticated:
         return queryset.none()

--- a/apps/requisitions/serializers.py
+++ b/apps/requisitions/serializers.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from rest_framework import serializers
 
-from apps.requisitions.models import ItemRequisicao, Requisicao
+from apps.requisitions.models import EventoTimeline, ItemRequisicao, Requisicao
 
 
 class RequisicaoUserOutputSerializer(serializers.Serializer):
@@ -111,6 +111,56 @@ class RequisicaoActionOutputSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class RequisicaoTimelineEventOutputSerializer(serializers.ModelSerializer):
+    usuario = RequisicaoUserOutputSerializer(read_only=True)
+
+    class Meta:
+        model = EventoTimeline
+        fields = [
+            "id",
+            "tipo_evento",
+            "usuario",
+            "data_hora",
+            "observacao",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoListOutputSerializer(serializers.ModelSerializer):
+    criador = RequisicaoUserOutputSerializer(read_only=True)
+    beneficiario = RequisicaoUserOutputSerializer(read_only=True)
+    setor_beneficiario = RequisicaoSetorOutputSerializer(read_only=True)
+    total_itens = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = Requisicao
+        fields = [
+            "id",
+            "numero_publico",
+            "status",
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+            "data_criacao",
+            "data_envio_autorizacao",
+            "data_autorizacao_ou_recusa",
+            "data_finalizacao",
+            "updated_at",
+            "total_itens",
+        ]
+        read_only_fields = fields
+
+
+class RequisicaoListPaginatedSerializer(serializers.Serializer):
+    count = serializers.IntegerField(read_only=True)
+    page = serializers.IntegerField(read_only=True)
+    page_size = serializers.IntegerField(read_only=True)
+    total_pages = serializers.IntegerField(read_only=True)
+    next = serializers.URLField(allow_null=True, read_only=True)
+    previous = serializers.URLField(allow_null=True, read_only=True)
+    results = RequisicaoListOutputSerializer(many=True, read_only=True)
+
+
 class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
     criador = RequisicaoUserOutputSerializer(read_only=True)
     beneficiario = RequisicaoUserOutputSerializer(read_only=True)
@@ -118,6 +168,7 @@ class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
     chefe_autorizador = RequisicaoUserOutputSerializer(read_only=True)
     responsavel_atendimento = RequisicaoUserOutputSerializer(read_only=True)
     itens = RequisicaoActionOutputSerializer(many=True, read_only=True)
+    eventos = RequisicaoTimelineEventOutputSerializer(many=True, read_only=True)
 
     class Meta:
         model = Requisicao
@@ -140,6 +191,7 @@ class RequisicaoDetailOutputSerializer(serializers.ModelSerializer):
             "observacao",
             "observacao_atendimento",
             "itens",
+            "eventos",
         ]
         read_only_fields = fields
 

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -71,7 +71,7 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
         return RequisicaoDetailOutputSerializer
 
     def get_object(self):
-        queryset = self.filter_queryset(self.get_queryset())
+        queryset = self.get_queryset()
         obj = get_object_or_404(queryset, pk=self.kwargs["pk"])
         self.check_object_permissions(self.request, obj)
         return obj

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -60,10 +60,16 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
     ]
 
     def get_queryset(self):
-        queryset = queryset_requisicoes_visiveis(self.request.user)
         if self.action == "list":
-            return queryset.annotate(total_itens=Count("itens")).order_by("-updated_at", "-id")
-        return queryset
+            return (
+                queryset_requisicoes_visiveis(
+                    self.request.user,
+                    skip_prefetch=True,
+                )
+                .annotate(total_itens=Count("itens"))
+                .order_by("-updated_at", "-id")
+            )
+        return queryset_requisicoes_visiveis(self.request.user)
 
     def get_serializer_class(self):
         if self.action == "list":

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -1,15 +1,17 @@
 from django.contrib.auth import get_user_model
 from django.db.models import Count
 from django.shortcuts import get_object_or_404
+from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.utils import extend_schema
-from rest_framework import status
+from rest_framework import filters, mixins, status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 
 from apps.core.api.serializers import ErrorResponseSerializer
+from apps.requisitions.filters import RequisicaoFilter
 from apps.requisitions.policies import queryset_requisicoes_visiveis
 from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
@@ -17,6 +19,8 @@ from apps.requisitions.serializers import (
     RequisicaoCreateInputSerializer,
     RequisicaoDetailOutputSerializer,
     RequisicaoFulfillInputSerializer,
+    RequisicaoListOutputSerializer,
+    RequisicaoListPaginatedSerializer,
     RequisicaoPendingApprovalOutputSerializer,
     RequisicaoPendingApprovalPaginatedSerializer,
     RequisicaoPendingFulfillmentOutputSerializer,
@@ -41,18 +45,97 @@ from apps.requisitions.services import (
 User = get_user_model()
 
 
-class RequisicaoViewSet(GenericViewSet):
+class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, GenericViewSet):
     permission_classes = [IsAuthenticated]
     serializer_class = RequisicaoDetailOutputSerializer
+    filterset_class = RequisicaoFilter
+    filter_backends = [
+        filters.SearchFilter,
+        DjangoFilterBackend,
+    ]
+    search_fields = [
+        "numero_publico",
+        "beneficiario__nome_completo",
+        "criador__nome_completo",
+    ]
 
     def get_queryset(self):
-        return queryset_requisicoes_visiveis(self.request.user)
+        queryset = queryset_requisicoes_visiveis(self.request.user)
+        if self.action == "list":
+            return queryset.annotate(total_itens=Count("itens")).order_by("-updated_at", "-id")
+        return queryset
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return RequisicaoListOutputSerializer
+        return RequisicaoDetailOutputSerializer
 
     def get_object(self):
         queryset = self.filter_queryset(self.get_queryset())
         obj = get_object_or_404(queryset, pk=self.kwargs["pk"])
         self.check_object_permissions(self.request, obj)
         return obj
+
+    @extend_schema(
+        operation_id="requisitions_list",
+        tags=["requisitions"],
+        description=(
+            "Lista paginada das requisições visíveis ao usuário autenticado. "
+            "Suporta busca textual simples e filtro por status."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="search",
+                description="Busca textual por número público, nome do beneficiário ou nome do criador.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="status",
+                description="Filtro exato por status da requisição.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: RequisicaoListPaginatedSerializer(),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        operation_id="requisitions_retrieve",
+        tags=["requisitions"],
+        description=(
+            "Detalhe canônico de uma requisição visível ao usuário autenticado, "
+            "incluindo itens e resumo operacional da timeline."
+        ),
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+        },
+    )
+    def retrieve(self, request, *args, **kwargs):
+        return super().retrieve(request, *args, **kwargs)
 
     @extend_schema(
         operation_id="requisitions_create_draft",

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -300,6 +300,41 @@ class TestRequisicaoAPI:
         assert "itens" not in response.data["results"][0]
         assert "eventos" not in response.data["results"][0]
 
+    def test_lista_requisicoes_nao_autenticado_retorna_403(self):
+        client = APIClient()
+
+        response = client.get(reverse("requisicao-list"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_lista_requisicoes_almoxarife_ve_todos_os_setores(self):
+        setor_a = self._criar_setor("Almoxarifado", "900079")
+        setor_b = self._criar_setor("Manutencao", "900080")
+        almoxarife = self._criar_usuario(
+            "100090",
+            "Auxiliar Almoxarifado",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_a,
+        )
+        usuario_b = self._criar_usuario("100091", "Solicitante B", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.057")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_b,
+            beneficiario=usuario_b,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000777",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.get(reverse("requisicao-list"))
+
+        assert response.status_code == 200
+        assert response.data["count"] >= 1
+        assert any(item["id"] == requisicao.id for item in response.data["results"])
+
     def test_lista_requisicoes_filtra_por_status_e_busca_textual(self):
         setor = self._criar_setor("Compras", "900074")
         usuario = self._criar_usuario("100084", "Solicitante Compras", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -103,6 +103,31 @@ class TestRequisicaoAPI:
             ]
         }
 
+    @staticmethod
+    def _criar_requisicao_com_item(
+        *,
+        criador: User,
+        beneficiario: User,
+        material: Material,
+        status: str = StatusRequisicao.RASCUNHO,
+        numero_publico: str | None = None,
+        observacao: str = "",
+        quantidade_solicitada: str = "2",
+    ) -> Requisicao:
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario,
+            status=status,
+            numero_publico=numero_publico,
+            observacao=observacao,
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal(quantidade_solicitada),
+        )
+        return requisicao
+
     def test_cria_rascunho_para_si(self):
         setor = self._criar_setor("Operacional", "90001")
         usuario = self._criar_usuario("10001", "Solicitante", setor=setor)
@@ -227,6 +252,146 @@ class TestRequisicaoAPI:
             self._payload_requisicao(beneficiario_id=999999, material_id=material.id),
             format="json",
         )
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
+    def test_lista_requisicoes_visiveis_paginada_e_leve(self):
+        setor = self._criar_setor("Operacoes", "900072")
+        outro_setor = self._criar_setor("Financeiro", "900073")
+        usuario = self._criar_usuario("100082", "Solicitante Operacoes", setor=setor)
+        outro_usuario = self._criar_usuario("100083", "Solicitante Financeiro", setor=outro_setor)
+        material = self._criar_material_com_estoque("001.001.052")
+
+        rascunho = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            observacao="Rascunho visivel",
+        )
+        submetida = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000111",
+            observacao="Requisicao enviada",
+        )
+        self._criar_requisicao_com_item(
+            criador=outro_usuario,
+            beneficiario=outro_usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000222",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("requisicao-list"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 2
+        assert response.data["page"] == 1
+        assert response.data["page_size"] == 20
+        resultado_ids = [item["id"] for item in response.data["results"]]
+        assert resultado_ids == [submetida.id, rascunho.id]
+        assert response.data["results"][1]["numero_publico"] is None
+        assert response.data["results"][0]["total_itens"] == 1
+        assert "itens" not in response.data["results"][0]
+        assert "eventos" not in response.data["results"][0]
+
+    def test_lista_requisicoes_filtra_por_status_e_busca_textual(self):
+        setor = self._criar_setor("Compras", "900074")
+        usuario = self._criar_usuario("100084", "Solicitante Compras", setor=setor)
+        material = self._criar_material_com_estoque("001.001.053")
+
+        self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            observacao="Rascunho para edicao",
+        )
+        aguardando = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000333",
+            observacao="Fluxo de autorizacao",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+
+        response_status = client.get(
+            reverse("requisicao-list"),
+            {"status": StatusRequisicao.AGUARDANDO_AUTORIZACAO},
+        )
+        assert response_status.status_code == 200
+        assert response_status.data["count"] == 1
+        assert response_status.data["results"][0]["id"] == aguardando.id
+
+        response_search = client.get(reverse("requisicao-list"), {"search": "000333"})
+        assert response_search.status_code == 200
+        assert response_search.data["count"] == 1
+        assert response_search.data["results"][0]["id"] == aguardando.id
+
+    def test_detail_retorna_itens_justificativas_e_eventos(self):
+        setor = self._criar_setor("Patrimonio", "900075")
+        usuario = self._criar_usuario("100085", "Solicitante Patrimonio", setor=setor)
+        autorizador = self._criar_usuario(
+            "100086",
+            "Chefe Patrimonio",
+            papel=PapelChoices.CHEFE_SETOR,
+            setor=setor,
+        )
+        material = self._criar_material_com_estoque("001.001.054")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AUTORIZADA,
+            numero_publico="REQ-2026-000444",
+        )
+        item = requisicao.itens.get()
+        item.quantidade_autorizada = Decimal("1")
+        item.justificativa_autorizacao_parcial = "Saldo parcial"
+        item.save(update_fields=["quantidade_autorizada", "justificativa_autorizacao_parcial"])
+        EventoTimeline.objects.create(
+            requisicao=requisicao,
+            tipo_evento=TipoEvento.AUTORIZACAO_PARCIAL,
+            usuario=autorizador,
+            observacao="Autorizado parcialmente por saldo.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+        assert response.data["itens"][0]["justificativa_autorizacao_parcial"] == "Saldo parcial"
+        assert response.data["eventos"][0]["tipo_evento"] == TipoEvento.AUTORIZACAO_PARCIAL
+        assert response.data["eventos"][0]["usuario"]["id"] == autorizador.id
+        assert response.data["eventos"][0]["observacao"] == "Autorizado parcialmente por saldo."
+
+    def test_detail_requisicao_fora_do_escopo_retorna_404(self):
+        setor_a = self._criar_setor("TI", "900076")
+        setor_b = self._criar_setor("Frota", "900077")
+        usuario = self._criar_usuario("100087", "Solicitante TI", setor=setor_a)
+        outro_usuario = self._criar_usuario("100088", "Solicitante Frota", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.055")
+        requisicao = self._criar_requisicao_com_item(
+            criador=outro_usuario,
+            beneficiario=outro_usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000555",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
 
         assert response.status_code == 404
         assert response.data["error"]["code"] == "not_found"

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -396,6 +396,28 @@ class TestRequisicaoAPI:
         assert response.status_code == 404
         assert response.data["error"]["code"] == "not_found"
 
+    def test_detail_ignora_filtros_de_listagem_na_url(self):
+        setor = self._criar_setor("Obras", "900078")
+        usuario = self._criar_usuario("100089", "Solicitante Obras", setor=setor)
+        material = self._criar_material_com_estoque("001.001.056")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000666",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(
+            reverse("requisicao-detail", args=[requisicao.id]),
+            {"status": StatusRequisicao.RASCUNHO, "search": "nao-corresponde"},
+        )
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+
     def test_submit_gera_numero_publico_e_entrada_na_fila(self):
         setor = self._criar_setor("Planejamento", "90008")
         usuario = self._criar_usuario("10009", "Solicitante Planejamento", setor=setor)

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -139,6 +139,7 @@ class TestOpenAPISchema:
         assert "/api/v1/users/beneficiary-lookup/" in paths
         assert "/api/v1/materials/{id}/" in paths
         assert "/api/v1/requisitions/" in paths
+        assert "/api/v1/requisitions/{id}/" in paths
         assert "/api/v1/requisitions/{id}/submit/" in paths
         assert "/api/v1/requisitions/{id}/return-to-draft/" in paths
         assert "/api/v1/requisitions/{id}/discard/" in paths
@@ -152,9 +153,41 @@ class TestOpenAPISchema:
 
         components = schema["components"]["schemas"]
         assert "RequisicaoItemFulfillInput" in components
+        assert "RequisicaoListOutput" in components
+        assert "RequisicaoTimelineEventOutput" in components
         item_schema = components["RequisicaoItemFulfillInput"]["properties"]
         assert "quantidade_entregue" in item_schema
         assert "justificativa_atendimento_parcial" in item_schema
+
+    def test_requisitions_read_endpoints_declaram_filtros_e_respostas(self):
+        """Verify canonical requisition reads expose explicit list/detail contracts."""
+        schema = self._get_schema()
+        paths = schema["paths"]
+        error_ref = "#/components/schemas/ErrorResponse"
+
+        list_operation = paths["/api/v1/requisitions/"]["get"]
+        list_parameters = {param["name"]: param for param in list_operation["parameters"]}
+        assert set(list_parameters) >= {"page", "page_size", "search", "status"}
+        assert list_operation["operationId"] == "requisitions_list"
+        assert (
+            list_operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+            == "#/components/schemas/PaginatedRequisicaoListPaginatedList"
+        )
+        assert (
+            list_operation["responses"]["403"]["content"]["application/json"]["schema"]["$ref"]
+            == error_ref
+        )
+
+        detail_operation = paths["/api/v1/requisitions/{id}/"]["get"]
+        assert detail_operation["operationId"] == "requisitions_retrieve"
+        assert (
+            detail_operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+            == "#/components/schemas/RequisicaoDetailOutput"
+        )
+        assert (
+            detail_operation["responses"]["404"]["content"]["application/json"]["schema"]["$ref"]
+            == error_ref
+        )
 
     def test_auth_endpoints_declaram_requests_responses_e_status_esperados(self):
         """Verify auth endpoints expose explicit schema contracts."""


### PR DESCRIPTION
# Contexto

## O que este PR faz
- adiciona `GET /api/v1/requisitions/` com paginação padrão, busca textual e filtro por `status`
- adiciona `GET /api/v1/requisitions/{id}/` como detalhe canônico com itens e timeline de eventos
- separa serializer leve de lista do serializer de detalhe e documenta ambos no OpenAPI
- adiciona testes de API e de schema para visibilidade, rascunhos sem número público, filtros e detalhe autorizado

## Por que esta mudança é necessária
Atende a issue #33 do bloco 0 da SPA do piloto. A frente `Minhas requisições` e a rota canônica `/requisicoes/:id` precisam de leituras HTTP estáveis, paginadas e alinhadas com a policy atual de visibilidade antes do início da implementação operacional do frontend.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [ ] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Lista ou detalhe exporem requisições fora do escopo visível do usuário se o queryset de leitura divergir da policy já usada nas ações do domínio.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: reutiliza `queryset_requisicoes_visiveis()` para lista e detalhe; fora de escopo continua respondendo `404`
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados

1. listagem paginada retorna apenas requisições visíveis, ordenadas por atualização recente, com serializer leve
2. filtro por `status` e busca textual por número público funcionam no endpoint de lista
3. detalhe retorna itens, justificativas e timeline; requisição fora do escopo visível responde `404`

## Como validar manualmente
1. autenticar com um usuário operacional do piloto
2. chamar `GET /api/v1/requisitions/` e validar paginação, `search`, `status` e rascunhos sem `numero_publico`
3. chamar `GET /api/v1/requisitions/{id}/` com uma requisição visível e conferir itens/eventos
4. repetir o detalhe com usuário fora do escopo e validar `404 not_found`

## Payloads / exemplos de uso

```json
{
  "list_example": "/api/v1/requisitions/?search=000333&status=aguardando_autorizacao",
  "detail_example": "/api/v1/requisitions/123/"
}
```

## Observações de validação
- `rtk ruff check apps/requisitions tests/requisitions/test_api.py tests/test_api_schema.py`
- `rtk proxy pytest tests/requisitions/test_api.py tests/test_api_schema.py -q -k 'lista_requisicoes_visiveis_paginada_e_leve or lista_requisicoes_filtra_por_status_e_busca_textual or detail_retorna_itens_justificativas_e_eventos or detail_requisicao_fora_do_escopo_retorna_404 or requisitions_read_endpoints_declaram_filtros_e_respostas or schema_contem_rotas_de_requisicoes'`
- rodada completa de `tests/requisitions/test_api.py tests/test_api_schema.py -q` ainda encontra 3 falhas preexistentes do Swagger UI local (`/api/v1/docs/`) relacionadas ao stack atual de template rendering; não foram introduzidas por este diff

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR: Adição de leituras canônicas para requisições

- Objetivo
  - Expor leituras HTTP canônicas para a SPA piloto: GET /api/v1/requisitions/ (lista paginada, busca textual e filtro por status) e GET /api/v1/requisitions/{id}/ (detalhe canônico com itens e timeline).

- Apps Django impactados
  - apps/requisitions (views, serializers, filters, policies)
  - tests/requisitions (novos testes de API)
  - tests/test_api_schema.py (validação OpenAPI)

- Risco funcional
  - Baixo: endpoints são read-only e reutilizam queryset_requisicoes_visiveis() para aplicar política de visibilidade. Testes cobrem visibilidade, rascunhos sem numero_publico e detalhe fora do escopo → 404.
  - Principal risco: divergência futura entre a política de visibilidade e o queryset usado aqui (lista usa annotate/ordering e skip_prefetch=True; detalhe usa queryset com prefetch). Possível exposição acidental se alguém alterar a política sem alinhar view.

- Impacto em regras de negócio
  - Nenhum efeito de escrita/transição de estado; apenas exposição de dados já existentes (itens, eventos, justificativas).

- Impacto em autenticação, autorização, escopo por perfil e setor
  - Mantém IsAuthenticated; visibilidade delegada a queryset_requisicoes_visiveis(user, skip_prefetch=...), que aplica regras por superuser, papel e setor.
  - get_object() busca usando get_queryset() e retorna 404 para objetos fora do escopo; testes validam comportamento.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Serializers: adicionados RequisicaoListOutputSerializer (leve) e RequisicaoDetailOutputSerializer (itens + eventos); RequisicaoListPaginatedSerializer para resposta paginada.
  - Paginação: usa o padrão do projeto (StandardPagination) com schema paginado exposto no OpenAPI.
  - Filtros: RequisicaoFilter adiciona parâmetro status (exact); SearchFilter ativado para numero_publico, beneficiario__nome_completo e criador__nome_completo.
  - OpenAPI: @extend_schema em list/retrieve declara parâmetros (page, page_size, search, status), schemas de resposta e respostas de erro (403/404).
  - Envelope de erro: mantém ErrorResponseSerializer para respostas 403/404/400/409.

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Timeline (EventoTimeline) é apenas lida e exposta; não altera imutabilidade, auditoria ou snapshots existentes.

- Impacto em transações, concorrência, idempotência, saldo físico/reservado/disponível
  - Nenhum — operações de escrita/estoque permanecem em services.py; endpoints são somente leitura.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque
  - Nenhum.

- Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero
  - Sem novas dependências ou migrations.
  - Adição de testes de API e de schema; CI pode falhar apenas por problemas pré-existentes do Swagger UI mencionados.

- Observações técnicas e riscos operacionais
  - policies.queryset_requisicoes_visiveis ganhou parâmetro skip_prefetch: list() chama com skip_prefetch=True e anota total_itens, detalhe usa prefetch (evita overhead na listagem).
  - Potencial N+1 no detalhe se prefetch/select_related não cobrirem todos os relacionamentos necessários em cenários de carga; a policy já prefetch_related("itens__material","eventos__usuario") por padrão.
  - get_object() utiliza get_queryset() + get_object_or_404(pk=...) e check_object_permissions, garantindo 404/autorização consistente.
  - list() aplica order_by("-updated_at","-id"); detalhe mantém ordenação definidas por EventoTimeline.Meta (cronológica) sem re-order_by explícito conforme comentário do autor.

- Como validar manualmente
  - Lista paginada (autenticado):
    GET /api/v1/requisitions/  (Authorization: Bearer <token>)
  - Lista com filtros/busca:
    GET /api/v1/requisitions/?status=aguardando_autorizacao&search=REQ-2026&page=1&page_size=10
  - Detalhe (autenticado):
    GET /api/v1/requisitions/{id}/
  - Detalhe fora do escopo → 404:
    GET /api/v1/requisitions/{id_de_outro_setor}/
  - Testes automatizados:
    pytest tests/requisitions/test_api.py::TestRequisicaoAPI::test_lista_requisicoes_visiveis_paginada_e_leve -v
    pytest tests/requisitions/test_api.py::TestRequisicaoAPI::test_detail_retorna_itens_justificativas_e_eventos -v
    pytest tests/test_api_schema.py::TestOpenAPISchema::test_requisitions_read_endpoints_declaram_filtros_e_respostas -v
<!-- end of auto-generated comment: release notes by coderabbit.ai -->