### PR TITLE
feat(requisitions): add explicit draft update

### DIFF
--- a/apps/requisitions/models.py
+++ b/apps/requisitions/models.py
@@ -230,17 +230,23 @@ class Requisicao(models.Model):
             if persisted is not None:
                 errors = {}
                 pode_alterar_snapshot = persisted["status"] == StatusRequisicao.RASCUNHO
-                if (
-                    self.beneficiario_id != persisted["beneficiario_id"]
-                    and not pode_alterar_snapshot
-                ):
-                    errors["beneficiario"] = "Beneficiário não pode ser alterado após a criação."
-                if (
+                beneficiario_foi_alterado = self.beneficiario_id != persisted["beneficiario_id"]
+                setor_beneficiario_foi_alterado = (
                     self.setor_beneficiario_id != persisted["setor_beneficiario_id"]
-                    and not pode_alterar_snapshot
-                ):
+                )
+                if beneficiario_foi_alterado and not pode_alterar_snapshot:
+                    errors["beneficiario"] = "Beneficiário não pode ser alterado após a criação."
+                if setor_beneficiario_foi_alterado and not pode_alterar_snapshot:
                     errors["setor_beneficiario"] = (
                         "Setor beneficiário é snapshot histórico e não pode ser alterado."
+                    )
+                if (
+                    pode_alterar_snapshot
+                    and (beneficiario_foi_alterado or setor_beneficiario_foi_alterado)
+                    and self.beneficiario.setor_id != self.setor_beneficiario_id
+                ):
+                    errors["setor_beneficiario"] = (
+                        "Setor beneficiário deve corresponder ao setor atual do beneficiário."
                     )
                 if errors:
                     raise ValidationError(errors)

--- a/apps/requisitions/models.py
+++ b/apps/requisitions/models.py
@@ -223,14 +223,22 @@ class Requisicao(models.Model):
                 .values(
                     "beneficiario_id",
                     "setor_beneficiario_id",
+                    "status",
                 )
                 .first()
             )
             if persisted is not None:
                 errors = {}
-                if self.beneficiario_id != persisted["beneficiario_id"]:
+                pode_alterar_snapshot = persisted["status"] == StatusRequisicao.RASCUNHO
+                if (
+                    self.beneficiario_id != persisted["beneficiario_id"]
+                    and not pode_alterar_snapshot
+                ):
                     errors["beneficiario"] = "Beneficiário não pode ser alterado após a criação."
-                if self.setor_beneficiario_id != persisted["setor_beneficiario_id"]:
+                if (
+                    self.setor_beneficiario_id != persisted["setor_beneficiario_id"]
+                    and not pode_alterar_snapshot
+                ):
                     errors["setor_beneficiario"] = (
                         "Setor beneficiário é snapshot histórico e não pode ser alterado."
                     )

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 from django.contrib.auth import get_user_model
 from django.db import IntegrityError, transaction
 from django.utils import timezone
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
 
 from apps.core.api.exceptions import DomainConflict
 from apps.core.events import (
@@ -29,6 +29,7 @@ from apps.requisitions.policies import (
     pode_autorizar_requisicao,
     pode_cancelar_autorizada,
     pode_manipular_pre_autorizacao,
+    pode_visualizar_requisicao,
     queryset_fila_atendimento,
     queryset_fila_autorizacao,
 )
@@ -38,7 +39,7 @@ from apps.stock.services import (
     registrar_reserva_por_autorizacao,
     registrar_saida_por_atendimento,
 )
-from apps.users.models import PapelChoices
+from apps.users.models import PapelChoices, Setor
 from apps.users.policies import (
     pode_criar_requisicao_para,
     pode_ver_fila_atendimento,
@@ -542,50 +543,71 @@ def criar_rascunho_requisicao(
 
 def atualizar_rascunho_requisicao(
     *,
-    requisicao: Requisicao,
+    requisicao_id: int,
     ator: User,
-    beneficiario: User,
+    beneficiario_id: int,
     observacao: str,
     itens: list[ItemRascunhoData],
 ) -> Requisicao:
-    if beneficiario.setor_id is None:
-        raise ValidationError({"beneficiario_id": ["Beneficiário deve possuir setor válido."]})
-
-    if not beneficiario.setor.is_active:
-        raise DomainConflict(
-            "Setor do beneficiário está inativo.",
-            details={"beneficiario_id": f"Setor '{beneficiario.setor.nome}' está inativo."},
-        )
-
     materiais = _validar_itens_rascunho(itens)
 
     with transaction.atomic():
-        requisicao = (
-            Requisicao.objects.select_for_update()
-            .select_related("criador", "beneficiario", "setor_beneficiario")
-            .prefetch_related("itens__material", "eventos__usuario")
-            .get(pk=requisicao.pk)
-        )
+        try:
+            requisicao_locked = (
+                Requisicao.objects.select_related(
+                    "criador",
+                    "beneficiario",
+                    "setor_beneficiario",
+                )
+                .select_for_update()
+                .prefetch_related("itens__material", "eventos__usuario")
+                .get(pk=requisicao_id)
+            )
+        except Requisicao.DoesNotExist as exc:
+            raise NotFound("Requisição não encontrada.") from exc
 
-        if not pode_manipular_pre_autorizacao(ator, requisicao):
+        if not pode_visualizar_requisicao(ator, requisicao_locked):
+            raise NotFound("Requisição não encontrada.")
+
+        if not pode_manipular_pre_autorizacao(ator, requisicao_locked):
             raise PermissionDenied("Apenas criador ou beneficiário podem editar a requisição.")
 
-        if requisicao.status != StatusRequisicao.RASCUNHO:
+        if requisicao_locked.status != StatusRequisicao.RASCUNHO:
             raise DomainConflict(
                 "Somente requisições em rascunho podem ser editadas.",
-                details={"status_atual": requisicao.status},
+                details={"status_atual": requisicao_locked.status},
             )
 
-        if not pode_criar_requisicao_para(ator, beneficiario):
+        try:
+            beneficiario_locked = User.objects.select_for_update().get(pk=beneficiario_id)
+        except User.DoesNotExist as exc:
+            raise NotFound("Beneficiário não encontrado.") from exc
+
+        if beneficiario_locked.setor_id is None:
+            raise ValidationError({"beneficiario_id": ["Beneficiário deve possuir setor válido."]})
+
+        setor_beneficiario_locked = Setor.objects.select_for_update().get(
+            pk=beneficiario_locked.setor_id
+        )
+
+        if not setor_beneficiario_locked.is_active:
+            raise DomainConflict(
+                "Setor do beneficiário está inativo.",
+                details={
+                    "beneficiario_id": f"Setor '{setor_beneficiario_locked.nome}' está inativo."
+                },
+            )
+
+        if not pode_criar_requisicao_para(ator, beneficiario_locked):
             raise PermissionDenied(
                 "Usuário sem permissão para criar requisição para este beneficiário."
             )
 
-        requisicao.beneficiario = beneficiario
-        requisicao.setor_beneficiario = beneficiario.setor
-        requisicao.observacao = observacao
-        requisicao.full_clean()
-        requisicao.save(
+        requisicao_locked.beneficiario = beneficiario_locked
+        requisicao_locked.setor_beneficiario = setor_beneficiario_locked
+        requisicao_locked.observacao = observacao
+        requisicao_locked.full_clean()
+        requisicao_locked.save(
             update_fields=[
                 "beneficiario",
                 "setor_beneficiario",
@@ -594,12 +616,12 @@ def atualizar_rascunho_requisicao(
             ]
         )
 
-        requisicao.itens.all().delete()
+        requisicao_locked.itens.all().delete()
         materiais_por_id = {material.pk: material for material in materiais}
         ItemRequisicao.objects.bulk_create(
             [
                 ItemRequisicao(
-                    requisicao=requisicao,
+                    requisicao=requisicao_locked,
                     material=materiais_por_id[item.material_id],
                     unidade_medida=materiais_por_id[item.material_id].unidade_medida,
                     quantidade_solicitada=item.quantidade_solicitada,
@@ -616,7 +638,7 @@ def atualizar_rascunho_requisicao(
             "setor_beneficiario",
         )
         .prefetch_related("itens__material", "eventos__usuario")
-        .get(pk=requisicao.pk)
+        .get(pk=requisicao_id)
     )
 
 

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -549,8 +549,6 @@ def atualizar_rascunho_requisicao(
     observacao: str,
     itens: list[ItemRascunhoData],
 ) -> Requisicao:
-    materiais = _validar_itens_rascunho(itens)
-
     with transaction.atomic():
         try:
             requisicao_locked = (
@@ -602,6 +600,8 @@ def atualizar_rascunho_requisicao(
             raise PermissionDenied(
                 "Usuário sem permissão para criar requisição para este beneficiário."
             )
+
+        materiais = _validar_itens_rascunho(itens)
 
         requisicao_locked.beneficiario = beneficiario_locked
         requisicao_locked.setor_beneficiario = setor_beneficiario_locked

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -548,13 +548,8 @@ def atualizar_rascunho_requisicao(
     observacao: str,
     itens: list[ItemRascunhoData],
 ) -> Requisicao:
-    if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador ou beneficiário podem editar a requisição.")
-
     if beneficiario.setor_id is None:
-        raise ValidationError(
-            {"beneficiario_id": ["Beneficiário deve possuir setor para criar a requisição."]}
-        )
+        raise ValidationError({"beneficiario_id": ["Beneficiário deve possuir setor válido."]})
 
     if not beneficiario.setor.is_active:
         raise DomainConflict(
@@ -571,6 +566,9 @@ def atualizar_rascunho_requisicao(
             .prefetch_related("itens__material", "eventos__usuario")
             .get(pk=requisicao.pk)
         )
+
+        if not pode_manipular_pre_autorizacao(ator, requisicao):
+            raise PermissionDenied("Apenas criador ou beneficiário podem editar a requisição.")
 
         if requisicao.status != StatusRequisicao.RASCUNHO:
             raise DomainConflict(

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -540,6 +540,88 @@ def criar_rascunho_requisicao(
     )
 
 
+def atualizar_rascunho_requisicao(
+    *,
+    requisicao: Requisicao,
+    ator: User,
+    beneficiario: User,
+    observacao: str,
+    itens: list[ItemRascunhoData],
+) -> Requisicao:
+    if not pode_manipular_pre_autorizacao(ator, requisicao):
+        raise PermissionDenied("Apenas criador ou beneficiário podem editar a requisição.")
+
+    if beneficiario.setor_id is None:
+        raise ValidationError(
+            {"beneficiario_id": ["Beneficiário deve possuir setor para criar a requisição."]}
+        )
+
+    if not beneficiario.setor.is_active:
+        raise DomainConflict(
+            "Setor do beneficiário está inativo.",
+            details={"beneficiario_id": f"Setor '{beneficiario.setor.nome}' está inativo."},
+        )
+
+    materiais = _validar_itens_rascunho(itens)
+
+    with transaction.atomic():
+        requisicao = (
+            Requisicao.objects.select_for_update()
+            .select_related("criador", "beneficiario", "setor_beneficiario")
+            .prefetch_related("itens__material", "eventos__usuario")
+            .get(pk=requisicao.pk)
+        )
+
+        if requisicao.status != StatusRequisicao.RASCUNHO:
+            raise DomainConflict(
+                "Somente requisições em rascunho podem ser editadas.",
+                details={"status_atual": requisicao.status},
+            )
+
+        if not pode_criar_requisicao_para(ator, beneficiario):
+            raise PermissionDenied(
+                "Usuário sem permissão para criar requisição para este beneficiário."
+            )
+
+        requisicao.beneficiario = beneficiario
+        requisicao.setor_beneficiario = beneficiario.setor
+        requisicao.observacao = observacao
+        requisicao.full_clean()
+        requisicao.save(
+            update_fields=[
+                "beneficiario",
+                "setor_beneficiario",
+                "observacao",
+                "updated_at",
+            ]
+        )
+
+        requisicao.itens.all().delete()
+        materiais_por_id = {material.pk: material for material in materiais}
+        ItemRequisicao.objects.bulk_create(
+            [
+                ItemRequisicao(
+                    requisicao=requisicao,
+                    material=materiais_por_id[item.material_id],
+                    unidade_medida=materiais_por_id[item.material_id].unidade_medida,
+                    quantidade_solicitada=item.quantidade_solicitada,
+                    observacao=item.observacao,
+                )
+                for item in itens
+            ]
+        )
+
+    return (
+        Requisicao.objects.select_related(
+            "criador",
+            "beneficiario",
+            "setor_beneficiario",
+        )
+        .prefetch_related("itens__material", "eventos__usuario")
+        .get(pk=requisicao.pk)
+    )
+
+
 def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
     if not pode_manipular_pre_autorizacao(ator, requisicao):
         raise PermissionDenied("Apenas criador ou beneficiário podem enviar a requisição.")

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -31,6 +31,7 @@ from apps.requisitions.services import (
     ItemAutorizacaoData,
     ItemRascunhoData,
     atender_requisicao,
+    atualizar_rascunho_requisicao,
     autorizar_requisicao,
     cancelar_requisicao,
     criar_rascunho_requisicao,
@@ -172,6 +173,37 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
         )
         output = RequisicaoDetailOutputSerializer(requisicao)
         return Response(output.data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(
+        operation_id="requisitions_update_draft",
+        tags=["requisitions"],
+        request=RequisicaoCreateInputSerializer,
+        responses={
+            200: RequisicaoDetailOutputSerializer(),
+            400: ErrorResponseSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+            409: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["put"], url_path="draft")
+    def update_draft(self, request, pk=None):
+        serializer = RequisicaoCreateInputSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        beneficiario = get_object_or_404(
+            User.objects.select_related("setor"), pk=serializer.validated_data["beneficiario_id"]
+        )
+        requisicao = atualizar_rascunho_requisicao(
+            requisicao=self.get_object(),
+            ator=request.user,
+            beneficiario=beneficiario,
+            observacao=serializer.validated_data["observacao"],
+            itens=[
+                ItemRascunhoData(**item_data) for item_data in serializer.validated_data["itens"]
+            ],
+        )
+        return Response(RequisicaoDetailOutputSerializer(requisicao).data)
 
     @extend_schema(
         operation_id="requisitions_submit",

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -191,13 +191,10 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
         serializer = RequisicaoCreateInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        beneficiario = get_object_or_404(
-            User.objects.select_related("setor"), pk=serializer.validated_data["beneficiario_id"]
-        )
         requisicao = atualizar_rascunho_requisicao(
-            requisicao=self.get_object(),
+            requisicao_id=int(pk),
             ator=request.user,
-            beneficiario=beneficiario,
+            beneficiario_id=serializer.validated_data["beneficiario_id"],
             observacao=serializer.validated_data["observacao"],
             itens=[
                 ItemRascunhoData(**item_data) for item_data in serializer.validated_data["itens"]

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -6,6 +6,7 @@ from drf_spectacular.openapi import OpenApiParameter
 from drf_spectacular.utils import extend_schema
 from rest_framework import filters, mixins, status
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -191,8 +192,13 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
         serializer = RequisicaoCreateInputSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
+        try:
+            requisicao_id = int(pk)
+        except (TypeError, ValueError) as exc:
+            raise ValidationError({"pk": ["Identificador de requisição inválido."]}) from exc
+
         requisicao = atualizar_rascunho_requisicao(
-            requisicao_id=int(pk),
+            requisicao_id=requisicao_id,
             ator=request.user,
             beneficiario_id=serializer.validated_data["beneficiario_id"],
             observacao=serializer.validated_data["observacao"],

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -505,6 +505,149 @@ class TestRequisicaoAPI:
             tipo_evento=TipoEvento.RETORNO_RASCUNHO,
         ).exists()
 
+    def test_update_draft_substitui_beneficiario_observacao_e_itens(self):
+        setor = self._criar_setor("Patio", "900091")
+        criador = self._criar_usuario(
+            "100101",
+            "Criador Patio",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor,
+        )
+        beneficiario_inicial = self._criar_usuario("100102", "Beneficiario Inicial", setor=setor)
+        beneficiario_novo = self._criar_usuario("100103", "Beneficiario Novo", setor=setor)
+        material_antigo = self._criar_material_com_estoque("001.001.071")
+        material_atualizado = self._criar_material_com_estoque("001.001.072")
+        material_novo = self._criar_material_com_estoque("001.001.073")
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario_inicial,
+            observacao="Observacao antiga",
+        )
+        item_antigo = requisicao.itens.create(
+            material=material_antigo,
+            unidade_medida=material_antigo.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+            observacao="Item antigo",
+        )
+        requisicao.itens.create(
+            material=material_atualizado,
+            unidade_medida=material_atualizado.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            observacao="Item manter",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=criador)
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            {
+                "beneficiario_id": beneficiario_novo.id,
+                "observacao": "Observacao nova",
+                "itens": [
+                    {
+                        "material_id": material_atualizado.id,
+                        "quantidade_solicitada": "5.000",
+                        "observacao": "Item atualizado",
+                    },
+                    {
+                        "material_id": material_novo.id,
+                        "quantidade_solicitada": "3.000",
+                        "observacao": "Item novo",
+                    },
+                ],
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.RASCUNHO
+        assert response.data["beneficiario"]["id"] == beneficiario_novo.id
+        assert response.data["observacao"] == "Observacao nova"
+        assert len(response.data["itens"]) == 2
+        assert {
+            (
+                item["material"]["id"],
+                item["quantidade_solicitada"],
+                item["observacao"],
+            )
+            for item in response.data["itens"]
+        } == {
+            (material_atualizado.id, "5.000", "Item atualizado"),
+            (material_novo.id, "3.000", "Item novo"),
+        }
+
+        requisicao.refresh_from_db()
+        assert requisicao.beneficiario_id == beneficiario_novo.id
+        assert requisicao.setor_beneficiario_id == beneficiario_novo.setor_id
+        assert requisicao.observacao == "Observacao nova"
+        assert not requisicao.itens.filter(id=item_antigo.id).exists()
+        assert {
+            (
+                item.material_id,
+                item.quantidade_solicitada,
+                item.observacao,
+            )
+            for item in requisicao.itens.all()
+        } == {
+            (material_atualizado.id, Decimal("5.000"), "Item atualizado"),
+            (material_novo.id, Decimal("3.000"), "Item novo"),
+        }
+
+    def test_update_draft_bloqueia_requisicao_fora_de_rascunho(self):
+        setor = self._criar_setor("Patio Status", "900092")
+        criador = self._criar_usuario(
+            "100111",
+            "Criador Patio Status",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor,
+        )
+        beneficiario = self._criar_usuario("100112", "Beneficiario Status", setor=setor)
+        material = self._criar_material_com_estoque("001.001.074")
+        requisicao = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000321",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=criador)
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 409
+        assert response.data["error"]["code"] == "domain_conflict"
+        assert response.data["error"]["details"]["status_atual"] == (
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        )
+
+    def test_update_draft_bloqueia_usuario_sem_permissao(self):
+        setor = self._criar_setor("Patio Permissao", "900093")
+        outro_setor = self._criar_setor("Outro Patio", "900094")
+        criador = self._criar_usuario("100121", "Criador", setor=setor)
+        beneficiario = self._criar_usuario("100122", "Beneficiario", setor=setor)
+        intruso = self._criar_usuario("100123", "Intruso", setor=outro_setor)
+        material = self._criar_material_com_estoque("001.001.075")
+        requisicao = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=intruso)
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 404
+
     def test_reenvio_preserva_numero_publico(self):
         setor = self._criar_setor("Frota", "90010")
         usuario = self._criar_usuario("10011", "Solicitante Frota", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -648,6 +648,34 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 404
 
+    def test_update_draft_bloqueia_chefe_almox_visivel_sem_permissao_contextual(self):
+        setor = self._criar_setor("Patio Permissao Contextual", "900096")
+        setor_almox = self._criar_setor(
+            "Almoxarifado",
+            "900097",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        criador = self._criar_usuario("100141", "Criador", setor=setor)
+        beneficiario = self._criar_usuario("100142", "Beneficiario", setor=setor)
+        chefe_almox = setor_almox.chefe_responsavel
+        material = self._criar_material_com_estoque("001.001.077")
+        requisicao = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_almox)
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"
+
     def test_update_draft_exige_autenticacao(self):
         setor = self._criar_setor("Patio Auth", "900095")
         usuario = self._criar_usuario("100131", "Usuario Auth", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -648,6 +648,26 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 404
 
+    def test_update_draft_exige_autenticacao(self):
+        setor = self._criar_setor("Patio Auth", "900095")
+        usuario = self._criar_usuario("100131", "Usuario Auth", setor=setor)
+        material = self._criar_material_com_estoque("001.001.076")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+        )
+
+        client = APIClient()
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            self._payload_requisicao(beneficiario_id=usuario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
+
     def test_reenvio_preserva_numero_publico(self):
         setor = self._criar_setor("Frota", "90010")
         usuario = self._criar_usuario("10011", "Solicitante Frota", setor=setor)

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -696,6 +696,25 @@ class TestRequisicaoAPI:
         assert response.status_code == 403
         assert response.data["error"]["code"] == "not_authenticated"
 
+    def test_update_draft_rejeita_pk_invalido_com_envelope_padrao(self):
+        setor = self._criar_setor("Patio PK", "900095A")
+        usuario = self._criar_usuario("100131A", "Usuario PK", setor=setor)
+        material = self._criar_material_com_estoque("001.001.176")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.put(
+            reverse("requisicao-update-draft", args=["abc"]),
+            self._payload_requisicao(beneficiario_id=usuario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert response.data["error"]["code"] == "validation_error"
+        assert response.data["error"]["details"] == {
+            "pk": ["Identificador de requisição inválido."]
+        }
+
     def test_reenvio_preserva_numero_publico(self):
         setor = self._criar_setor("Frota", "90010")
         usuario = self._criar_usuario("10011", "Solicitante Frota", setor=setor)

--- a/tests/requisitions/test_models.py
+++ b/tests/requisitions/test_models.py
@@ -166,6 +166,21 @@ class TestRequisicaoModel:
         req.refresh_from_db()
         assert req.setor_beneficiario == outro_setor
 
+    def test_rascunho_rejeita_snapshot_inconsistente_com_setor_do_beneficiario(self):
+        """REQ-domain — rascunho não aceita beneficiário/setor_beneficiario desencontrados"""
+        req = self._criar_requisicao()
+        outro_setor = self._criar_setor(nome="Setor Inconsistente", matricula_chefe="9912")
+        novo_beneficiario = self._criar_usuario(
+            matricula="1006",
+            nome="Beneficiario Inconsistente",
+            setor=outro_setor,
+        )
+
+        req.beneficiario = novo_beneficiario
+
+        with pytest.raises(ValidationError):
+            req.save(update_fields=["beneficiario"])
+
     def test_setor_beneficiario_nao_pode_ser_alterado_fora_de_rascunho(self):
         """REQ-domain — snapshot de setor segue imutável após sair de rascunho"""
         req = self._criar_requisicao()

--- a/tests/requisitions/test_models.py
+++ b/tests/requisitions/test_models.py
@@ -122,20 +122,55 @@ class TestRequisicaoModel:
 
         assert req.setor_beneficiario == beneficiario.setor
 
-    def test_beneficiario_nao_pode_ser_alterado_apos_criacao(self):
-        """REQ-domain — beneficiário é imutável após a criação"""
+    def test_beneficiario_pode_ser_alterado_enquanto_rascunho(self):
+        """REQ-domain — beneficiário pode mudar enquanto a requisição segue em rascunho"""
         req = self._criar_requisicao()
         novo_beneficiario = self._criar_usuario(matricula="1003", nome="Carlos")
 
         req.beneficiario = novo_beneficiario
+        req.setor_beneficiario = novo_beneficiario.setor
+
+        req.save(update_fields=["beneficiario", "setor_beneficiario"])
+
+        req.refresh_from_db()
+        assert req.beneficiario == novo_beneficiario
+        assert req.setor_beneficiario == novo_beneficiario.setor
+
+    def test_beneficiario_nao_pode_ser_alterado_fora_de_rascunho(self):
+        """REQ-domain — beneficiário volta a ser imutável após sair de rascunho"""
+        req = self._criar_requisicao()
+        self._marcar_primeiro_envio(req)
+        novo_beneficiario = self._criar_usuario(matricula="1004", nome="Carlos")
+
+        req.beneficiario = novo_beneficiario
+        req.setor_beneficiario = novo_beneficiario.setor
 
         with pytest.raises(ValidationError):
-            req.save(update_fields=["beneficiario"])
+            req.save(update_fields=["beneficiario", "setor_beneficiario"])
 
-    def test_setor_beneficiario_nao_pode_ser_alterado_apos_criacao(self):
-        """REQ-domain — snapshot de setor é imutável após a criação"""
+    def test_setor_beneficiario_pode_ser_alterado_enquanto_rascunho(self):
+        """REQ-domain — snapshot de setor acompanha troca de beneficiário em rascunho"""
         req = self._criar_requisicao()
         outro_setor = self._criar_setor(nome="Setor Alternativo", matricula_chefe="9910")
+        novo_beneficiario = self._criar_usuario(
+            matricula="1005",
+            nome="Beneficiario Alternativo",
+            setor=outro_setor,
+        )
+
+        req.beneficiario = novo_beneficiario
+        req.setor_beneficiario = outro_setor
+
+        req.save(update_fields=["beneficiario", "setor_beneficiario"])
+
+        req.refresh_from_db()
+        assert req.setor_beneficiario == outro_setor
+
+    def test_setor_beneficiario_nao_pode_ser_alterado_fora_de_rascunho(self):
+        """REQ-domain — snapshot de setor segue imutável após sair de rascunho"""
+        req = self._criar_requisicao()
+        self._marcar_primeiro_envio(req)
+        outro_setor = self._criar_setor(nome="Setor Alternativo 2", matricula_chefe="9911")
 
         req.setor_beneficiario = outro_setor
 

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -140,6 +140,7 @@ class TestOpenAPISchema:
         assert "/api/v1/materials/{id}/" in paths
         assert "/api/v1/requisitions/" in paths
         assert "/api/v1/requisitions/{id}/" in paths
+        assert "/api/v1/requisitions/{id}/draft/" in paths
         assert "/api/v1/requisitions/{id}/submit/" in paths
         assert "/api/v1/requisitions/{id}/return-to-draft/" in paths
         assert "/api/v1/requisitions/{id}/discard/" in paths
@@ -291,6 +292,13 @@ class TestOpenAPISchema:
                 "request_body": True,
                 "request_ref": "#/components/schemas/RequisicaoCreateInput",
                 "success_codes": {"201"},
+                "success_ref": "#/components/schemas/RequisicaoDetailOutput",
+                "error_codes": {"400", "403", "404", "409"},
+            },
+            ("/api/v1/requisitions/{id}/draft/", "put"): {
+                "request_body": True,
+                "request_ref": "#/components/schemas/RequisicaoCreateInput",
+                "success_codes": {"200"},
                 "success_ref": "#/components/schemas/RequisicaoDetailOutput",
                 "error_codes": {"400", "403", "404", "409"},
             },


### PR DESCRIPTION
# Contexto

## O que este PR faz
- adiciona endpoint explícito `PUT /api/v1/requisitions/{id}/draft/` para atualizar rascunho existente
- aplica atualização por substituição completa de beneficiário, observação e itens
- mantém bloqueio da operação fora de `rascunho` e documenta o contrato no OpenAPI
- ajusta invariantes do model para permitir troca de beneficiário/setor apenas enquanto a requisição persistida segue em rascunho

## Por que esta mudança é necessária
A SPA do piloto precisa reutilizar a mesma tela para criar e editar rascunhos sem microações por item. A issue #34 pede uma operação explícita de update completo, com coerência entre itens removidos, alterados e adicionados.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [x] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Permitir troca de beneficiário em rascunho sem abrir brecha para alteração após formalização da requisição.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: edição continua restrita ao escopo visível e a troca de beneficiário segue a política `pode_criar_requisicao_para`
- dados / migration / constraints: snapshot de beneficiário/setor agora é mutável apenas em `rascunho`; após sair de rascunho segue imutável

---

# Testes e validação

## Cenários validados

1. update válido substitui beneficiário, observação e lista de itens do rascunho
2. update fora de `rascunho` retorna `409 domain_conflict`
3. OpenAPI expõe a nova rota e o contrato de request/response

## Como validar manualmente
1. Criar requisição em rascunho via API.
2. Chamar `PUT /api/v1/requisitions/{id}/draft/` com novo `beneficiario_id`, nova `observacao` e nova lista completa de itens.
3. Confirmar no detalhe que itens removidos sumiram, itens novos foram criados e status continua `rascunho`.
4. Repetir o `PUT` com a requisição já enviada para autorização e confirmar `409 domain_conflict`.

## Payloads / exemplos de uso

```json
{
  "beneficiario_id": 42,
  "observacao": "Atualizacao completa do rascunho",
  "itens": [
    {
      "material_id": 10,
      "quantidade_solicitada": "5.000",
      "observacao": "Item atualizado"
    },
    {
      "material_id": 11,
      "quantidade_solicitada": "3.000",
      "observacao": "Item novo"
    }
  ]
}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR: Endpoint explícito para atualização de rascunhos

### Objetivo da mudança
- Adiciona endpoint `PUT /api/v1/requisitions/{id}/draft/` para permitir que a SPA do piloto edite rascunhos com operação única de substituição completa de beneficiário, observação e itens (sem necessidade de microações por item).

### Apps Django impactados
- `apps/requisitions/models.py`: Ajusta validação de snapshot para permitir troca de `beneficiario_id` e `setor_beneficiario_id` apenas enquanto `status == RASCUNHO`; adiciona validação de coerência entre `beneficiario.setor_id` e `setor_beneficiario_id` durante edição em rascunho.
- `apps/requisitions/services.py`: Nova função `atualizar_rascunho_requisicao()` com lógica de transação.
- `apps/requisitions/views.py`: Novo endpoint `@action` `update_draft` com método `PUT`.
- `tests/requisitions/test_models.py`: Reescrita de testes para refletir imutabilidade apenas após formalização (não após criação).
- `tests/requisitions/test_api.py`: 5 novos testes (sucesso, bloqueio fora RASCUNHO, permissão, autenticação).
- `tests/test_api_schema.py`: Adição de schema OpenAPI para o novo endpoint.

### Risco funcional
- **Alto risco de perda de auditoria**: Atualização não cria eventos/registros de mudança. Apenas `updated_at` é registrado via `auto_now`. Deleção de itens não deixa rastro de "foi removido" vs "nunca existiu".
- **Troca ilimitada de beneficiário em rascunho**: Permite reatribuição completa enquanto RASCUNHO (design intencional para pilotos, mas sem limite de edições).

### Impacto em regras de negócio
- **Permite edição de beneficiário/setor apenas em RASCUNHO**: Requisições formalizadas não permitem alteração (validação adicionada em `Requisicao.save()`).
- **Substituição completa de itens**: Itens são deletados em massa e recriados via `bulk_create`, sem rastreabilidade individual.
- **Snapshot manual de setor**: `setor_beneficiario_id` é copiado de `beneficiario.setor_id` em cada edição e validado para consistência.

### Impacto em autenticação, autorização e escopo por setor/perfil
- **Autorização contextual preservada**: Valida `pode_visualizar_requisicao()` (escopo de setor), `pode_manipular_pre_autorizacao()` (apenas criador ou beneficiário), e `pode_criar_requisicao_para()` (permissão para setor do beneficiário).
- **Bloqueio de acesso cross-setor**: Não autenticados e usuários sem visibilidade retornam `404` ou `403 permission_denied`.
- **Validação de setor ativo**: Rejeita com `409 domain_conflict` se setor do beneficiário está inativo.

### Impacto em contratos DRF, serializers e OpenAPI
- **Reutilização de serializers**: Usa `RequisicaoCreateInputSerializer` para validação (mesmo da criação).
- **Response**: Retorna `RequisicaoDetailOutputSerializer` (estado completo da requisição atualizada).
- **OpenAPI**: Novo endpoint documentado como `PUT /api/v1/requisitions/{id}/draft/` com request `RequisicaoCreateInput`, response `200 RequisicaoDetailOutput`, e erros `400/403/404/409`.

### Impacto em integridade de dados, constraints e snapshots históricos
- **Snapshots mantidos**: `setor_beneficiario_id` continua sendo snapshot (nunca recalculado após formalização).
- **Validação de coerência adicionada**: Se beneficiário é alterado em RASCUNHO, `setor_beneficiario_id` deve bater com `beneficiario.setor_id`, senão dispara `ValidationError`.
- **Sem eventos de auditoria**: Diferente de outras transições, atualização de rascunho não cria registros de evento (apenas `updated_at` automático).
- **Integridade de itens**: Valida duplicação de material, existência e validade (via `_validar_itens_rascunho()`).

### Impacto em transações e concorrência
- **Transaction.atomic() bem estruturado**: Usa 4 níveis de `select_for_update()` (Requisicao, User/beneficiario, Setor, ItemRequisicao), prevenindo race conditions.
- **Recarregamento final**: Requisição é recarregada ao término com `select_related`/`prefetch_related` adequados.
- **Bulk delete/create**: `requisicao.itens.all().delete()` + `ItemRequisicao.objects.bulk_create()` são operações atômicas na transação.

### Impacto em importação SCPI, dados oficiais e saldos
- **Sem impacto em estoque**: Atualização é pré-formalização; não toca saldos físico/reservado.

### Impacto em configuração, CI, dependências, lint e ambiente
- **Sem impacto**: Nenhuma migration versionada, nenhuma dependência nova, nenhuma mudança de CI.

### Validação manual via API
1. Criar rascunho via `POST /api/v1/requisitions/` com beneficiário A e item X.
2. Chamar `PUT /api/v1/requisitions/{id}/draft/` com beneficiário B, observação alterada, itens [Y, Z] (removendo X).
3. Verificar que resposta `200` retorna requisição com novo beneficiário, observação, e itens Y/Z (X desapareceu).
4. Chamar novamente com requisição fora RASCUNHO (após envio para autorização): deve retornar `409 domain_conflict` com `status_atual`.
5. Usuário sem permissão para editar: retorna `404` (intruso) ou `403 permission_denied` (sem visibilidade/escopo).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->