### PR TITLE
[codex] Frontend piloto: login e bootstrap de sessão na SPA

### DIFF
--- a/.serena/memories/WMS-SAEP/pr51/frontend-scaffold-technical-debt.md
+++ b/.serena/memories/WMS-SAEP/pr51/frontend-scaffold-technical-debt.md
@@ -3,9 +3,10 @@
 Context: PR #51 delivered the pilot SPA foundation in `frontend/`, integrated the Makefile entrypoints, exported the OpenAPI contract for the frontend client, and left the repository ready for the first operational frontend slices.
 
 Residual debt / follow-up:
-- Frontend authentication is still scaffold-only. `/login` remains a placeholder, there is no session bootstrap from `GET /api/v1/auth/me/`, and route guards/home-by-role resolution are not implemented yet. This is the next mandatory slice before any protected operational flow is treated as real UI.
+- Frontend authentication debt is resolved by issue #37: `/login` authenticates with matricula/password through session Django + CSRF, `/auth/me` bootstraps protected routes, `/` resolves home by `papel`, and logout clears session cache.
 - The repository still lacks the initial frontend CI workflow. The next CI slice should run at least the generated-artifact and frontend quality gates: `pnpm tsr generate` with drift detection for `frontend/src/routeTree.gen.ts`, `frontend-gen-api`/OpenAPI drift protection, lint, typecheck, unit smoke tests, and the Playwright smoke test.
-- The `features/` tree now exists only as scaffold directories. Keep domain logic out of `shared/` and avoid expanding placeholder route files with real business behavior; move each real slice into `src/features/{auth,materials,requisitions,approvals,fulfillment}/` as soon as implementation starts.
+- New debt from #37: official `rtk make frontend-test` can still try `frontend-init` via `npx pnpm@10.15.1`; in no-network environments use local `frontend/node_modules/.bin/*` for verification or run the official init first.
+- The `features/` tree now has real `features/auth` behavior. Keep future domain behavior in `src/features/{materials,requisitions,approvals,fulfillment}/` and avoid growing placeholders in `routes/`/`shared/`.
 
 Validation snapshot after review hardening:
 - `pytest tests/test_api_schema.py tests/users/test_auth_api.py -q` passed with 35 tests.

--- a/.serena/memories/frontend/pilot_architecture_and_block0.md
+++ b/.serena/memories/frontend/pilot_architecture_and_block0.md
@@ -76,4 +76,5 @@ Recorded from the 2026-05-02 architecture session.
 - Delivered base includes Vite, React, TypeScript, TanStack Router file-based routing, TanStack Query provider, Tailwind CSS baseline, `openapi-fetch` client, Vitest smoke tests, and Playwright smoke E2E.
 - Official repo entrypoints are `rtk make frontend-init`, `frontend-gen-api`, `frontend-dev`, `frontend-build`, `frontend-lint`, `frontend-test`, and `frontend-e2e`.
 - `frontend/openapi/schema.json`, `frontend/src/shared/api/schema.d.ts`, and `frontend/src/routeTree.gen.ts` are generated artifacts and should not be edited manually.
-- Next frontend slices move to `#37` login/bootstrap, `#42` initial frontend CI, then operational worklists and draft/detail flows.
+- Issue `#37` login/bootstrap is now implemented: `/login` performs Django session + CSRF auth, protected routes bootstrap via `GET /api/v1/auth/me/`, `/` resolves home by operational `papel`, shell shows current user, and logout clears session cache.
+- Next frontend slices move to `#42` initial frontend CI, then `#38` minhas requisicoes + canonical detail, then draft/detail operational flows.

--- a/docs/backlog/backlog-tecnico-piloto.md
+++ b/docs/backlog/backlog-tecnico-piloto.md
@@ -1246,6 +1246,8 @@ Débito técnico residual do scaffold frontend:
 - O repositório ainda não tem a primeira fatia de CI do frontend. Ela deve validar artefatos gerados (`frontend/src/routeTree.gen.ts` e OpenAPI/types), lint, typecheck, smoke tests e Playwright.
 - A árvore `src/features/` começou a receber comportamento real por `features/auth`, mas as próximas fatias ainda devem evitar crescimento permanente de placeholders em `routes/`/`shared/`.
 - `frontend-gen-api`/`frontend-test` ainda depende de `frontend-init` via `npx pnpm@10.15.1`; em ambiente sem rede, use os binários locais em `frontend/node_modules/.bin` ou conclua a instalação oficial antes dos checks completos.
+- O E2E atual da SPA é smoke mockado para login/logout. Próximo degrau: E2E real com backend e seed mínima quando a infra estiver estável.
+- `/unknown-role` é fallback defensivo para papel não mapeado, não fluxo de negócio. Se aparecer em uso real, tratar como desalinhamento de contrato/cadastro/OpenAPI.
 
 Próxima fatia recomendada:
 

--- a/docs/backlog/backlog-tecnico-piloto.md
+++ b/docs/backlog/backlog-tecnico-piloto.md
@@ -1243,16 +1243,16 @@ Status do enablement do frontend: bloco 0 do backend concluído em código/contr
 
 Débito técnico residual do scaffold frontend:
 
-- `frontend/` ainda não executa autenticação real: `/login` segue placeholder, falta bootstrap de sessão via `GET /api/v1/auth/me/`, guards de rota e resolução de home por papel.
 - O repositório ainda não tem a primeira fatia de CI do frontend. Ela deve validar artefatos gerados (`frontend/src/routeTree.gen.ts` e OpenAPI/types), lint, typecheck, smoke tests e Playwright.
-- A árvore `src/features/` já foi criada, mas ainda sem módulos reais. As próximas fatias devem migrar comportamento de domínio para `features/` e evitar crescimento permanente de placeholders em `routes/`/`shared/`.
+- A árvore `src/features/` começou a receber comportamento real por `features/auth`, mas as próximas fatias ainda devem evitar crescimento permanente de placeholders em `routes/`/`shared/`.
+- `frontend-gen-api`/`frontend-test` ainda depende de `frontend-init` via `npx pnpm@10.15.1`; em ambiente sem rede, use os binários locais em `frontend/node_modules/.bin` ou conclua a instalação oficial antes dos checks completos.
 
 Próxima fatia recomendada:
 
-1. login/bootstrap da SPA;
-2. CI inicial do frontend;
-3. `Minhas requisições` + detalhe canônico;
-4. criação/edição de rascunho e envio.
+1. CI inicial do frontend;
+2. `Minhas requisições` + detalhe canônico;
+3. criação/edição de rascunho e envio;
+4. filas de autorização e atendimento.
 
 Depois disso, a próxima frente segue para as filas operacionais e a timeline básica da requisição. `PIL-DOC-IMP-001`, `PIL-DOC-IMP-002` e `PIL-DOC-IMP-003` continuam relevantes, mas deixam de ser a próxima prioridade imediata do backlog ativo.
 

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -186,6 +186,13 @@ Regras complementares:
 7. `Fila de atendimento` + atendimento total/parcial + cancelamento operacional permitido
 8. Notificações como segunda onda
 
+Estado atual após a fatia #37:
+
+- bloco 0 de backend concluído;
+- fundação `frontend/` concluída;
+- login real, bootstrap via `GET /api/v1/auth/me/`, guards, logout e home por papel implementados;
+- próxima fatia funcional da SPA deve partir de `Minhas requisições` e detalhe canônico.
+
 ## 10. Worklists e detalhe
 
 ### Minhas requisições

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -126,6 +126,7 @@ Rotas públicas da SPA:
 - `/requisicoes/:id`
 - `/autorizacoes`
 - `/atendimentos`
+- `/unknown-role`
 
 Regras:
 
@@ -141,6 +142,7 @@ Homes por papel:
 - `chefe_setor`: `Fila de autorizações`
 - `auxiliar_almoxarifado`: `Fila de atendimento`
 - `chefe_almoxarifado`: `Fila de atendimento`
+- papel desconhecido: página neutra `/unknown-role`, sem voltar para `/login`, para evitar loop e explicitar desalinhamento de contrato/cadastro.
 
 ## 8. Bloco 0 de APIs habilitadoras
 
@@ -190,7 +192,7 @@ Estado atual após a fatia #37:
 
 - bloco 0 de backend concluído;
 - fundação `frontend/` concluída;
-- login real, bootstrap via `GET /api/v1/auth/me/`, guards, logout e home por papel implementados;
+- login real, bootstrap via `GET /api/v1/auth/me/`, guards, logout com erro visível, home por papel e fallback `/unknown-role` implementados;
 - próxima fatia funcional da SPA deve partir de `Minhas requisições` e detalhe canônico.
 
 ## 10. Worklists e detalhe

--- a/frontend/src/app/layouts/app-shell.tsx
+++ b/frontend/src/app/layouts/app-shell.tsx
@@ -1,8 +1,20 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, Outlet, useLocation, useNavigate } from "@tanstack/react-router";
 
-import { authQueryKeys, logoutSession, meQueryOptions } from "../../features/auth/session";
+import { ApiError, authQueryKeys, logoutSession, meQueryOptions } from "../../features/auth/session";
 import { navigationItems } from "../../shared/config/navigation";
+
+function messageFromLogoutError(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.payload?.error.message || error.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Não foi possível sair. Tente novamente.";
+}
 
 export function AppShell() {
   const location = useLocation();
@@ -86,6 +98,11 @@ export function AppShell() {
                 >
                   {logoutMutation.isPending ? "Saindo..." : "Sair"}
                 </button>
+                {logoutMutation.isError ? (
+                  <p className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+                    {messageFromLogoutError(logoutMutation.error)}
+                  </p>
+                ) : null}
               </div>
             ) : (
               <>

--- a/frontend/src/app/layouts/app-shell.tsx
+++ b/frontend/src/app/layouts/app-shell.tsx
@@ -1,9 +1,23 @@
-import { Link, Outlet, useLocation } from "@tanstack/react-router";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, Outlet, useLocation, useNavigate } from "@tanstack/react-router";
 
+import { authQueryKeys, logoutSession, meQueryOptions } from "../../features/auth/session";
 import { navigationItems } from "../../shared/config/navigation";
 
 export function AppShell() {
   const location = useLocation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const sessionQuery = useQuery(meQueryOptions);
+  const session = sessionQuery.data;
+  const logoutMutation = useMutation({
+    mutationFn: logoutSession,
+    retry: false,
+    onSuccess: async () => {
+      queryClient.removeQueries({ queryKey: authQueryKeys.me });
+      await navigate({ to: "/login", search: { redirect: undefined } });
+    },
+  });
 
   return (
     <div className="min-h-screen bg-[var(--page-bg)] text-[var(--ink-strong)]">
@@ -48,14 +62,43 @@ export function AppShell() {
           </nav>
 
           <div className="border-t border-[var(--line-soft)] px-6 py-5">
-            <p className="text-xs uppercase tracking-[0.28em] text-[var(--ink-muted)]">
-              Bloco 0 consumido
-            </p>
-            <ul className="mt-3 space-y-2 text-sm text-[var(--ink-soft)]">
-              <li>`auth/csrf` `auth/login` `auth/logout` `auth/me`</li>
-              <li>`users/beneficiary-lookup`</li>
-              <li>`requisitions list/detail` + `draft update`</li>
-            </ul>
+            {session ? (
+              <div className="space-y-3">
+                <p className="text-xs uppercase tracking-[0.28em] text-[var(--ink-muted)]">
+                  Sessão atual
+                </p>
+                <div>
+                  <p className="text-sm font-semibold text-[var(--ink-strong)]">
+                    {session.nome_completo}
+                  </p>
+                  <p className="mt-1 text-xs uppercase tracking-[0.18em] text-[var(--ink-muted)]">
+                    {session.papel}
+                  </p>
+                  {session.setor ? (
+                    <p className="mt-2 text-sm text-[var(--ink-soft)]">{session.setor.nome}</p>
+                  ) : null}
+                </div>
+                <button
+                  className="preview-button w-full"
+                  disabled={logoutMutation.isPending}
+                  onClick={() => logoutMutation.mutate()}
+                  type="button"
+                >
+                  {logoutMutation.isPending ? "Saindo..." : "Sair"}
+                </button>
+              </div>
+            ) : (
+              <>
+                <p className="text-xs uppercase tracking-[0.28em] text-[var(--ink-muted)]">
+                  Bloco 0 consumido
+                </p>
+                <ul className="mt-3 space-y-2 text-sm text-[var(--ink-soft)]">
+                  <li>`auth/csrf` `auth/login` `auth/logout` `auth/me`</li>
+                  <li>`users/beneficiary-lookup`</li>
+                  <li>`requisitions list/detail` + `draft update`</li>
+                </ul>
+              </>
+            )}
           </div>
         </aside>
 

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,18 +1,12 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { type PropsWithChildren, useState } from "react";
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import { type PropsWithChildren } from "react";
 
-export function AppProviders({ children }: PropsWithChildren) {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            retry: 1,
-            refetchOnWindowFocus: false,
-          },
-        },
-      }),
-  );
+import { appQueryClient } from "./query-client";
 
+type AppProvidersProps = PropsWithChildren<{
+  queryClient?: QueryClient;
+}>;
+
+export function AppProviders({ children, queryClient = appQueryClient }: AppProvidersProps) {
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/frontend/src/app/query-client.ts
+++ b/frontend/src/app/query-client.ts
@@ -11,6 +11,7 @@ export function createAppQueryClient() {
             return false;
           }
 
+          // Pilot default: one retry for transient non-auth failures, no noisy loops.
           return failureCount < 1;
         },
         refetchOnWindowFocus: false,

--- a/frontend/src/app/query-client.ts
+++ b/frontend/src/app/query-client.ts
@@ -1,0 +1,22 @@
+import { QueryClient } from "@tanstack/react-query";
+
+import { isAuthError } from "../features/auth/session";
+
+export function createAppQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: (failureCount, error) => {
+          if (isAuthError(error)) {
+            return false;
+          }
+
+          return failureCount < 1;
+        },
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+}
+
+export const appQueryClient = createAppQueryClient();

--- a/frontend/src/app/router.tsx
+++ b/frontend/src/app/router.tsx
@@ -1,12 +1,16 @@
 import { createBrowserHistory, createRouter } from "@tanstack/react-router";
 
 import { routeTree } from "../routeTree.gen";
+import { appQueryClient } from "./query-client";
 
-export function buildRouter() {
+export function buildRouter({ queryClient = appQueryClient } = {}) {
   return createRouter({
     routeTree,
     defaultPreload: "intent",
     history: createBrowserHistory(),
+    context: {
+      queryClient,
+    },
   });
 }
 

--- a/frontend/src/features/auth/guards.ts
+++ b/frontend/src/features/auth/guards.ts
@@ -1,0 +1,29 @@
+import type { QueryClient } from "@tanstack/react-query";
+import { redirect } from "@tanstack/react-router";
+
+import { ApiError, authQueryKeys, meQueryOptions } from "./session";
+
+export async function requireSession({
+  queryClient,
+  locationHref,
+}: {
+  queryClient: QueryClient;
+  locationHref: string;
+}) {
+  try {
+    return await queryClient.ensureQueryData(meQueryOptions);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 401) {
+      queryClient.removeQueries({ queryKey: authQueryKeys.me });
+      // eslint-disable-next-line @typescript-eslint/only-throw-error
+      throw redirect({
+        to: "/login",
+        search: {
+          redirect: locationHref,
+        },
+      });
+    }
+
+    throw error;
+  }
+}

--- a/frontend/src/features/auth/guards.ts
+++ b/frontend/src/features/auth/guards.ts
@@ -1,7 +1,7 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { redirect } from "@tanstack/react-router";
 
-import { ApiError, authQueryKeys, meQueryOptions } from "./session";
+import { authQueryKeys, isAuthError, meQueryOptions } from "./session";
 
 export async function requireSession({
   queryClient,
@@ -13,7 +13,7 @@ export async function requireSession({
   try {
     return await queryClient.ensureQueryData(meQueryOptions);
   } catch (error) {
-    if (error instanceof ApiError && error.status === 401) {
+    if (isAuthError(error)) {
       queryClient.removeQueries({ queryKey: authQueryKeys.me });
       // eslint-disable-next-line @typescript-eslint/only-throw-error
       throw redirect({

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -1,0 +1,105 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { apiClient } from "../../shared/api/client";
+import type { components } from "../../shared/api/schema";
+
+export type AuthSession = components["schemas"]["AuthSessionOutput"];
+export type AuthLoginInput = components["schemas"]["AuthLoginInput"];
+export type ErrorResponse = components["schemas"]["ErrorResponse"];
+
+export type PapelOperacional =
+  | "solicitante"
+  | "auxiliar_setor"
+  | "chefe_setor"
+  | "auxiliar_almoxarifado"
+  | "chefe_almoxarifado";
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly payload?: ErrorResponse,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+export const authQueryKeys = {
+  me: ["auth", "me"] as const,
+};
+
+function messageFromError(error: ErrorResponse | undefined, fallback: string) {
+  return error?.error?.message || fallback;
+}
+
+export function isAuthError(error: unknown) {
+  return error instanceof ApiError && (error.status === 401 || error.status === 403);
+}
+
+export async function ensureCsrfCookie() {
+  const { data, response } = await apiClient.GET("/api/v1/auth/csrf/");
+
+  if (!data) {
+    throw new ApiError("Não foi possível preparar a sessão.", response.status);
+  }
+}
+
+export async function fetchCurrentSession() {
+  const { data, error, response } = await apiClient.GET("/api/v1/auth/me/");
+
+  if (error || !data) {
+    throw new ApiError(messageFromError(error, "Sessão expirada."), response.status, error);
+  }
+
+  return data;
+}
+
+export async function loginWithMatricula(input: AuthLoginInput) {
+  await ensureCsrfCookie();
+
+  const { data, error, response } = await apiClient.POST("/api/v1/auth/login/", {
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Matrícula funcional ou senha inválidas."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function logoutSession() {
+  await ensureCsrfCookie();
+
+  const { error, response } = await apiClient.POST("/api/v1/auth/logout/");
+
+  if (error) {
+    throw new ApiError(messageFromError(error, "Não foi possível encerrar a sessão."), response.status, error);
+  }
+}
+
+export const meQueryOptions = queryOptions({
+  queryKey: authQueryKeys.me,
+  queryFn: fetchCurrentSession,
+  retry: false,
+});
+
+export function homePathForPapel(papel: string) {
+  switch (papel as PapelOperacional) {
+    case "solicitante":
+    case "auxiliar_setor":
+      return "/minhas-requisicoes";
+    case "chefe_setor":
+      return "/autorizacoes";
+    case "auxiliar_almoxarifado":
+    case "chefe_almoxarifado":
+      return "/atendimentos";
+    default:
+      return "/login";
+  }
+}

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -14,6 +14,8 @@ export type PapelOperacional =
   | "auxiliar_almoxarifado"
   | "chefe_almoxarifado";
 
+export const UNKNOWN_ROLE_PATH = "/unknown-role";
+
 export class ApiError extends Error {
   constructor(
     message: string,
@@ -100,6 +102,6 @@ export function homePathForPapel(papel: string) {
     case "chefe_almoxarifado":
       return "/atendimentos";
     default:
-      return "/login";
+      return UNKNOWN_ROLE_PATH;
   }
 }

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -40,14 +40,20 @@ export function isAuthError(error: unknown) {
 }
 
 export async function ensureCsrfCookie() {
-  const { data, response } = await apiClient.GET("/api/v1/auth/csrf/");
+  const result = await apiClient.GET("/api/v1/auth/csrf/");
+  const error = result.error as ErrorResponse | undefined;
 
-  if (!data) {
-    throw new ApiError("Não foi possível preparar a sessão.", response.status);
+  if (error || !result.data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível preparar a sessão."),
+      result.response.status,
+      error,
+    );
   }
 }
 
 export async function fetchCurrentSession() {
+  // Contract: GET /auth/me/ bootstraps session state and does not require CSRF.
   const { data, error, response } = await apiClient.GET("/api/v1/auth/me/");
 
   if (error || !data) {

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as UnknownRoleRouteImport } from './routes/unknown-role'
 import { Route as MinhasRequisicoesRouteImport } from './routes/minhas-requisicoes'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as AutorizacoesRouteImport } from './routes/autorizacoes'
@@ -17,6 +18,11 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as RequisicoesNovaRouteImport } from './routes/requisicoes/nova'
 import { Route as RequisicoesIdRouteImport } from './routes/requisicoes/$id'
 
+const UnknownRoleRoute = UnknownRoleRouteImport.update({
+  id: '/unknown-role',
+  path: '/unknown-role',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MinhasRequisicoesRoute = MinhasRequisicoesRouteImport.update({
   id: '/minhas-requisicoes',
   path: '/minhas-requisicoes',
@@ -59,6 +65,7 @@ export interface FileRoutesByFullPath {
   '/autorizacoes': typeof AutorizacoesRoute
   '/login': typeof LoginRoute
   '/minhas-requisicoes': typeof MinhasRequisicoesRoute
+  '/unknown-role': typeof UnknownRoleRoute
   '/requisicoes/$id': typeof RequisicoesIdRoute
   '/requisicoes/nova': typeof RequisicoesNovaRoute
 }
@@ -68,6 +75,7 @@ export interface FileRoutesByTo {
   '/autorizacoes': typeof AutorizacoesRoute
   '/login': typeof LoginRoute
   '/minhas-requisicoes': typeof MinhasRequisicoesRoute
+  '/unknown-role': typeof UnknownRoleRoute
   '/requisicoes/$id': typeof RequisicoesIdRoute
   '/requisicoes/nova': typeof RequisicoesNovaRoute
 }
@@ -78,6 +86,7 @@ export interface FileRoutesById {
   '/autorizacoes': typeof AutorizacoesRoute
   '/login': typeof LoginRoute
   '/minhas-requisicoes': typeof MinhasRequisicoesRoute
+  '/unknown-role': typeof UnknownRoleRoute
   '/requisicoes/$id': typeof RequisicoesIdRoute
   '/requisicoes/nova': typeof RequisicoesNovaRoute
 }
@@ -89,6 +98,7 @@ export interface FileRouteTypes {
     | '/autorizacoes'
     | '/login'
     | '/minhas-requisicoes'
+    | '/unknown-role'
     | '/requisicoes/$id'
     | '/requisicoes/nova'
   fileRoutesByTo: FileRoutesByTo
@@ -98,6 +108,7 @@ export interface FileRouteTypes {
     | '/autorizacoes'
     | '/login'
     | '/minhas-requisicoes'
+    | '/unknown-role'
     | '/requisicoes/$id'
     | '/requisicoes/nova'
   id:
@@ -107,6 +118,7 @@ export interface FileRouteTypes {
     | '/autorizacoes'
     | '/login'
     | '/minhas-requisicoes'
+    | '/unknown-role'
     | '/requisicoes/$id'
     | '/requisicoes/nova'
   fileRoutesById: FileRoutesById
@@ -117,12 +129,20 @@ export interface RootRouteChildren {
   AutorizacoesRoute: typeof AutorizacoesRoute
   LoginRoute: typeof LoginRoute
   MinhasRequisicoesRoute: typeof MinhasRequisicoesRoute
+  UnknownRoleRoute: typeof UnknownRoleRoute
   RequisicoesIdRoute: typeof RequisicoesIdRoute
   RequisicoesNovaRoute: typeof RequisicoesNovaRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/unknown-role': {
+      id: '/unknown-role'
+      path: '/unknown-role'
+      fullPath: '/unknown-role'
+      preLoaderRoute: typeof UnknownRoleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/minhas-requisicoes': {
       id: '/minhas-requisicoes'
       path: '/minhas-requisicoes'
@@ -181,6 +201,7 @@ const rootRouteChildren: RootRouteChildren = {
   AutorizacoesRoute: AutorizacoesRoute,
   LoginRoute: LoginRoute,
   MinhasRequisicoesRoute: MinhasRequisicoesRoute,
+  UnknownRoleRoute: UnknownRoleRoute,
   RequisicoesIdRoute: RequisicoesIdRoute,
   RequisicoesNovaRoute: RequisicoesNovaRoute,
 }

--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,7 +1,12 @@
-import { createRootRoute } from "@tanstack/react-router";
+import type { QueryClient } from "@tanstack/react-query";
+import { createRootRouteWithContext } from "@tanstack/react-router";
 
 import { AppShell } from "../app/layouts/app-shell";
 
-export const Route = createRootRoute({
+type RouterContext = {
+  queryClient: QueryClient;
+};
+
+export const Route = createRootRouteWithContext<RouterContext>()({
   component: AppShell,
 });

--- a/frontend/src/routes/atendimentos.tsx
+++ b/frontend/src/routes/atendimentos.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { requireSession } from "../features/auth/guards";
 import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/atendimentos")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: AtendimentosPlaceholderPage,
 });
 

--- a/frontend/src/routes/autorizacoes.tsx
+++ b/frontend/src/routes/autorizacoes.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { requireSession } from "../features/auth/guards";
 import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/autorizacoes")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: AutorizacoesPlaceholderPage,
 });
 

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,8 +1,19 @@
-import { Link, createFileRoute } from "@tanstack/react-router";
+import { Link, createFileRoute, redirect } from "@tanstack/react-router";
 
+import { requireSession } from "../features/auth/guards";
+import { homePathForPapel } from "../features/auth/session";
 import { navigationItems } from "../shared/config/navigation";
 
 export const Route = createFileRoute("/")({
+  beforeLoad: async ({ context, location }) => {
+    const session = await requireSession({
+      queryClient: context.queryClient,
+      locationHref: location.href,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/only-throw-error
+    throw redirect({ to: homePathForPapel(session.papel) });
+  },
   component: HomePage,
 });
 

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -47,6 +47,7 @@ function LoginPage() {
     retry: false,
     onSuccess: async (session) => {
       queryClient.setQueryData(authQueryKeys.me, session);
+      // Trusted redirects win; otherwise fall back to the papel-derived home, including /unknown-role.
       await navigate({
         href: safeInternalRedirectPath(redirect) ?? homePathForPapel(session.papel),
         search: { redirect: undefined },

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -22,6 +22,8 @@ function safeInternalRedirectPath(redirect: string | undefined) {
       return undefined;
     }
 
+    url.searchParams.delete("redirect");
+
     return `${url.pathname}${url.search}${url.hash}`;
   } catch {
     return undefined;

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -10,6 +10,24 @@ import {
 } from "../features/auth/session";
 import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
 
+function safeInternalRedirectPath(redirect: string | undefined) {
+  if (!redirect || redirect.startsWith("//")) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(redirect, window.location.origin);
+
+    if (url.origin !== window.location.origin || !url.pathname.startsWith("/")) {
+      return undefined;
+    }
+
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return undefined;
+  }
+}
+
 export const Route = createFileRoute("/login")({
   validateSearch: (search) => ({
     redirect: typeof search.redirect === "string" ? search.redirect : undefined,
@@ -29,12 +47,10 @@ function LoginPage() {
     retry: false,
     onSuccess: async (session) => {
       queryClient.setQueryData(authQueryKeys.me, session);
-      if (redirect) {
-        await navigate({ href: redirect, search: { redirect: undefined } });
-        return;
-      }
-
-      await navigate({ to: homePathForPapel(session.papel), search: {} });
+      await navigate({
+        href: safeInternalRedirectPath(redirect) ?? homePathForPapel(session.papel),
+        search: { redirect: undefined },
+      });
     },
     onError: (error) => {
       if (error instanceof ApiError) {
@@ -83,6 +99,7 @@ function LoginPage() {
             Matrícula funcional
             <input
               className="preview-input"
+              autoComplete="username"
               name="matricula_funcional"
               onChange={(event) => setMatriculaFuncional(event.target.value)}
               required
@@ -93,6 +110,7 @@ function LoginPage() {
             Senha
             <input
               className="preview-input"
+              autoComplete="current-password"
               name="password"
               onChange={(event) => setPassword(event.target.value)}
               required

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -1,18 +1,66 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
 
+import {
+  ApiError,
+  authQueryKeys,
+  homePathForPapel,
+  loginWithMatricula,
+} from "../features/auth/session";
 import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/login")({
-  component: LoginPlaceholderPage,
+  validateSearch: (search) => ({
+    redirect: typeof search.redirect === "string" ? search.redirect : undefined,
+  }),
+  component: LoginPage,
 });
 
-function LoginPlaceholderPage() {
+function LoginPage() {
+  const queryClient = useQueryClient();
+  const navigate = Route.useNavigate();
+  const { redirect } = Route.useSearch();
+  const [matriculaFuncional, setMatriculaFuncional] = useState("");
+  const [password, setPassword] = useState("");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const loginMutation = useMutation({
+    mutationFn: loginWithMatricula,
+    retry: false,
+    onSuccess: async (session) => {
+      queryClient.setQueryData(authQueryKeys.me, session);
+      if (redirect) {
+        await navigate({ href: redirect, search: { redirect: undefined } });
+        return;
+      }
+
+      await navigate({ to: homePathForPapel(session.papel), search: {} });
+    },
+    onError: (error) => {
+      if (error instanceof ApiError) {
+        setErrorMessage(error.payload?.error.message || error.message);
+        return;
+      }
+
+      setErrorMessage("Não foi possível entrar. Tente novamente.");
+    },
+  });
+
+  function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setErrorMessage(null);
+    loginMutation.mutate({
+      matricula_funcional: matriculaFuncional,
+      password,
+    });
+  }
+
   return (
     <FeaturePlaceholder
       kicker="Auth shell"
       title="Entrar no piloto"
-      summary="Tela-base pronta para receber fluxo de sessão Django + CSRF. Nesta fatia, o formulário ainda não autentica nem resolve home por papel."
-      nextSlice="#37 — login e bootstrap de sessão"
+      summary="Autenticação por sessão Django + CSRF. A matrícula funcional identifica o usuário e o papel operacional principal define a home inicial."
+      nextSlice="#37 — login e bootstrap de sessão em execução"
       contracts={[
         "GET /api/v1/auth/csrf/",
         "POST /api/v1/auth/login/",
@@ -25,19 +73,37 @@ function LoginPlaceholderPage() {
         "Tratar sessão expirada com retorno previsível para /login.",
       ]}
       preview={
-        <div className="preview-panel space-y-4">
+        <form className="preview-panel space-y-4" onSubmit={handleSubmit}>
+          {errorMessage ? (
+            <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+              {errorMessage}
+            </div>
+          ) : null}
           <label className="preview-label">
             Matrícula funcional
-            <input className="preview-input" disabled value="91003" />
+            <input
+              className="preview-input"
+              name="matricula_funcional"
+              onChange={(event) => setMatriculaFuncional(event.target.value)}
+              required
+              value={matriculaFuncional}
+            />
           </label>
           <label className="preview-label">
             Senha
-            <input className="preview-input" disabled type="password" value="123456" />
+            <input
+              className="preview-input"
+              name="password"
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              type="password"
+              value={password}
+            />
           </label>
-          <button className="preview-button" disabled type="button">
-            Autenticação chega em #37
+          <button className="preview-button" disabled={loginMutation.isPending} type="submit">
+            {loginMutation.isPending ? "Entrando..." : "Entrar"}
           </button>
-        </div>
+        </form>
       }
     />
   );

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { requireSession } from "../features/auth/guards";
 import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/minhas-requisicoes")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: MinhasRequisicoesPlaceholderPage,
 });
 

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { requireSession } from "../../features/auth/guards";
 import { FeaturePlaceholder } from "../../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/requisicoes/$id")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: DetalhePlaceholderPage,
 });
 

--- a/frontend/src/routes/requisicoes/nova.tsx
+++ b/frontend/src/routes/requisicoes/nova.tsx
@@ -1,8 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { requireSession } from "../../features/auth/guards";
 import { FeaturePlaceholder } from "../../shared/ui/feature-placeholder";
 
 export const Route = createFileRoute("/requisicoes/nova")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: NovaRequisicaoPlaceholderPage,
 });
 

--- a/frontend/src/routes/unknown-role.tsx
+++ b/frontend/src/routes/unknown-role.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { requireSession } from "../features/auth/guards";
+
+export const Route = createFileRoute("/unknown-role")({
+  beforeLoad: ({ context, location }) =>
+    requireSession({
+      queryClient: context.queryClient,
+      locationHref: location.href,
+    }),
+  component: UnknownRolePage,
+});
+
+function UnknownRolePage() {
+  return (
+    <section className="glass-inset space-y-4 p-6">
+      <p className="eyebrow">Sessão sem home operacional</p>
+      <h3 className="font-title text-4xl leading-none tracking-[-0.04em]">
+        Papel operacional não mapeado
+      </h3>
+      <p className="max-w-[58ch] text-base leading-7 text-[var(--ink-soft)]">
+        Sua sessão está ativa, mas o papel recebido ainda não tem uma rota inicial no piloto.
+        Peça ao administrador para revisar o cadastro ou alinhar o novo papel ao frontend.
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -19,8 +19,9 @@ function getCookie(name: string) {
 }
 
 export const apiClient = createClient<paths>({
-  baseUrl: "/api/v1",
+  baseUrl: globalThis.location?.origin ?? "",
   credentials: "include",
+  fetch: (request) => globalThis.fetch(request),
 });
 
 apiClient.use({

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -1,35 +1,248 @@
 import { RouterProvider } from "@tanstack/react-router";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { AppProviders } from "../app/providers";
+import { createAppQueryClient } from "../app/query-client";
 import { buildRouter } from "../app/router";
 
 function renderRoute(pathname: string) {
   window.history.replaceState({}, "", pathname);
-  const router = buildRouter();
+  const queryClient = createAppQueryClient();
+  const router = buildRouter({ queryClient });
 
   return render(
-    <AppProviders>
+    <AppProviders queryClient={queryClient}>
       <RouterProvider router={router} />
     </AppProviders>,
   );
 }
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function mockCurrentSession(papel = "solicitante") {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      new Response(
+        JSON.stringify({
+          id: 10,
+          matricula_funcional: "91003",
+          nome_completo: "Usuario Piloto",
+          papel,
+          setor: {
+            id: 1,
+            nome: "Operacao",
+          },
+          is_authenticated: true,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ),
+  );
+}
+
 describe("frontend scaffold router", () => {
-  it("renders login placeholder", async () => {
+  it("resolves root to home by operational papel", async () => {
+    mockCurrentSession("chefe_setor");
+
+    const { container } = renderRoute("/");
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
+  });
+
+  it("logs in with matricula and sends chefe de setor to authorization queue", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (request.url.endsWith("/api/v1/auth/me/")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "not_authenticated",
+              message: "Autenticação necessária.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (request.url.endsWith("/api/v1/auth/csrf/")) {
+        return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (request.url.endsWith("/api/v1/auth/login/")) {
+        return new Response(
+          JSON.stringify({
+            id: 20,
+            matricula_funcional: "91003",
+            nome_completo: "Chefe Piloto",
+            papel: "chefe_setor",
+            setor: {
+              id: 2,
+              nome: "Manutencao",
+            },
+            is_authenticated: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      throw new Error(`Unexpected request: ${request.url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/login");
+
+    fireEvent.change(await screen.findByLabelText("Matrícula funcional"), {
+      target: { value: "91003" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "senha-segura-123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: expect.stringContaining("/api/v1/auth/login/"),
+      }),
+    );
+  });
+
+  it("shows backend authentication error on invalid credentials", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (request.url.endsWith("/api/v1/auth/me/")) {
+          return new Response(JSON.stringify({ error: { code: "not_authenticated" } }), {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        if (request.url.endsWith("/api/v1/auth/csrf/")) {
+          return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "authentication_failed",
+              message: "Matrícula funcional ou senha inválidas.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }),
+    );
+
     renderRoute("/login");
 
+    fireEvent.change(await screen.findByLabelText("Matrícula funcional"), {
+      target: { value: "91003" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "errada" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    expect(
+      await screen.findByText("Matrícula funcional ou senha inválidas."),
+    ).toBeInTheDocument();
+  });
+
+  it("redirects protected routes without session to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        new Response(
+          JSON.stringify({
+            error: {
+              code: "not_authenticated",
+              message: "Autenticação necessária.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+
+    const { container } = renderRoute("/minhas-requisicoes");
+
     expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
-    expect(screen.getByText("#37 — login e bootstrap de sessão")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/login");
+    expect(container.ownerDocument.location.search).toBe("?redirect=%2Fminhas-requisicoes");
   });
 
   it("renders minhas requisicoes placeholder", async () => {
+    mockCurrentSession();
     renderRoute("/minhas-requisicoes");
 
     expect(
       await screen.findByRole("heading", { name: "Minhas requisições" }),
     ).toBeInTheDocument();
     expect(screen.getByText("GET /api/v1/requisitions/?page=&page_size=&search=&status=")).toBeInTheDocument();
+  });
+
+  it("logs out from authenticated shell and returns to login", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (request.url.endsWith("/api/v1/auth/me/")) {
+        return new Response(
+          JSON.stringify({
+            id: 10,
+            matricula_funcional: "91003",
+            nome_completo: "Usuario Piloto",
+            papel: "solicitante",
+            setor: {
+              id: 1,
+              nome: "Operacao",
+            },
+            is_authenticated: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (request.url.endsWith("/api/v1/auth/csrf/")) {
+        return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      if (request.url.endsWith("/api/v1/auth/logout/")) {
+        return new Response(null, { status: 204 });
+      }
+
+      throw new Error(`Unexpected request: ${request.url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("Usuario Piloto")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sair" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/login");
+    });
   });
 });

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -22,25 +22,75 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+const jsonHeaders = { "Content-Type": "application/json" };
+
+function requestUrl(request: Request) {
+  return request.url;
+}
+
+function authSession(papel = "solicitante") {
+  return {
+    id: 10,
+    matricula_funcional: "91003",
+    nome_completo: "Usuario Piloto",
+    papel,
+    setor: {
+      id: 1,
+      nome: "Operacao",
+    },
+    is_authenticated: true,
+  };
+}
+
+function chefeSession() {
+  return {
+    id: 20,
+    matricula_funcional: "91003",
+    nome_completo: "Chefe Piloto",
+    papel: "chefe_setor",
+    setor: {
+      id: 2,
+      nome: "Manutencao",
+    },
+    is_authenticated: true,
+  };
+}
+
+function sessionResponse(session = authSession()) {
+  return new Response(JSON.stringify(session), { status: 200, headers: jsonHeaders });
+}
+
+function csrfResponse() {
+  return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
+    status: 200,
+    headers: jsonHeaders,
+  });
+}
+
+function unauthenticatedResponse() {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "not_authenticated",
+        message: "Autenticação necessária.",
+        details: {},
+        trace_id: null,
+      },
+    }),
+    { status: 401, headers: jsonHeaders },
+  );
+}
+
 function mockCurrentSession(papel = "solicitante") {
   vi.stubGlobal(
     "fetch",
-    vi.fn(() =>
-      new Response(
-        JSON.stringify({
-          id: 10,
-          matricula_funcional: "91003",
-          nome_completo: "Usuario Piloto",
-          papel,
-          setor: {
-            id: 1,
-            nome: "Operacao",
-          },
-          is_authenticated: true,
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      ),
-    ),
+    vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession(papel));
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    }),
   );
 }
 
@@ -55,47 +105,37 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("resolves unknown operational papel to neutral fallback", async () => {
+    mockCurrentSession("papel_novo");
+
+    const { container } = renderRoute("/");
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/unknown-role");
+    });
+    expect(
+      await screen.findByRole("heading", { name: "Papel operacional não mapeado" }),
+    ).toBeInTheDocument();
+  });
+
   it("logs in with matricula and sends chefe de setor to authorization queue", async () => {
+    let loggedIn = false;
+    const session = chefeSession();
     const fetchMock = vi.fn((request: Request) => {
-      if (request.url.endsWith("/api/v1/auth/me/")) {
-        return new Response(
-          JSON.stringify({
-            error: {
-              code: "not_authenticated",
-              message: "Autenticação necessária.",
-              details: {},
-              trace_id: null,
-            },
-          }),
-          { status: 401, headers: { "Content-Type": "application/json" } },
-        );
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return loggedIn ? sessionResponse(session) : unauthenticatedResponse();
       }
 
-      if (request.url.endsWith("/api/v1/auth/csrf/")) {
-        return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return csrfResponse();
       }
 
-      if (request.url.endsWith("/api/v1/auth/login/")) {
-        return new Response(
-          JSON.stringify({
-            id: 20,
-            matricula_funcional: "91003",
-            nome_completo: "Chefe Piloto",
-            papel: "chefe_setor",
-            setor: {
-              id: 2,
-              nome: "Manutencao",
-            },
-            is_authenticated: true,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+      if (requestUrl(request).endsWith("/api/v1/auth/login/")) {
+        loggedIn = true;
+        return sessionResponse(session);
       }
 
-      throw new Error(`Unexpected request: ${request.url}`);
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -124,18 +164,15 @@ describe("frontend scaffold router", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn((request: Request) => {
-        if (request.url.endsWith("/api/v1/auth/me/")) {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
           return new Response(JSON.stringify({ error: { code: "not_authenticated" } }), {
             status: 401,
-            headers: { "Content-Type": "application/json" },
+            headers: jsonHeaders,
           });
         }
 
-        if (request.url.endsWith("/api/v1/auth/csrf/")) {
-          return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
-            status: 200,
-            headers: { "Content-Type": "application/json" },
-          });
+        if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+          return csrfResponse();
         }
 
         return new Response(
@@ -147,7 +184,7 @@ describe("frontend scaffold router", () => {
               trace_id: null,
             },
           }),
-          { status: 401, headers: { "Content-Type": "application/json" } },
+          { status: 401, headers: jsonHeaders },
         );
       }),
     );
@@ -167,6 +204,42 @@ describe("frontend scaffold router", () => {
     ).toBeInTheDocument();
   });
 
+  it("ignores external redirect after login", async () => {
+    let loggedIn = false;
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return loggedIn ? sessionResponse(authSession("solicitante")) : unauthenticatedResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return csrfResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/login/")) {
+        loggedIn = true;
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/login?redirect=https%3A%2F%2Fevil.example%2Fsteal");
+
+    fireEvent.change(await screen.findByLabelText("Matrícula funcional"), {
+      target: { value: "91003" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "senha-segura-123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+    expect(container.ownerDocument.location.search).toBe("");
+  });
+
   it("redirects protected routes without session to login", async () => {
     vi.stubGlobal(
       "fetch",
@@ -180,7 +253,7 @@ describe("frontend scaffold router", () => {
               trace_id: null,
             },
           }),
-          { status: 401, headers: { "Content-Type": "application/json" } },
+          { status: 401, headers: jsonHeaders },
         ),
       ),
     );
@@ -203,36 +276,22 @@ describe("frontend scaffold router", () => {
   });
 
   it("logs out from authenticated shell and returns to login", async () => {
+    let loggedIn = true;
     const fetchMock = vi.fn((request: Request) => {
-      if (request.url.endsWith("/api/v1/auth/me/")) {
-        return new Response(
-          JSON.stringify({
-            id: 10,
-            matricula_funcional: "91003",
-            nome_completo: "Usuario Piloto",
-            papel: "solicitante",
-            setor: {
-              id: 1,
-              nome: "Operacao",
-            },
-            is_authenticated: true,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return loggedIn ? sessionResponse(authSession("solicitante")) : unauthenticatedResponse();
       }
 
-      if (request.url.endsWith("/api/v1/auth/csrf/")) {
-        return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return csrfResponse();
       }
 
-      if (request.url.endsWith("/api/v1/auth/logout/")) {
+      if (requestUrl(request).endsWith("/api/v1/auth/logout/")) {
+        loggedIn = false;
         return new Response(null, { status: 204 });
       }
 
-      throw new Error(`Unexpected request: ${request.url}`);
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -244,5 +303,42 @@ describe("frontend scaffold router", () => {
     await waitFor(() => {
       expect(container.ownerDocument.location.pathname).toBe("/login");
     });
+  });
+
+  it("shows logout error when the backend rejects logout", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return csrfResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/logout/")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "logout_failed",
+              message: "Não foi possível encerrar a sessão.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 500, headers: jsonHeaders },
+        );
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("Usuario Piloto")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sair" }));
+
+    expect(await screen.findByText("Não foi possível encerrar a sessão.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
   });
 });

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -179,27 +179,28 @@ describe("frontend scaffold router", () => {
       "fetch",
       vi.fn((request: Request) => {
         if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
-          return new Response(JSON.stringify({ error: { code: "not_authenticated" } }), {
-            status: 401,
-            headers: jsonHeaders,
-          });
+          return unauthenticatedResponse();
         }
 
         if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
           return csrfResponse();
         }
 
-        return new Response(
-          JSON.stringify({
-            error: {
-              code: "authentication_failed",
-              message: "Matrícula funcional ou senha inválidas.",
-              details: {},
-              trace_id: null,
-            },
-          }),
-          { status: 401, headers: jsonHeaders },
-        );
+        if (requestUrl(request).endsWith("/api/v1/auth/login/")) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "authentication_failed",
+                message: "Matrícula funcional ou senha inválidas.",
+                details: {},
+                trace_id: null,
+              },
+            }),
+            { status: 401, headers: jsonHeaders },
+          );
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -254,22 +255,54 @@ describe("frontend scaffold router", () => {
     expect(container.ownerDocument.location.search).toBe("");
   });
 
+  it("strips nested redirect from safe internal redirect", async () => {
+    let loggedIn = false;
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return loggedIn ? sessionResponse(authSession("solicitante")) : unauthenticatedResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return csrfResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/login/")) {
+        loggedIn = true;
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const encodedRedirect = encodeURIComponent("/minhas-requisicoes?redirect=/login#secao");
+    const { container } = renderRoute(`/login?redirect=${encodedRedirect}`);
+
+    fireEvent.change(await screen.findByLabelText("Matrícula funcional"), {
+      target: { value: "91003" },
+    });
+    fireEvent.change(screen.getByLabelText("Senha"), {
+      target: { value: "senha-segura-123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Entrar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+    expect(container.ownerDocument.location.search).toBe("");
+    expect(container.ownerDocument.location.hash).toBe("#secao");
+  });
+
   it("redirects protected routes without session to login", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn(() =>
-        new Response(
-          JSON.stringify({
-            error: {
-              code: "not_authenticated",
-              message: "Autenticação necessária.",
-              details: {},
-              trace_id: null,
-            },
-          }),
-          { status: 401, headers: jsonHeaders },
-        ),
-      ),
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return unauthenticatedResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
     );
 
     const { container } = renderRoute("/minhas-requisicoes");

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -81,6 +81,20 @@ function unauthenticatedResponse() {
   );
 }
 
+function forbiddenResponse() {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "permission_denied",
+        message: "Permissão negada.",
+        details: {},
+        trace_id: null,
+      },
+    }),
+    { status: 403, headers: jsonHeaders },
+  );
+}
+
 function mockCurrentSession(papel = "solicitante") {
   vi.stubGlobal(
     "fetch",
@@ -265,6 +279,25 @@ describe("frontend scaffold router", () => {
     expect(container.ownerDocument.location.search).toBe("?redirect=%2Fminhas-requisicoes");
   });
 
+  it("redirects protected routes on forbidden session bootstrap", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return forbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/atendimentos");
+
+    expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/login");
+    expect(container.ownerDocument.location.search).toBe("?redirect=%2Fatendimentos");
+  });
+
   it("renders minhas requisicoes placeholder", async () => {
     mockCurrentSession();
     renderRoute("/minhas-requisicoes");
@@ -339,6 +372,46 @@ describe("frontend scaffold router", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sair" }));
 
     expect(await screen.findByText("Não foi possível encerrar a sessão.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+  });
+
+  it("does not post logout when csrf preparation fails", async () => {
+    let logoutCalled = false;
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/csrf/")) {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "csrf_unavailable",
+              message: "CSRF indisponível.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 503, headers: jsonHeaders },
+        );
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/auth/logout/")) {
+        logoutCalled = true;
+        return new Response(null, { status: 204 });
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("Usuario Piloto")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Sair" }));
+
+    expect(await screen.findByText("CSRF indisponível.")).toBeInTheDocument();
+    expect(logoutCalled).toBe(false);
     expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
   });
 });

--- a/frontend/src/tests/setup.ts
+++ b/frontend/src/tests/setup.ts
@@ -1,3 +1,11 @@
 import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+
+import { appQueryClient } from "../app/query-client";
 
 window.scrollTo = () => {};
+
+afterEach(async () => {
+  await appQueryClient.cancelQueries();
+  appQueryClient.clear();
+});

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -1,9 +1,82 @@
 import { expect, test } from "@playwright/test";
 
-test("loads frontend shell", async ({ page }) => {
-  await page.goto("/");
+test("logs in and logs out through pilot shell", async ({ page }) => {
+  let authenticated = false;
 
-  await expect(page.locator("aside.glass-panel")).toBeVisible();
-  await expect(page.locator("main .status-chip")).toBeVisible();
-  await expect(page.locator('nav a[href="/login"]').first()).toBeVisible();
+  await page.route("**/api/v1/auth/me/", async (route) => {
+    if (!authenticated) {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            code: "not_authenticated",
+            message: "Autenticação necessária.",
+            details: {},
+            trace_id: null,
+          },
+        }),
+      });
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 20,
+        matricula_funcional: "91003",
+        nome_completo: "Chefe Piloto",
+        papel: "chefe_setor",
+        setor: {
+          id: 2,
+          nome: "Manutencao",
+        },
+        is_authenticated: true,
+      }),
+    });
+  });
+  await page.route("**/api/v1/auth/csrf/", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ csrf_token: "csrf-token" }),
+    });
+  });
+  await page.route("**/api/v1/auth/login/", async (route) => {
+    authenticated = true;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 20,
+        matricula_funcional: "91003",
+        nome_completo: "Chefe Piloto",
+        papel: "chefe_setor",
+        setor: {
+          id: 2,
+          nome: "Manutencao",
+        },
+        is_authenticated: true,
+      }),
+    });
+  });
+  await page.route("**/api/v1/auth/logout/", async (route) => {
+    authenticated = false;
+    await route.fulfill({ status: 204 });
+  });
+
+  await page.goto("/login");
+
+  await page.getByLabel("Matrícula funcional").fill("91003");
+  await page.getByLabel("Senha").fill("senha-segura-123");
+  await page.getByRole("button", { name: "Entrar" }).click();
+
+  await expect(page).toHaveURL(/\/autorizacoes$/);
+  await expect(page.getByText("Chefe Piloto")).toBeVisible();
+
+  await page.getByRole("button", { name: "Sair" }).click();
+
+  await expect(page).toHaveURL(/\/login$/);
+  await expect(page.getByRole("heading", { name: "Entrar no piloto" })).toBeVisible();
 });


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Implementa a rota `/login` com bootstrap de sessão por Django session + CSRF.
- Adiciona guards e redirecionamento por papel operacional para home e áreas protegidas.
- Atualiza shell, client, router, smoke tests e E2E para cobrir login, sessão válida, sessão expirada e logout.
- Sincroniza docs e memórias operacionais com a base da SPA.

## Por que esta mudança é necessária
- Fecha a issue #37 e entrega a fundação do fluxo de autenticação da SPA do piloto.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [ ] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [x] não há impacto relevante além do comportamento descrito acima

## Risco principal
- Redirect/bootstrapping errado em sessão expirada ou papel inesperado, causando loop entre home e `/login`.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor:
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `rtk make frontend-lint` passou.
3. Smoke test e2e do shell/login atualizados para cobrir os fluxos principais.

## Como validar manualmente
- Rodar `rtk make frontend-dev`.
- Entrar em `/login` com sessão inválida, autenticar e confirmar redirect para home do papel.
- Recarregar com sessão expirada e confirmar retorno previsível para `/login`.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR #52: Login e Bootstrap de Sessão na SPA

- Objetivo
  - Implementa rota /login com login por matrícula/senha usando Django session + CSRF.
  - Bootstrap de sessão via GET /api/v1/auth/me/ e guards que protegem rotas da SPA.
  - Redirecionamento por papel operacional (papel → rota inicial) e tratamento para papel desconhecido.
  - Atualiza docs/memórias, smoke tests e E2E; fecha issue #37.

- Apps Django impactados
  - apps/users (endpoints usados: /auth/csrf/, /auth/login/, /auth/logout/, /auth/me/). Backend não mudou neste PR; frontend integra esses contratos.

- Risco funcional
  - Possível loop ou redirect incorreto em sessão expirada / papel inesperado se redirect mal sanitizado.
  - Comportamento explícito agora para papel não mapeado: rota /unknown-role (evita loop de volta a /login).
  - Logout exposto a AllowAny no backend (mitigado por CSRF), comportamento atípico que merece atenção operacional.
  - Principal risco identificado no checklist: redirect/bootstrapping incorreto em sessão expirada ou papel inesperado.

- Impacto em regras de negócio
  - Nenhuma alteração de regras de negócio ou transições de estado do domínio (somente fluxo de autenticação/UX).
  - Não há side effects em domain services; autenticação usa operações de sessão padrão.

- Impacto em autenticação, autorização, escopo por perfil e setor
  - Autenticação baseada em Django session; MatriculaBackend respeita is_active.
  - /auth/me/ usado para bootstrap; frontend guarda sessão em React Query (authQueryKeys.me).
  - Guards (requireSession) bloqueiam rotas protegidas e redirecionam para /login?redirect=...
  - Escopo por papel: homePathForPapel mapeia papéis operacionais para rotas (solicitante/auxiliares → /minhas-requisicoes; chefe_setor → /autorizacoes; almoxarifado → /atendimentos); papel desconhecido → /unknown-role.
  - Setor pode ser null no payload de /auth/me/ — frontend exibe setor opcionalmente; ausência de validação de setor pode precisar de atenção quando regras por setor forem aplicadas.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Contratos consumidos (existentes): AuthSessionOutput (id, matricula_funcional, nome_completo, papel, setor?, is_authenticated), AuthLoginInput, CsrfTokenOutput, ErrorResponse.
  - CSRF endpoint e enforcement (ensure_csrf_cookie) devem existir no backend; OpenAPI permanece compatível — PR apenas integra no frontend.
  - Erros API envolvem ApiError com status/payload; frontend trata 401/403 como auth errors (isAuthError).

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Nenhuma operação que altere dados de domínio, saldos ou snapshots; não afeta integridade ou auditoria.
  - Sessão/logout são operações de sessão (sem mutations em modelos de negócio).

- Impacto em transações, concorrência, idempotência, saldo físico/reservado/disponível
  - Não aplicável — fluxo de autenticação não toca em estoque nem executa transações de domínio.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque
  - Não aplicável.

- Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero
  - Testes: router-smoke (Vitest) e E2E Playwright atualizados/adicionados cobrindo login, sessão válida, sessão expirada, logout e papel desconhecido.
  - Lint/checagens: git diff --check e rtk make frontend-lint passaram; smoke/E2E atualizados.
  - Pequena alteração em client OpenAPI baseUrl (usa globalThis.location.origin) e configuração de React Query (createAppQueryClient) — sem dependências externas novas.
  - Nota operacional adicionada na documentação sobre pnpm@10.15.1 em cenários offline (frontend-init/test).

- Como validar manualmente
  - Frontend dev: rtk make frontend-dev; acessar /login.
  - Cenários:
    1. Sem sessão: acessar /login → autenticar com matrícula/senha válidas → confirmar setQueryData(authQueryKeys.me) e redirecionamento para rota por papel.
    2. Redirecionamento interno: tentar /recurso-protegido sem sessão → confirmar redirect para /login?redirect=<origem>; após login, confirmar retorno ao destino ou à rota mapeada por papel (sanitização de redirect).
    3. Sessão expirada: recarregar página com sessão inválida → confirmar redirecionamento previsível para /login (e evitar loops).
    4. Papel desconhecido: autenticar com usuário cujo papel não consta no mapeamento → confirmar navegação para /unknown-role (página neutra).
    5. Logout: clicar "Sair" no shell → POST /auth/logout/ executado, cache de me limpo e navegação para /login; se logout falhar exibir mensagem de erro e permanecer.
  - Testes automatizados: rodar suite Vitest (router-smoke) e Playwright E2E (shell.spec.ts) adicionadas/atualizadas.

- Pontos prioritários a revisar (recomendado)
  - Verificar sanitização do param redirect para evitar open-redirects ou loops.
  - Conferir comportamento quando setor = null em /auth/me/ se regras por setor forem aplicadas futuramente.
  - Revisar política de logout AllowAny + CSRF no backend para garantir esperada intenção de segurança.
  - Validar que isAuthError detecta corretamente 401/403 e que React Query retry config não reencadeia requisições problemáticas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->