### PR TITLE
feat(frontend): add minhas requisicoes flow

### DIFF
--- a/.serena/memories/architecture_and_domain_invariants.md
+++ b/.serena/memories/architecture_and_domain_invariants.md
@@ -36,6 +36,7 @@ Technical debt to revisit before adding new stock writers:
 
 Request/requisition invariants:
 - `Requisicao.setor_beneficiario` is a historical snapshot and must not be recalculated from `beneficiario.setor` after creation.
+- Draft requisitions are creator-owned: while `status=rascunho`, only the creator may view or manipulate the request; beneficiary visibility starts only after the request leaves draft and is revoked again if it returns to draft.
 - Request status transitions must follow the declarative state machine documented in domain/process docs and existing services when present.
 - Do not scatter status transitions through ad hoc `if/elif` logic.
 - Preserve consistency between requisition, requisition items, stock reservation, stock decrement, delivery, and audit trail.

--- a/.serena/memories/project_status_post_materialization.md
+++ b/.serena/memories/project_status_post_materialization.md
@@ -42,6 +42,7 @@ Technical baseline:
 - Requisition public numbers start only on first submission for authorization, never on draft creation
 - Requisition public numbering is annual and concurrency-safe
 - A returned-to-draft requisition keeps its existing `numero_publico`
+- Draft requisitions are creator-owned: while `status=rascunho`, only the creator may list, view, edit, submit, discard, or cancel the request; a third-party beneficiary gains visibility only after the request leaves draft and loses it again on return to draft
 - Pending-approvals listing must contain only `aguardando_autorizacao` requests in the caller scope
 - Authorization/recusal permission checks run in services against the `select_for_update()`-locked requisition, not against a stale caller instance
 - Partial or zero authorization requires non-blank trimmed justification; authorization payload cannot repeat `item_id`; at least one authorized item must remain with quantity greater than zero

--- a/.serena/memories/requisitions/pre_authorization_workflow.md
+++ b/.serena/memories/requisitions/pre_authorization_workflow.md
@@ -1,6 +1,6 @@
 # Requisitions authorization and fulfillment workflow
 
-Updated on 2026-05-01 after merge of PR #25.
+Updated on 2026-05-06 after merge of PR #54.
 
 ## Scope landed
 - `PIL-BE-REQ-002`: annual public numbering on first submission for authorization

--- a/.serena/memories/requisitions/pre_authorization_workflow.md
+++ b/.serena/memories/requisitions/pre_authorization_workflow.md
@@ -38,6 +38,8 @@ View layer is a thin `RequisicaoViewSet`; domain rules live in `apps/requisition
 - Public number format is `REQ-AAAA-NNNNNN` and generation is concurrency-safe via `transaction.atomic()` + `select_for_update()` on the annual sequence row.
 - Re-submit after return to draft preserves the existing public number.
 - Drafts may temporarily exist with `status=rascunho` and `numero_publico` filled only when they were already formally submitted once and later returned to draft.
+- Draft ownership is creator-only: while `status=rascunho`, only the creator may list, view, edit, submit, discard, or cancel the requisition, even if it was created for a third-party beneficiary.
+- A third-party beneficiary gains visibility only after the requisition leaves `rascunho` for a non-draft state such as `aguardando_autorizacao`, and loses that visibility again if the request returns to `rascunho`.
 - If `data_envio_autorizacao` is filled, `numero_publico` is mandatory at DB level.
 - Draft discard is physical delete only for a request never formalized (`numero_publico` absent and `data_envio_autorizacao` null).
 - Cancel is logical and allowed for formalized draft or pending-authorization request; discard and cancel are different operations.

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,24 +3,26 @@ project_name: "WMS-SAEP"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  ansible             bash                clojure             cpp
-#   cpp_ccls            crystal             csharp              csharp_omnisharp    dart
-#   elixir              elm                 erlang              fortran             fsharp
-#   go                  groovy              haskell             haxe                hlsl
-#   java                json                julia               kotlin              lean4
-#   lua                 luau                markdown            matlab              msl
-#   nix                 ocaml               pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         python_ty
-#   r                   rego                ruby                ruby_solargraph     rust
-#   scala               solidity            swift               systemverilog       terraform
-#   toml                typescript          typescript_vts      vue                 yaml
-#   zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -127,3 +129,14 @@ ignored_memory_patterns: []
 # The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -6,36 +6,13 @@ from apps.users.policies import (
     pode_autorizar_setor,
     pode_operar_estoque,
     pode_ver_fila_atendimento,
+    setor_responsavel_chefia,
+    usuario_almoxarifado,
+    usuario_operacional_ativo,
 )
 
 
-def _usuario_operacional_ativo(user) -> bool:
-    return user.is_authenticated and user.is_active and not user.is_superuser
-
-
-def pode_visualizar_requisicao(user, requisicao: Requisicao) -> bool:
-    if not user.is_authenticated:
-        return False
-
-    if user.is_superuser:
-        return True
-
-    if requisicao.criador_id == user.pk or requisicao.beneficiario_id == user.pk:
-        return True
-
-    if user.papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
-        return _usuario_operacional_ativo(user)
-
-    return _usuario_operacional_ativo(user) and pode_autorizar_setor(
-        user, requisicao.setor_beneficiario
-    )
-
-
-def queryset_requisicoes_visiveis(
-    user,
-    *,
-    skip_prefetch: bool = False,
-) -> QuerySet[Requisicao]:
+def _queryset_requisicoes_base(*, skip_prefetch: bool = False) -> QuerySet[Requisicao]:
     queryset = Requisicao.objects.select_related(
         "criador",
         "beneficiario",
@@ -48,6 +25,31 @@ def queryset_requisicoes_visiveis(
             "itens__material",
             "eventos__usuario",
         )
+    return queryset
+
+
+def _draft_owner_filter(user) -> Q:
+    return Q(status=StatusRequisicao.RASCUNHO, criador_id=user.pk)
+
+
+def _non_draft_filter(base_filter: Q) -> Q:
+    return ~Q(status=StatusRequisicao.RASCUNHO) & base_filter
+
+
+def _user_non_draft_personal_filter(user) -> Q:
+    return Q(criador_id=user.pk) | Q(beneficiario_id=user.pk)
+
+
+def user_is_creator(user, requisicao: Requisicao) -> bool:
+    return requisicao.criador_id == user.pk
+
+
+def queryset_requisicoes_visiveis(
+    user,
+    *,
+    skip_prefetch: bool = False,
+) -> QuerySet[Requisicao]:
+    queryset = _queryset_requisicoes_base(skip_prefetch=skip_prefetch)
 
     if not user.is_authenticated:
         return queryset.none()
@@ -55,46 +57,44 @@ def queryset_requisicoes_visiveis(
     if user.is_superuser:
         return queryset
 
-    if not _usuario_operacional_ativo(user):
+    if not usuario_operacional_ativo(user):
         return queryset.none()
 
-    if user.papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+    if usuario_almoxarifado(user):
+        return queryset.filter(_draft_owner_filter(user) | ~Q(status=StatusRequisicao.RASCUNHO))
+
+    filtro = _user_non_draft_personal_filter(user)
+    if user.papel == PapelChoices.CHEFE_SETOR:
+        setor_responsavel = setor_responsavel_chefia(user)
+        if setor_responsavel is not None:
+            filtro |= Q(setor_beneficiario=setor_responsavel)
+
+    return queryset.filter(_draft_owner_filter(user) | _non_draft_filter(filtro)).distinct()
+
+
+def queryset_requisicoes_pessoais(
+    user,
+    *,
+    skip_prefetch: bool = False,
+) -> QuerySet[Requisicao]:
+    queryset = _queryset_requisicoes_base(skip_prefetch=skip_prefetch)
+
+    if user.is_superuser:
         return queryset
 
-    filtro = Q(criador_id=user.pk) | Q(beneficiario_id=user.pk)
-    setor_responsavel = getattr(user, "setor_responsavel", None)
-    if setor_responsavel is not None:
-        filtro |= Q(setor_beneficiario=setor_responsavel)
+    if not user.is_authenticated or not user.is_active:
+        return queryset.none()
 
-    return queryset.filter(filtro).distinct()
-
-
-def pode_manipular_pre_autorizacao(user, requisicao: Requisicao) -> bool:
-    return _usuario_operacional_ativo(user) and (
-        requisicao.criador_id == user.pk or requisicao.beneficiario_id == user.pk
-    )
-
-
-def pode_cancelar_autorizada(user, requisicao: Requisicao) -> bool:
-    return pode_manipular_pre_autorizacao(user, requisicao) or pode_operar_estoque(user)
-
-
-def pode_autorizar_requisicao(user, requisicao: Requisicao) -> bool:
-    return _usuario_operacional_ativo(user) and pode_autorizar_setor(
-        user, requisicao.setor_beneficiario
-    )
-
-
-def pode_atender_requisicao(user, requisicao: Requisicao) -> bool:
-    return pode_operar_estoque(user) and pode_visualizar_requisicao(user, requisicao)
+    filtro = _user_non_draft_personal_filter(user)
+    return queryset.filter(_draft_owner_filter(user) | _non_draft_filter(filtro)).distinct()
 
 
 def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:
-    if not _usuario_operacional_ativo(user):
+    if not usuario_operacional_ativo(user):
         return Requisicao.objects.none()
 
     if user.papel == PapelChoices.CHEFE_SETOR:
-        setor_responsavel = getattr(user, "setor_responsavel", None)
+        setor_responsavel = setor_responsavel_chefia(user)
         if setor_responsavel is None:
             return Requisicao.objects.none()
         return Requisicao.objects.filter(
@@ -102,15 +102,66 @@ def queryset_fila_autorizacao(user) -> QuerySet[Requisicao]:
             status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
         )
 
-    # INVARIANTE: CHEFE_ALMOXARIFADO precisa estar lotado no setor do almoxarifado.
-    # Se `setor_id` vier vazio, tratamos como configuração inválida e retornamos vazio.
-    if user.papel == PapelChoices.CHEFE_ALMOXARIFADO and user.setor_id is not None:
+    if user.papel == PapelChoices.CHEFE_ALMOXARIFADO:
+        setor_responsavel = setor_responsavel_chefia(user)
+        if setor_responsavel is None:
+            return Requisicao.objects.none()
         return Requisicao.objects.filter(
-            setor_beneficiario_id=user.setor_id,
+            setor_beneficiario=setor_responsavel,
             status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
         )
 
     return Requisicao.objects.none()
+
+
+def user_is_creator_or_beneficiary(user, requisicao: Requisicao) -> bool:
+    return user_is_creator(user, requisicao) or requisicao.beneficiario_id == user.pk
+
+
+def pode_visualizar_requisicao(user, requisicao: Requisicao) -> bool:
+    if not user.is_authenticated:
+        return False
+
+    if user.is_superuser:
+        return True
+
+    if not usuario_operacional_ativo(user):
+        return False
+
+    if requisicao.status == StatusRequisicao.RASCUNHO:
+        return user_is_creator(user, requisicao)
+
+    if user_is_creator_or_beneficiary(user, requisicao):
+        return True
+
+    if usuario_almoxarifado(user):
+        return True
+
+    return pode_autorizar_setor(user, requisicao.setor_beneficiario)
+
+
+def pode_manipular_pre_autorizacao(user, requisicao: Requisicao) -> bool:
+    if not usuario_operacional_ativo(user):
+        return False
+
+    if requisicao.status == StatusRequisicao.RASCUNHO:
+        return user_is_creator(user, requisicao)
+
+    return user_is_creator_or_beneficiary(user, requisicao)
+
+
+def pode_cancelar_autorizada(user, requisicao: Requisicao) -> bool:
+    return pode_manipular_pre_autorizacao(user, requisicao) or pode_operar_estoque(user)
+
+
+def pode_autorizar_requisicao(user, requisicao: Requisicao) -> bool:
+    return usuario_operacional_ativo(user) and pode_autorizar_setor(
+        user, requisicao.setor_beneficiario
+    )
+
+
+def pode_atender_requisicao(user, requisicao: Requisicao) -> bool:
+    return pode_operar_estoque(user) and pode_visualizar_requisicao(user, requisicao)
 
 
 def queryset_fila_atendimento(user) -> QuerySet[Requisicao]:

--- a/apps/requisitions/policies.py
+++ b/apps/requisitions/policies.py
@@ -79,9 +79,6 @@ def queryset_requisicoes_pessoais(
 ) -> QuerySet[Requisicao]:
     queryset = _queryset_requisicoes_base(skip_prefetch=skip_prefetch)
 
-    if user.is_superuser:
-        return queryset
-
     if not user.is_authenticated or not user.is_active:
         return queryset.none()
 

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -20,12 +20,22 @@ from apps.stock.models import EstoqueMaterial
 from apps.stock.services import registrar_saldo_inicial
 from apps.users.models import PapelChoices, Setor, User
 
-SEED_PASSWORD = "senha-segura-123"
+SEED_PASSWORD = "1234"
 SEED_OBSERVACAO_PREFIX = "SEED_PILOT_MINIMO"
 SEED_RASCUNHO = f"{SEED_OBSERVACAO_PREFIX}:rascunho"
 SEED_AGUARDANDO = f"{SEED_OBSERVACAO_PREFIX}:aguardando"
 SEED_AUTORIZADA = f"{SEED_OBSERVACAO_PREFIX}:autorizada_parcial"
 SEED_ATENDIDA = f"{SEED_OBSERVACAO_PREFIX}:atendida_parcial"
+SEED_RASCUNHO_SETOR_SECUNDARIO = f"{SEED_OBSERVACAO_PREFIX}:rascunho_setor_secundario"
+SEED_AGUARDANDO_SETOR_SECUNDARIO = f"{SEED_OBSERVACAO_PREFIX}:aguardando_setor_secundario"
+SEED_RASCUNHO_MANUTENCAO_TERC = f"{SEED_OBSERVACAO_PREFIX}:rascunho_manutencao_terceiro"
+SEED_AGUARDANDO_MANUTENCAO = f"{SEED_OBSERVACAO_PREFIX}:aguardando_manutencao"
+SEED_AUTORIZADA_MANUTENCAO = f"{SEED_OBSERVACAO_PREFIX}:autorizada_manutencao"
+SEED_ATENDIDA_MANUTENCAO = f"{SEED_OBSERVACAO_PREFIX}:atendida_manutencao"
+SEED_RASCUNHO_MANUTENCAO_PURO = f"{SEED_OBSERVACAO_PREFIX}:rascunho_manutencao_puro"
+SEED_AGUARDANDO_SECUNDARIO_TERC = f"{SEED_OBSERVACAO_PREFIX}:aguardando_secundario_terceiro"
+SEED_AUTORIZADA_SECUNDARIO = f"{SEED_OBSERVACAO_PREFIX}:autorizada_secundario"
+SEED_ATENDIDA_SECUNDARIO = f"{SEED_OBSERVACAO_PREFIX}:atendida_secundario"
 
 
 def _ensure_ephemeral_environment() -> None:
@@ -247,6 +257,7 @@ def _seed_requisicao_atendida_parcial(
             ItemAutorizacaoData(
                 item_id=item.id,
                 quantidade_autorizada=Decimal("2"),
+                justificativa_autorizacao_parcial="Reserva parcial para o cenario da manutencao.",
             )
         ],
     )
@@ -266,69 +277,385 @@ def _seed_requisicao_atendida_parcial(
     )
 
 
+def _seed_requisicao_rascunho_setor_secundario(
+    *, criador: User, beneficiario: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_RASCUNHO_SETOR_SECUNDARIO).first()
+    if requisicao is not None:
+        return requisicao
+
+    return criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=beneficiario,
+        observacao=SEED_RASCUNHO_SETOR_SECUNDARIO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("1"),
+                observacao="Rascunho do setor secundario",
+            )
+        ],
+    )
+
+
+def _seed_requisicao_aguardando_setor_secundario(
+    *, criador: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_SETOR_SECUNDARIO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=criador,
+        observacao=SEED_AGUARDANDO_SETOR_SECUNDARIO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("1"),
+                observacao="Aguardando autorizacao do setor secundario",
+            )
+        ],
+    )
+    return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
+
+
+def _seed_requisicao_rascunho_manutencao_terceiro(
+    *, criador: User, beneficiario: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_RASCUNHO_MANUTENCAO_TERC).first()
+    if requisicao is not None:
+        return requisicao
+
+    return criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=beneficiario,
+        observacao=SEED_RASCUNHO_MANUTENCAO_TERC,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("1"),
+                observacao="Rascunho com beneficiario de terceiro",
+            )
+        ],
+    )
+
+
+def _seed_requisicao_aguardando_manutencao(*, criador: User, material: Material) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_MANUTENCAO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=criador,
+        observacao=SEED_AGUARDANDO_MANUTENCAO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("4"),
+                observacao="Aguardando autorizacao no setor de manutencao",
+            )
+        ],
+    )
+    return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
+
+
+def _seed_requisicao_autorizada_manutencao(
+    *, solicitante: User, chefe_setor: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_AUTORIZADA_MANUTENCAO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=solicitante,
+        beneficiario=solicitante,
+        observacao=SEED_AUTORIZADA_MANUTENCAO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("2"),
+                observacao="Autorizacao parcial da manutencao",
+            )
+        ],
+    )
+    requisicao = enviar_para_autorizacao(requisicao=requisicao, ator=solicitante)
+    item = requisicao.itens.get()
+    return autorizar_requisicao(
+        requisicao=requisicao,
+        ator=chefe_setor,
+        itens=[
+            ItemAutorizacaoData(
+                item_id=item.id,
+                quantidade_autorizada=Decimal("1"),
+                justificativa_autorizacao_parcial="Cenario do setor de manutencao em piloto.",
+            )
+        ],
+    )
+
+
+def _seed_requisicao_atendida_manutencao(
+    *, solicitante: User, chefe_setor: User, auxiliar_almox: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_ATENDIDA_MANUTENCAO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=solicitante,
+        beneficiario=solicitante,
+        observacao=SEED_ATENDIDA_MANUTENCAO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("3"),
+                observacao="Atendimento parcial da manutencao",
+            )
+        ],
+    )
+    requisicao = enviar_para_autorizacao(requisicao=requisicao, ator=solicitante)
+    item = requisicao.itens.get()
+    requisicao = autorizar_requisicao(
+        requisicao=requisicao,
+        ator=chefe_setor,
+        itens=[
+            ItemAutorizacaoData(
+                item_id=item.id,
+                quantidade_autorizada=Decimal("2"),
+                justificativa_autorizacao_parcial="Reserva parcial para o cenario da manutencao.",
+            )
+        ],
+    )
+    item = requisicao.itens.get()
+    return atender_requisicao(
+        requisicao=requisicao,
+        ator=auxiliar_almox,
+        itens=[
+            ItemAtendimentoData(
+                item_id=item.id,
+                quantidade_entregue=Decimal("1"),
+                justificativa_atendimento_parcial="Entrega parcial para cenario da manutencao.",
+            )
+        ],
+        retirante_fisico="Equipe de manutencao",
+        observacao_atendimento=SEED_OBSERVACAO_PREFIX,
+    )
+
+
+def _seed_requisicao_rascunho_manutencao_puro(
+    *, criador: User, beneficiario: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_RASCUNHO_MANUTENCAO_PURO).first()
+    if requisicao is not None:
+        return requisicao
+
+    return criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=beneficiario,
+        observacao=SEED_RASCUNHO_MANUTENCAO_PURO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("5"),
+                observacao="Rascunho direto do setor de manutencao",
+            )
+        ],
+    )
+
+
+def _seed_requisicao_aguardando_secundario_terceiro(
+    *, criador: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_SECUNDARIO_TERC).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=criador,
+        beneficiario=criador,
+        observacao=SEED_AGUARDANDO_SECUNDARIO_TERC,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("2"),
+                observacao="Aguardando autorizacao com terceiro beneficiario",
+            )
+        ],
+    )
+    return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
+
+
+def _seed_requisicao_autorizada_secundario(
+    *, solicitante: User, chefe_setor: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_AUTORIZADA_SECUNDARIO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=solicitante,
+        beneficiario=solicitante,
+        observacao=SEED_AUTORIZADA_SECUNDARIO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("3"),
+                observacao="Autorizacao do setor secundario",
+            )
+        ],
+    )
+    requisicao = enviar_para_autorizacao(requisicao=requisicao, ator=solicitante)
+    item = requisicao.itens.get()
+    return autorizar_requisicao(
+        requisicao=requisicao,
+        ator=chefe_setor,
+        itens=[
+            ItemAutorizacaoData(
+                item_id=item.id,
+                quantidade_autorizada=Decimal("2"),
+                justificativa_autorizacao_parcial="Variacao do cenario do setor secundario.",
+            )
+        ],
+    )
+
+
+def _seed_requisicao_atendida_secundario(
+    *, solicitante: User, chefe_setor: User, auxiliar_almox: User, material: Material
+) -> Requisicao:
+    requisicao = Requisicao.objects.filter(observacao=SEED_ATENDIDA_SECUNDARIO).first()
+    if requisicao is not None:
+        return requisicao
+
+    requisicao = criar_rascunho_requisicao(
+        criador=solicitante,
+        beneficiario=solicitante,
+        observacao=SEED_ATENDIDA_SECUNDARIO,
+        itens=[
+            ItemRascunhoData(
+                material_id=material.id,
+                quantidade_solicitada=Decimal("2"),
+                observacao="Atendimento do setor secundario",
+            )
+        ],
+    )
+    requisicao = enviar_para_autorizacao(requisicao=requisicao, ator=solicitante)
+    item = requisicao.itens.get()
+    requisicao = autorizar_requisicao(
+        requisicao=requisicao,
+        ator=chefe_setor,
+        itens=[
+            ItemAutorizacaoData(
+                item_id=item.id,
+                quantidade_autorizada=Decimal("2"),
+            )
+        ],
+    )
+    item = requisicao.itens.get()
+    return atender_requisicao(
+        requisicao=requisicao,
+        ator=auxiliar_almox,
+        itens=[
+            ItemAtendimentoData(
+                item_id=item.id,
+                quantidade_entregue=Decimal("2"),
+            )
+        ],
+        retirante_fisico="Equipe de operacao",
+        observacao_atendimento=SEED_OBSERVACAO_PREFIX,
+    )
+
+
 def carregar_seed_pilot_minimo() -> None:
     _ensure_ephemeral_environment()
 
     with transaction.atomic():
         chefe_setor = _upsert_usuario(
-            matricula="91001",
-            nome_completo="Chefe Operacional",
+            matricula="chefe-setor",
+            nome_completo="Wagner Fonseca",
             papel=PapelChoices.CHEFE_SETOR,
         )
         chefe_almox = _upsert_usuario(
-            matricula="91005",
-            nome_completo="Chefe Almoxarifado",
+            matricula="chefe-almox",
+            nome_completo="João Zuñeda",
             papel=PapelChoices.CHEFE_ALMOXARIFADO,
         )
 
         setor_operacional = _upsert_setor(
-            nome="Setor Operacional Seed",
+            nome="Manutenção de Redes de Água",
             chefe_responsavel=chefe_setor,
         )
+        chefe_setor_secundario = _upsert_usuario(
+            matricula="chefe-setor-2",
+            nome_completo="Rafael Siqueira",
+            papel=PapelChoices.CHEFE_SETOR,
+        )
+        setor_operacional_secundario = _upsert_setor(
+            nome="Operação de Esgoto",
+            chefe_responsavel=chefe_setor_secundario,
+        )
+        chefe_setor_secundario = _upsert_usuario(
+            matricula="chefe-setor-2",
+            nome_completo="Rafael Siqueira",
+            papel=PapelChoices.CHEFE_SETOR,
+            setor=setor_operacional_secundario,
+        )
+        auxiliar_setor_secundario = _upsert_usuario(
+            matricula="auxiliar-setor-2",
+            nome_completo="Camila Duarte",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor_operacional_secundario,
+        )
+        solicitante_secundario = _upsert_usuario(
+            matricula="solicitante3",
+            nome_completo="Bruno Cardoso",
+            papel=PapelChoices.SOLICITANTE,
+            setor=setor_operacional_secundario,
+        )
         setor_almox = _upsert_setor(
-            nome="Almoxarifado Seed",
+            nome="Almoxarifado",
             chefe_responsavel=chefe_almox,
         )
 
         chefe_setor = _upsert_usuario(
-            matricula="91001",
-            nome_completo="Chefe Operacional",
+            matricula="chefe-setor",
+            nome_completo="Wagner Fonseca",
             papel=PapelChoices.CHEFE_SETOR,
             setor=setor_operacional,
         )
         chefe_almox = _upsert_usuario(
-            matricula="91005",
-            nome_completo="Chefe Almoxarifado",
+            matricula="chefe-almox",
+            nome_completo="João Zuñeda",
             papel=PapelChoices.CHEFE_ALMOXARIFADO,
             setor=setor_almox,
         )
         auxiliar_setor = _upsert_usuario(
             matricula="91002",
-            nome_completo="Auxiliar Operacional",
+            nome_completo="Thiago Baldin",
             papel=PapelChoices.AUXILIAR_SETOR,
             setor=setor_operacional,
         )
         solicitante = _upsert_usuario(
-            matricula="91003",
-            nome_completo="Solicitante Operacional",
+            matricula="solicitante1",
+            nome_completo="Marieberton Pinheiro",
             papel=PapelChoices.SOLICITANTE,
             setor=setor_operacional,
         )
         beneficiario_terceiro = _upsert_usuario(
-            matricula="91004",
-            nome_completo="Beneficiario Operacional",
+            matricula="solicitante2",
+            nome_completo="Pedro Nunes",
             papel=PapelChoices.SOLICITANTE,
             setor=setor_operacional,
         )
         auxiliar_almox = _upsert_usuario(
-            matricula="91006",
-            nome_completo="Auxiliar Almoxarifado",
+            matricula="auxiliar-almox",
+            nome_completo="Lázaro Fernando",
             papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
             setor=setor_almox,
         )
         _upsert_usuario(
-            matricula="91998",
-            nome_completo="Superusuario Tecnico Seed",
+            matricula="super",
+            nome_completo="Superusuario",
             papel=PapelChoices.CHEFE_ALMOXARIFADO,
             setor=setor_almox,
             is_active=True,
@@ -336,8 +663,8 @@ def carregar_seed_pilot_minimo() -> None:
             is_staff=True,
         )
         _upsert_usuario(
-            matricula="91999",
-            nome_completo="Usuario Inativo Seed",
+            matricula="inativo",
+            nome_completo="José Roberto",
             papel=PapelChoices.SOLICITANTE,
             setor=setor_operacional,
             is_active=False,
@@ -345,19 +672,19 @@ def carregar_seed_pilot_minimo() -> None:
 
         grupo, _ = GrupoMaterial.objects.get_or_create(
             codigo_grupo="010",
-            defaults={"nome": "Materiais de Consumo Seed"},
+            defaults={"nome": "Materiais de Consumo"},
         )
-        if grupo.nome != "Materiais de Consumo Seed":
-            grupo.nome = "Materiais de Consumo Seed"
+        if grupo.nome != "Materiais de Consumo":
+            grupo.nome = "Materiais de Consumo"
             grupo.save(update_fields=["nome", "updated_at"])
 
         subgrupo, _ = SubgrupoMaterial.objects.get_or_create(
             grupo=grupo,
             codigo_subgrupo="001",
-            defaults={"nome": "Uso Diario Seed"},
+            defaults={"nome": "Uso Diario"},
         )
-        if subgrupo.nome != "Uso Diario Seed":
-            subgrupo.nome = "Uso Diario Seed"
+        if subgrupo.nome != "Uso Diario":
+            subgrupo.nome = "Uso Diario"
             subgrupo.save(update_fields=["nome", "updated_at"])
 
         material_saldo_confortavel = _upsert_material(
@@ -388,10 +715,34 @@ def carregar_seed_pilot_minimo() -> None:
             subgrupo=subgrupo,
             codigo_completo="010.001.004",
             sequencial="004",
-            nome="Material inativo seed",
+            nome="Material inativo",
             unidade_medida="UN",
             saldo_inicial=Decimal("8"),
             is_active=False,
+        )
+        material_saldo_intermediario = _upsert_material(
+            subgrupo=subgrupo,
+            codigo_completo="010.001.005",
+            sequencial="005",
+            nome="Filtro para torneira",
+            unidade_medida="UN",
+            saldo_inicial=Decimal("12"),
+        )
+        material_variacao_manutencao = _upsert_material(
+            subgrupo=subgrupo,
+            codigo_completo="010.001.006",
+            sequencial="006",
+            nome="Mangueira flexivel",
+            unidade_medida="UN",
+            saldo_inicial=Decimal("20"),
+        )
+        material_variacao_secundario = _upsert_material(
+            subgrupo=subgrupo,
+            codigo_completo="010.001.007",
+            sequencial="007",
+            nome="Luva nitrilica",
+            unidade_medida="UN",
+            saldo_inicial=Decimal("15"),
         )
 
         _seed_requisicao_rascunho(
@@ -413,4 +764,53 @@ def carregar_seed_pilot_minimo() -> None:
             chefe_setor=chefe_setor,
             auxiliar_almox=auxiliar_almox,
             material=material_saldo_baixo,
+        )
+        _seed_requisicao_rascunho_setor_secundario(
+            criador=auxiliar_setor_secundario,
+            beneficiario=solicitante_secundario,
+            material=material_saldo_confortavel,
+        )
+        _seed_requisicao_aguardando_setor_secundario(
+            criador=solicitante_secundario,
+            material=material_saldo_baixo,
+        )
+        _seed_requisicao_rascunho_manutencao_terceiro(
+            criador=auxiliar_setor,
+            beneficiario=beneficiario_terceiro,
+            material=material_saldo_confortavel,
+        )
+        _seed_requisicao_aguardando_manutencao(
+            criador=auxiliar_setor,
+            material=material_saldo_confortavel,
+        )
+        _seed_requisicao_autorizada_manutencao(
+            solicitante=solicitante,
+            chefe_setor=chefe_setor,
+            material=material_variacao_manutencao,
+        )
+        _seed_requisicao_atendida_manutencao(
+            solicitante=solicitante,
+            chefe_setor=chefe_setor,
+            auxiliar_almox=auxiliar_almox,
+            material=material_variacao_manutencao,
+        )
+        _seed_requisicao_rascunho_manutencao_puro(
+            criador=chefe_setor,
+            beneficiario=solicitante,
+            material=material_saldo_intermediario,
+        )
+        _seed_requisicao_aguardando_secundario_terceiro(
+            criador=solicitante_secundario,
+            material=material_variacao_secundario,
+        )
+        _seed_requisicao_autorizada_secundario(
+            solicitante=solicitante_secundario,
+            chefe_setor=chefe_setor_secundario,
+            material=material_variacao_secundario,
+        )
+        _seed_requisicao_atendida_secundario(
+            solicitante=solicitante_secundario,
+            chefe_setor=chefe_setor_secundario,
+            auxiliar_almox=auxiliar_almox,
+            material=material_variacao_secundario,
         )

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -585,6 +585,10 @@ def carregar_seed_pilot_minimo() -> None:
             nome="Manutenção de Redes de Água",
             chefe_responsavel=chefe_setor,
         )
+        # This seed intentionally provisions the secondary sector in two steps:
+        # the chief is created first without setor, then the setor is created,
+        # and finally the chief is upserted again with the setor assigned.
+        # The sequence currently relies on _upsert_setor not calling Setor.clean().
         chefe_setor_secundario = _upsert_usuario(
             matricula="chefe-setor-2",
             nome_completo="Rafael Siqueira",

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -335,7 +335,7 @@ def _seed_requisicao_rascunho_manutencao_terceiro(
             ItemRascunhoData(
                 material_id=material.id,
                 quantidade_solicitada=Decimal("1"),
-                observacao="Rascunho com beneficiario de terceiro",
+                observacao="Rascunho de manutencao com beneficiario de terceiro",
             )
         ],
     )
@@ -781,7 +781,7 @@ def carregar_seed_pilot_minimo() -> None:
         _seed_requisicao_rascunho_manutencao_terceiro(
             criador=auxiliar_setor,
             beneficiario=beneficiario_terceiro,
-            material=material_saldo_confortavel,
+            material=material_variacao_manutencao,
         )
         _seed_requisicao_aguardando_manutencao(
             criador=auxiliar_setor,

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -465,7 +465,7 @@ def _seed_requisicao_rascunho_manutencao_puro(
 
 
 def _seed_requisicao_aguardando_secundario_terceiro(
-    *, criador: User, material: Material
+    *, criador: User, beneficiario: User, material: Material
 ) -> Requisicao:
     requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_SECUNDARIO_TERC).first()
     if requisicao is not None:
@@ -473,7 +473,7 @@ def _seed_requisicao_aguardando_secundario_terceiro(
 
     requisicao = criar_rascunho_requisicao(
         criador=criador,
-        beneficiario=criador,
+        beneficiario=beneficiario,
         observacao=SEED_AGUARDANDO_SECUNDARIO_TERC,
         itens=[
             ItemRascunhoData(
@@ -801,6 +801,7 @@ def carregar_seed_pilot_minimo() -> None:
         )
         _seed_requisicao_aguardando_secundario_terceiro(
             criador=solicitante_secundario,
+            beneficiario=auxiliar_setor_secundario,
             material=material_variacao_secundario,
         )
         _seed_requisicao_autorizada_secundario(

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -325,21 +325,37 @@ def _seed_requisicao_aguardando_setor_secundario(
 def _seed_requisicao_rascunho_manutencao_terceiro(
     *, criador: User, beneficiario: User, material: Material
 ) -> Requisicao:
+    item_desejado = ItemRascunhoData(
+        material_id=material.id,
+        quantidade_solicitada=Decimal("1"),
+        observacao="Rascunho de manutencao com beneficiario de terceiro",
+    )
     requisicao = Requisicao.objects.filter(observacao=SEED_RASCUNHO_MANUTENCAO_TERC).first()
     if requisicao is not None:
-        return requisicao
+        item_atual = requisicao.itens.first()
+        if (
+            requisicao.beneficiario_id == beneficiario.id
+            and requisicao.itens.count() == 1
+            and item_atual is not None
+            and item_atual.material_id == item_desejado.material_id
+            and item_atual.quantidade_solicitada == item_desejado.quantidade_solicitada
+            and item_atual.observacao == item_desejado.observacao
+        ):
+            return requisicao
+
+        return atualizar_rascunho_requisicao(
+            requisicao_id=requisicao.id,
+            ator=criador,
+            beneficiario_id=beneficiario.id,
+            observacao=SEED_RASCUNHO_MANUTENCAO_TERC,
+            itens=[item_desejado],
+        )
 
     return criar_rascunho_requisicao(
         criador=criador,
         beneficiario=beneficiario,
         observacao=SEED_RASCUNHO_MANUTENCAO_TERC,
-        itens=[
-            ItemRascunhoData(
-                material_id=material.id,
-                quantidade_solicitada=Decimal("1"),
-                observacao="Rascunho de manutencao com beneficiario de terceiro",
-            )
-        ],
+        itens=[item_desejado],
     )
 
 

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -257,7 +257,7 @@ def _seed_requisicao_atendida_parcial(
             ItemAutorizacaoData(
                 item_id=item.id,
                 quantidade_autorizada=Decimal("2"),
-                justificativa_autorizacao_parcial="Reserva parcial para o cenario da manutencao.",
+                justificativa_autorizacao_parcial="Reserva parcial para o cenario de atendimento.",
             )
         ],
     )
@@ -469,6 +469,13 @@ def _seed_requisicao_aguardando_secundario_terceiro(
 ) -> Requisicao:
     requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_SECUNDARIO_TERC).first()
     if requisicao is not None:
+        if requisicao.beneficiario_id == beneficiario.id:
+            return requisicao
+        Requisicao.objects.filter(pk=requisicao.pk).update(
+            beneficiario=beneficiario,
+            setor_beneficiario=beneficiario.setor,
+        )
+        requisicao.refresh_from_db()
         return requisicao
 
     requisicao = criar_rascunho_requisicao(
@@ -660,8 +667,8 @@ def carregar_seed_pilot_minimo() -> None:
         _upsert_usuario(
             matricula="super",
             nome_completo="Superusuario",
-            papel=PapelChoices.CHEFE_ALMOXARIFADO,
-            setor=setor_almox,
+            papel=PapelChoices.SOLICITANTE,
+            setor=None,
             is_active=True,
             is_superuser=True,
             is_staff=True,

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -485,9 +485,20 @@ def _seed_requisicao_rascunho_manutencao_puro(
 def _seed_requisicao_aguardando_secundario_terceiro(
     *, criador: User, beneficiario: User, material: Material
 ) -> Requisicao:
+    item_data = ItemRascunhoData(
+        material_id=material.id,
+        quantidade_solicitada=Decimal("2"),
+        observacao="Aguardando autorizacao com terceiro beneficiario",
+    )
     requisicao = Requisicao.objects.filter(observacao=SEED_AGUARDANDO_SECUNDARIO_TERC).first()
     if requisicao is not None:
-        if requisicao.beneficiario_id == beneficiario.id:
+        item_atual = requisicao.itens.first()
+        item_diverge = item_atual is None or (
+            item_atual.material_id != item_data.material_id
+            or item_atual.quantidade_solicitada != item_data.quantidade_solicitada
+            or item_atual.observacao != item_data.observacao
+        )
+        if requisicao.beneficiario_id == beneficiario.id and not item_diverge:
             return requisicao
 
         requisicao = retornar_para_rascunho(requisicao=requisicao, ator=criador)
@@ -496,13 +507,7 @@ def _seed_requisicao_aguardando_secundario_terceiro(
             ator=criador,
             beneficiario_id=beneficiario.id,
             observacao=SEED_AGUARDANDO_SECUNDARIO_TERC,
-            itens=[
-                ItemRascunhoData(
-                    material_id=material.id,
-                    quantidade_solicitada=Decimal("2"),
-                    observacao="Aguardando autorizacao com terceiro beneficiario",
-                )
-            ],
+            itens=[item_data],
         )
         return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
 
@@ -510,13 +515,7 @@ def _seed_requisicao_aguardando_secundario_terceiro(
         criador=criador,
         beneficiario=beneficiario,
         observacao=SEED_AGUARDANDO_SECUNDARIO_TERC,
-        itens=[
-            ItemRascunhoData(
-                material_id=material.id,
-                quantidade_solicitada=Decimal("2"),
-                observacao="Aguardando autorizacao com terceiro beneficiario",
-            )
-        ],
+        itens=[item_data],
     )
     return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
 

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -12,9 +12,11 @@ from apps.requisitions.services import (
     ItemAutorizacaoData,
     ItemRascunhoData,
     atender_requisicao,
+    atualizar_rascunho_requisicao,
     autorizar_requisicao,
     criar_rascunho_requisicao,
     enviar_para_autorizacao,
+    retornar_para_rascunho,
 )
 from apps.stock.models import EstoqueMaterial
 from apps.stock.services import registrar_saldo_inicial
@@ -471,12 +473,22 @@ def _seed_requisicao_aguardando_secundario_terceiro(
     if requisicao is not None:
         if requisicao.beneficiario_id == beneficiario.id:
             return requisicao
-        Requisicao.objects.filter(pk=requisicao.pk).update(
-            beneficiario=beneficiario,
-            setor_beneficiario=beneficiario.setor,
+
+        requisicao = retornar_para_rascunho(requisicao=requisicao, ator=criador)
+        requisicao = atualizar_rascunho_requisicao(
+            requisicao_id=requisicao.id,
+            ator=criador,
+            beneficiario_id=beneficiario.id,
+            observacao=SEED_AGUARDANDO_SECUNDARIO_TERC,
+            itens=[
+                ItemRascunhoData(
+                    material_id=material.id,
+                    quantidade_solicitada=Decimal("2"),
+                    observacao="Aguardando autorizacao com terceiro beneficiario",
+                )
+            ],
         )
-        requisicao.refresh_from_db()
-        return requisicao
+        return enviar_para_autorizacao(requisicao=requisicao, ator=criador)
 
     requisicao = criar_rascunho_requisicao(
         criador=criador,

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -20,7 +20,7 @@ from apps.stock.models import EstoqueMaterial
 from apps.stock.services import registrar_saldo_inicial
 from apps.users.models import PapelChoices, Setor, User
 
-SEED_PASSWORD = "1234"
+SEED_PASSWORD = "piloto-minimo"
 SEED_OBSERVACAO_PREFIX = "SEED_PILOT_MINIMO"
 SEED_RASCUNHO = f"{SEED_OBSERVACAO_PREFIX}:rascunho"
 SEED_AGUARDANDO = f"{SEED_OBSERVACAO_PREFIX}:aguardando"
@@ -804,8 +804,8 @@ def carregar_seed_pilot_minimo() -> None:
             material=material_saldo_intermediario,
         )
         _seed_requisicao_aguardando_secundario_terceiro(
-            criador=solicitante_secundario,
-            beneficiario=auxiliar_setor_secundario,
+            criador=auxiliar_setor_secundario,
+            beneficiario=solicitante_secundario,
             material=material_variacao_secundario,
         )
         _seed_requisicao_autorizada_secundario(

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -712,9 +712,6 @@ def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao
 
 
 def retornar_para_rascunho(*, requisicao: Requisicao, ator: User) -> Requisicao:
-    if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador ou beneficiário podem retornar a requisição.")
-
     with transaction.atomic():
         requisicao = (
             Requisicao.objects.select_for_update()
@@ -722,6 +719,9 @@ def retornar_para_rascunho(*, requisicao: Requisicao, ator: User) -> Requisicao:
             .prefetch_related("itens__material", "eventos__usuario")
             .get(pk=requisicao.pk)
         )
+
+        if not pode_manipular_pre_autorizacao(ator, requisicao):
+            raise PermissionDenied("Apenas criador ou beneficiário podem retornar a requisição.")
 
         if requisicao.status != StatusRequisicao.AGUARDANDO_AUTORIZACAO:
             raise DomainConflict(
@@ -749,13 +749,13 @@ def retornar_para_rascunho(*, requisicao: Requisicao, ator: User) -> Requisicao:
 
 
 def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> None:
-    if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador pode descartar a requisição.")
-
     with transaction.atomic():
         requisicao = (
             Requisicao.objects.select_for_update().prefetch_related("itens").get(pk=requisicao.pk)
         )
+
+        if not pode_manipular_pre_autorizacao(ator, requisicao):
+            raise PermissionDenied("Apenas criador pode descartar a requisição.")
 
         if requisicao.status != StatusRequisicao.RASCUNHO:
             raise DomainConflict(

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -643,9 +643,6 @@ def atualizar_rascunho_requisicao(
 
 
 def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
-    if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador pode enviar a requisição.")
-
     with transaction.atomic():
         requisicao = (
             Requisicao.objects.select_for_update()
@@ -653,6 +650,9 @@ def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao
             .prefetch_related("itens__material__estoque", "eventos__usuario")
             .get(pk=requisicao.pk)
         )
+
+        if not pode_manipular_pre_autorizacao(ator, requisicao):
+            raise PermissionDenied("Apenas criador pode enviar a requisição.")
 
         if requisicao.status != StatusRequisicao.RASCUNHO:
             raise DomainConflict(

--- a/apps/requisitions/services.py
+++ b/apps/requisitions/services.py
@@ -568,7 +568,7 @@ def atualizar_rascunho_requisicao(
             raise NotFound("Requisição não encontrada.")
 
         if not pode_manipular_pre_autorizacao(ator, requisicao_locked):
-            raise PermissionDenied("Apenas criador ou beneficiário podem editar a requisição.")
+            raise PermissionDenied("Apenas criador pode editar a requisição.")
 
         if requisicao_locked.status != StatusRequisicao.RASCUNHO:
             raise DomainConflict(
@@ -644,7 +644,7 @@ def atualizar_rascunho_requisicao(
 
 def enviar_para_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
     if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador ou beneficiário podem enviar a requisição.")
+        raise PermissionDenied("Apenas criador pode enviar a requisição.")
 
     with transaction.atomic():
         requisicao = (
@@ -750,7 +750,7 @@ def retornar_para_rascunho(*, requisicao: Requisicao, ator: User) -> Requisicao:
 
 def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> None:
     if not pode_manipular_pre_autorizacao(ator, requisicao):
-        raise PermissionDenied("Apenas criador ou beneficiário podem descartar a requisição.")
+        raise PermissionDenied("Apenas criador pode descartar a requisição.")
 
     with transaction.atomic():
         requisicao = (
@@ -774,6 +774,8 @@ def descartar_rascunho_nunca_enviado(*, requisicao: Requisicao, ator: User) -> N
 
 def _cancelar_pre_autorizacao(*, requisicao: Requisicao, ator: User) -> Requisicao:
     if not pode_manipular_pre_autorizacao(ator, requisicao):
+        if requisicao.status == StatusRequisicao.RASCUNHO:
+            raise PermissionDenied("Apenas criador pode cancelar a requisição.")
         raise PermissionDenied("Apenas criador ou beneficiário podem cancelar a requisição.")
 
     if requisicao.status == StatusRequisicao.RASCUNHO:

--- a/apps/requisitions/views.py
+++ b/apps/requisitions/views.py
@@ -14,7 +14,10 @@ from rest_framework.viewsets import GenericViewSet
 
 from apps.core.api.serializers import ErrorResponseSerializer
 from apps.requisitions.filters import RequisicaoFilter
-from apps.requisitions.policies import queryset_requisicoes_visiveis
+from apps.requisitions.policies import (
+    queryset_requisicoes_pessoais,
+    queryset_requisicoes_visiveis,
+)
 from apps.requisitions.serializers import (
     RequisicaoAuthorizeInputSerializer,
     RequisicaoCancelInputSerializer,
@@ -129,6 +132,63 @@ class RequisicaoViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, Generi
     )
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        operation_id="requisitions_mine",
+        tags=["requisitions"],
+        description=(
+            "Lista paginada das requisições pessoais do usuário autenticado. "
+            "Inclui apenas requisições em que o usuário é criador ou beneficiário."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="search",
+                description="Busca textual por número público, nome do beneficiário ou nome do criador.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="status",
+                description="Filtro exato por status da requisição.",
+                required=False,
+                type=str,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: forced_singular_serializer(RequisicaoListPaginatedSerializer),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="mine")
+    def mine(self, request):
+        queryset = (
+            queryset_requisicoes_pessoais(
+                request.user,
+                skip_prefetch=True,
+            )
+            .annotate(total_itens=Count("itens"))
+            .order_by("-updated_at", "-id")
+        )
+        queryset = self.filter_queryset(queryset)
+        page = self.paginate_queryset(queryset)
+        serializer = RequisicaoListOutputSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 
     @extend_schema(
         operation_id="requisitions_retrieve",

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -25,8 +25,16 @@ class Setor(models.Model):
     chefe_responsavel = models.OneToOneField(
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,
-        related_name="setor_responsavel",
+        related_name="setor_como_chefe",
         help_text="Chefe responsável pelo setor.",
+    )
+    auxiliar_responsavel = models.OneToOneField(  # TODO: assumir a modelagem de “auxiliar responsável nomeado” e propagar a regra pelo sistema inteiro. ajustar lógicas, admin, seed e testes para refletir isso.
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="setor_como_auxiliar",
+        help_text="Auxiliar responsável pelo setor",
+        null=True,
+        blank=True,
     )
     is_active = models.BooleanField(
         default=True,
@@ -48,21 +56,19 @@ class Setor(models.Model):
         if not self.chefe_responsavel_id:
             return
 
-        chefe_setor = getattr(self.chefe_responsavel, "setor", None)
-        if chefe_setor is self:
+        setor_do_chefe = getattr(self.chefe_responsavel, "setor", None)
+        if setor_do_chefe is self:
             return
         if self.pk and self.chefe_responsavel.setor_id == self.pk:
             return
 
-        if chefe_setor is None:
-            raise ValidationError(
-                {"chefe_responsavel": "O chefe responsável deve pertencer a este setor."}
-            )
+        if setor_do_chefe is None:
+            raise ValidationError({"chefe_responsavel": "O usuário não possui setor atribuído."})
 
         raise ValidationError(
             {
                 "chefe_responsavel": (
-                    f"O chefe responsável pertence ao setor '{chefe_setor.nome}', não a este setor."
+                    f"O chefe responsável pertence ao setor '{setor_do_chefe.nome}', não a este setor."
                 )
             }
         )

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -51,26 +51,37 @@ class Setor(models.Model):
     def __str__(self):
         return f"{self.nome} (Chefe: {self.chefe_responsavel.matricula_funcional})"
 
-    def clean(self):
-        super().clean()
-        if not self.chefe_responsavel_id:
+    def _validar_responsavel_no_setor(self, *, field_name: str, label: str) -> None:
+        if not getattr(self, f"{field_name}_id"):
             return
 
-        setor_do_chefe = getattr(self.chefe_responsavel, "setor", None)
-        if setor_do_chefe is self:
+        responsavel = getattr(self, field_name)
+        setor_do_responsavel = getattr(responsavel, "setor", None)
+        if setor_do_responsavel is self:
             return
-        if self.pk and self.chefe_responsavel.setor_id == self.pk:
+        if self.pk and responsavel.setor_id == self.pk:
             return
 
-        if setor_do_chefe is None:
-            raise ValidationError({"chefe_responsavel": "O usuário não possui setor atribuído."})
+        if setor_do_responsavel is None:
+            raise ValidationError({field_name: "O usuário não possui setor atribuído."})
 
         raise ValidationError(
             {
-                "chefe_responsavel": (
-                    f"O chefe responsável pertence ao setor '{setor_do_chefe.nome}', não a este setor."
+                field_name: (
+                    f"O {label} pertence ao setor '{setor_do_responsavel.nome}', não a este setor."
                 )
             }
+        )
+
+    def clean(self):
+        super().clean()
+        self._validar_responsavel_no_setor(
+            field_name="chefe_responsavel",
+            label="chefe responsável",
+        )
+        self._validar_responsavel_no_setor(
+            field_name="auxiliar_responsavel",
+            label="auxiliar responsável",
         )
 
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -28,7 +28,9 @@ class Setor(models.Model):
         related_name="setor_como_chefe",
         help_text="Chefe responsável pelo setor.",
     )
-    auxiliar_responsavel = models.OneToOneField(  # TODO: assumir a modelagem de “auxiliar responsável nomeado” e propagar a regra pelo sistema inteiro. ajustar lógicas, admin, seed e testes para refletir isso.
+    # Auxiliary ownership is provisional and may later expand to admin, seed,
+    # policies, and tests once the full workflow is closed.
+    auxiliar_responsavel = models.OneToOneField(
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,
         related_name="setor_como_auxiliar",
@@ -57,9 +59,7 @@ class Setor(models.Model):
 
         responsavel = getattr(self, field_name)
         setor_do_responsavel = getattr(responsavel, "setor", None)
-        if setor_do_responsavel is self:
-            return
-        if self.pk and responsavel.setor_id == self.pk:
+        if setor_do_responsavel is not None and setor_do_responsavel.pk == self.pk:
             return
 
         if setor_do_responsavel is None:

--- a/apps/users/policies.py
+++ b/apps/users/policies.py
@@ -94,9 +94,6 @@ def queryset_beneficiarios_lookup_para(criador) -> QuerySet[User]:
     if not criador.is_authenticated or not criador.is_active:
         return queryset.none()
 
-    if criador.is_superuser:
-        return queryset
-
     if usuario_almoxarifado(criador):
         return queryset
 

--- a/apps/users/policies.py
+++ b/apps/users/policies.py
@@ -12,8 +12,29 @@ from django.db.models import QuerySet
 from .models import PapelChoices, User
 
 
-def _user_ativo_nao_superuser(user) -> bool:
-    return user.is_active and not user.is_superuser
+def usuario_operacional_ativo(user) -> bool:
+    return user.is_authenticated and user.is_active and not user.is_superuser
+
+
+def usuario_almoxarifado(user) -> bool:
+    return usuario_operacional_ativo(user) and user.papel in (
+        PapelChoices.AUXILIAR_ALMOXARIFADO,
+        PapelChoices.CHEFE_ALMOXARIFADO,
+    )
+
+
+def usuario_chefe_almoxarifado(user) -> bool:
+    return usuario_operacional_ativo(user) and user.papel == PapelChoices.CHEFE_ALMOXARIFADO
+
+
+def setor_responsavel_chefia(user):
+    if not usuario_operacional_ativo(user) or user.papel not in (
+        PapelChoices.CHEFE_SETOR,
+        PapelChoices.CHEFE_ALMOXARIFADO,
+    ):
+        return None
+
+    return getattr(user, "setor_como_chefe", None)
 
 
 def pode_criar_requisicao_para(criador, beneficiario) -> bool:
@@ -21,7 +42,7 @@ def pode_criar_requisicao_para(criador, beneficiario) -> bool:
     Verifica se `criador` pode criar uma requisição em nome de `beneficiario`.
 
     Regras (matriz-permissoes.md, seção 4):
-    - Solicitante: apenas para si mesmo.
+    - Solicitante: apenas para si.
     - Auxiliar de setor: apenas para funcionários do próprio setor.
     - Chefe de setor: apenas para funcionários do próprio setor.
     - Auxiliar de Almoxarifado: qualquer funcionário.
@@ -29,13 +50,13 @@ def pode_criar_requisicao_para(criador, beneficiario) -> bool:
     - Superusuário: nunca (suporte/admin, não operador cotidiano).
     - Usuário inativo: nunca (invariante USR-03).
     """
-    if not _user_ativo_nao_superuser(criador):
+    if not usuario_operacional_ativo(criador):
         return False
 
-    papel = criador.papel
-
-    if papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+    if usuario_almoxarifado(criador):
         return True
+
+    papel = criador.papel
 
     if papel == PapelChoices.SOLICITANTE:
         return criador.pk == beneficiario.pk
@@ -43,14 +64,15 @@ def pode_criar_requisicao_para(criador, beneficiario) -> bool:
     if papel == PapelChoices.AUXILIAR_SETOR:
         if criador.setor_id is None or beneficiario.setor_id is None:
             return False
-        setor_escopo_id = criador.setor_id
-        return setor_escopo_id == beneficiario.setor_id
+        setor_responsavel = criador.setor_id
+        return setor_responsavel == beneficiario.setor_id
 
     if papel == PapelChoices.CHEFE_SETOR:
-        setor_responsavel = getattr(criador, "setor_responsavel", None)
-        if setor_responsavel is None or beneficiario.setor_id is None:
-            return False
-        return setor_responsavel.pk == beneficiario.setor_id
+        setor_responsavel = setor_responsavel_chefia(criador)
+        return (
+            beneficiario.setor_id is not None
+            and getattr(setor_responsavel, "pk", None) == beneficiario.setor_id
+        )
 
     return False
 
@@ -63,16 +85,16 @@ def queryset_beneficiarios_lookup_para(criador) -> QuerySet[User]:
         setor__is_active=True,
     )
 
-    if not criador.is_active:
+    if not criador.is_authenticated or not criador.is_active:
         return queryset.none()
 
     if criador.is_superuser:
         return queryset
 
-    papel = criador.papel
-
-    if papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+    if usuario_almoxarifado(criador):
         return queryset
+
+    papel = criador.papel
 
     if papel == PapelChoices.SOLICITANTE:
         return queryset.filter(pk=criador.pk)
@@ -83,7 +105,7 @@ def queryset_beneficiarios_lookup_para(criador) -> QuerySet[User]:
         return queryset.filter(setor_id=criador.setor_id)
 
     if papel == PapelChoices.CHEFE_SETOR:
-        setor_responsavel = getattr(criador, "setor_responsavel", None)
+        setor_responsavel = setor_responsavel_chefia(criador)
         if setor_responsavel is None:
             return queryset.none()
         return queryset.filter(setor=setor_responsavel)
@@ -102,21 +124,16 @@ def pode_autorizar_setor(autorizador, setor) -> bool:
     - Demais papéis e superusuário: nunca.
     - Usuário inativo: nunca (invariante USR-03).
     """
-    if not _user_ativo_nao_superuser(autorizador):
+    if not usuario_operacional_ativo(autorizador):
         return False
 
     papel = autorizador.papel
 
-    if papel == PapelChoices.CHEFE_SETOR:
-        setor_responsavel = getattr(autorizador, "setor_responsavel", None)
+    if papel in (PapelChoices.CHEFE_SETOR, PapelChoices.CHEFE_ALMOXARIFADO):
+        setor_responsavel = setor_responsavel_chefia(autorizador)
         if setor_responsavel is None:
             return False
         return setor_responsavel.pk == setor.pk
-
-    if papel == PapelChoices.CHEFE_ALMOXARIFADO:
-        if autorizador.setor_id is None:
-            return False
-        return autorizador.setor_id == setor.pk
 
     return False
 
@@ -132,13 +149,7 @@ def pode_ver_fila_atendimento(user) -> bool:
     - Demais papéis: não.
     - Usuário inativo: nunca (invariante USR-03).
     """
-    if not _user_ativo_nao_superuser(user):
-        return False
-
-    return user.papel in (
-        PapelChoices.AUXILIAR_ALMOXARIFADO,
-        PapelChoices.CHEFE_ALMOXARIFADO,
-    )
+    return usuario_almoxarifado(user)
 
 
 def pode_operar_estoque(user) -> bool:
@@ -153,13 +164,7 @@ def pode_operar_estoque(user) -> bool:
     - Demais papéis: não.
     - Usuário inativo: nunca (invariante USR-03).
     """
-    if not _user_ativo_nao_superuser(user):
-        return False
-
-    return user.papel in (
-        PapelChoices.AUXILIAR_ALMOXARIFADO,
-        PapelChoices.CHEFE_ALMOXARIFADO,
-    )
+    return usuario_almoxarifado(user)
 
 
 def pode_operar_estoque_chefia(user) -> bool:
@@ -174,7 +179,4 @@ def pode_operar_estoque_chefia(user) -> bool:
     - Demais papéis: não.
     - Usuário inativo: nunca (invariante USR-03).
     """
-    if not _user_ativo_nao_superuser(user):
-        return False
-
-    return user.papel == PapelChoices.CHEFE_ALMOXARIFADO
+    return usuario_chefe_almoxarifado(user)

--- a/apps/users/policies.py
+++ b/apps/users/policies.py
@@ -34,7 +34,13 @@ def setor_responsavel_chefia(user):
     ):
         return None
 
-    return getattr(user, "setor_como_chefe", None)
+    setor = getattr(user, "setor_como_chefe", None)
+    if (
+        user.papel == PapelChoices.CHEFE_ALMOXARIFADO
+        and getattr(setor, "nome", None) != "Almoxarifado"
+    ):
+        return None
+    return setor
 
 
 def pode_criar_requisicao_para(criador, beneficiario) -> bool:

--- a/docs/design-acesso-rapido/api-contracts.md
+++ b/docs/design-acesso-rapido/api-contracts.md
@@ -75,12 +75,16 @@ Contrato da lista pessoal usada por `Minhas requisições` na SPA do piloto:
 - autenticação: sessão Django padrão;
 - autorização geral: usuário autenticado;
 - autorização contextual: `queryset_requisicoes_pessoais()`;
-- escopo: `criador_id = user.id OR beneficiario_id = user.id`;
+- escopo:
+  - em `rascunho`: apenas `criador_id = user.id`;
+  - fora de `rascunho`: `criador_id = user.id OR beneficiario_id = user.id`;
+  - após `envio`, o beneficiário passa a ver a requisição; se houver retorno para `rascunho`, perde o acesso novamente;
+  - nota: a formulação anterior `criador_id = user.id OR beneficiario_id = user.id` sem exceção para `rascunho` estava incorreta.
 - sem ampliação por papel operacional, setor responsável, Almoxarifado ou suporte/admin;
 - entrada: sem body;
 - query params: `page`, `page_size`, `search` e `status`;
 - saída: `200` com envelope paginado de `RequisicaoListOutputSerializer`;
-- erros esperados: `401 not_authenticated`/`403 permission_denied` conforme autenticação da API.
+- erros esperados: `403 not_authenticated` para sessão ausente ou expirada e `403 permission_denied` quando o usuário autenticado não puder acessar a rota.
 
 ### 3.2. `POST /api/v1/requisitions/{id}/fulfill/`
 
@@ -148,7 +152,8 @@ Campos:
 Mapeamento base:
 
 - `400 validation_error`: payload inválido ou erro de serializer;
-- `401 not_authenticated`: usuário não autenticado;
+- `401 not_authenticated`: apenas endpoints que optam por `SessionAuthentication401` retornam `401` quando a sessão não está autenticada;
+- `403 not_authenticated`: endpoints com `SessionAuthentication` padrão retornam `403` quando a sessão não está autenticada;
 - `403 permission_denied`: usuário autenticado sem permissão para a ação;
 - `404 not_found`: recurso inexistente ou fora do escopo visível;
 - `409 domain_conflict`: estado atual impede a operação, saldo mudou, transição inválida ou regra de domínio conflitou com dados atuais;

--- a/docs/design-acesso-rapido/api-contracts.md
+++ b/docs/design-acesso-rapido/api-contracts.md
@@ -68,7 +68,21 @@ Padrão de status:
 
 Qualquer exceção a esse padrão deve ser documentada no `@extend_schema`, nos testes de contrato e, quando afetar contrato público, no documento de domínio ou backlog correspondente.
 
-### 3.1. `POST /api/v1/requisitions/{id}/fulfill/`
+### 3.1. `GET /api/v1/requisitions/mine/`
+
+Contrato da lista pessoal usada por `Minhas requisições` na SPA do piloto:
+
+- autenticação: sessão Django padrão;
+- autorização geral: usuário autenticado;
+- autorização contextual: `queryset_requisicoes_pessoais()`;
+- escopo: `criador_id = user.id OR beneficiario_id = user.id`;
+- sem ampliação por papel operacional, setor responsável, Almoxarifado ou suporte/admin;
+- entrada: sem body;
+- query params: `page`, `page_size`, `search` e `status`;
+- saída: `200` com envelope paginado de `RequisicaoListOutputSerializer`;
+- erros esperados: `401 not_authenticated`/`403 permission_denied` conforme autenticação da API.
+
+### 3.2. `POST /api/v1/requisitions/{id}/fulfill/`
 
 Contrato do atendimento de requisição autorizada:
 

--- a/docs/design-acesso-rapido/estado-transicoes-requisicao.md
+++ b/docs/design-acesso-rapido/estado-transicoes-requisicao.md
@@ -20,7 +20,7 @@ Fontes completas: `docs/design-acesso-ocasional/processos-almoxarifado.md`, `mod
 
 | Estado | Técnico | Papel no fluxo | Itens editáveis? | Estoque/reserva | Final? |
 |---|---|---|---|---|---|
-| Rascunho | `rascunho` | Criação/correção antes da autorização. | Sim, criador ou beneficiário. | Sem reserva/baixa. | Não |
+| Rascunho | `rascunho` | Criação/correção antes da autorização. | Sim, só criador. | Sem reserva/baixa. | Não |
 | Aguardando autorização | `aguardando_autorizacao` | Fila do chefe do setor do beneficiário. | Não; deve retornar para rascunho. | Sem reserva/baixa. | Não |
 | Recusada | `recusada` | Recusa da requisição inteira com motivo. | Só no fluxo de correção pelo criador/beneficiário. | Sem reserva/baixa. | Não |
 | Autorizada | `autorizada` | Disponível para atendimento pelo Almoxarifado. | Não | Reserva criada na autorização. | Não |
@@ -34,9 +34,9 @@ Fontes completas: `docs/design-acesso-ocasional/processos-almoxarifado.md`, `mod
 | Evento | Técnico | Quando | Responsável | Justificativa |
 |---|---|---|---|---|
 | Criação | `criacao` | Criação do rascunho ou formalização no primeiro envio. | Criador | Não |
-| Envio | `envio_autorizacao` | Rascunho vai para autorização. | Criador ou beneficiário | Não |
+| Envio | `envio_autorizacao` | Rascunho vai para autorização. | Criador | Não |
 | Retorno para rascunho | `retorno_rascunho` | `aguardando_autorizacao` volta para correção. | Criador ou beneficiário | Não |
-| Reenvio | `reenvio_autorizacao` | Recusada ou retornada é reenviada. | Criador ou beneficiário | Não |
+| Reenvio | `reenvio_autorizacao` | Rascunho retornado é reenviado para autorização. | Criador | Não |
 | Recusa | `recusa` | Chefe recusa a requisição inteira. | Chefe do setor do beneficiário | Sim |
 | Autorização total | `autorizacao_total` | Todos os itens autorizados integralmente. | Chefe do setor do beneficiário | Não |
 | Autorização parcial | `autorizacao_parcial` | Algum item autorizado abaixo do solicitado ou zerado. | Chefe do setor do beneficiário | Sim, por item |
@@ -53,12 +53,12 @@ Fontes completas: `docs/design-acesso-ocasional/processos-almoxarifado.md`, `mod
 | ID | De -> Para | Ação | Atores | Regras críticas | Efeitos | Ref. |
 |---|---|---|---|---|---|---|
 | TR-001 | N/A -> Rascunho | Criar requisição | Solicitante para si; chefe/auxiliar de setor no próprio setor; Almoxarifado qualquer setor | Usuário ativo; beneficiário permitido; setor ativo; ao menos um item; material ativo, sem divergência, saldo positivo; quantidade <= saldo disponível inicial | Cria cabeçalho, itens, criador, beneficiário e setor do beneficiário; sem número público | 1.1, 11 |
-| TR-002 | Rascunho -> Rascunho | Editar rascunho | Criador ou beneficiário | Itens continuam válidos | Atualiza itens/observações editáveis; sem estoque | 1.8, 1.9 |
-| TR-003 | Rascunho -> descartado | Descartar rascunho nunca enviado | Criador ou beneficiário | Nunca enviado; sem número público | Pode excluir/descartar sem timeline formal, reserva ou movimentação | 1.9 |
-| TR-004 | Rascunho -> Cancelada | Cancelar rascunho já numerado | Criador ou beneficiário | Já enviado e retornado; preserva número público | Encerra logicamente; bloqueia edição/reenvio/atendimento | 1.9, 9.5 |
-| TR-005 | Rascunho -> Aguardando autorização | Enviar | Criador ou beneficiário | Ao menos um item; gera `REQ-AAAA-NNNNNN` no primeiro envio | Registra envio; entra na fila do chefe do setor do beneficiário; bloqueia edição | 1.6, 9.1 |
-| TR-006 | Aguardando autorização -> Rascunho | Retornar para rascunho | Criador ou beneficiário | Ainda não autorizada/recusada | Remove da fila; preserva número; resolve notificação pendente | 1.7, 1.8, 9.6 |
-| TR-007 | Recusada/Rascunho -> Aguardando autorização | Reenviar | Criador ou beneficiário | Correções permitidas; ao menos um item; preserva número se existir | Retorna à fila; registra reenvio | 2.6, 9.1 |
+| TR-002 | Rascunho -> Rascunho | Editar rascunho | Criador | Itens continuam válidos | Atualiza itens/observações editáveis; sem estoque | 1.8, 1.9 |
+| TR-003 | Rascunho -> descartado | Descartar rascunho nunca enviado | Criador | Nunca enviado; sem número público | Pode excluir/descartar sem timeline formal, reserva ou movimentação | 1.9 |
+| TR-004 | Rascunho -> Cancelada | Cancelar rascunho já numerado | Criador | Já enviado e retornado; preserva número público | Encerra logicamente; bloqueia edição/reenvio/atendimento | 1.9, 9.5 |
+| TR-005 | Rascunho -> Aguardando autorização | Enviar | Criador | Ao menos um item; gera `REQ-AAAA-NNNNNN` no primeiro envio | Registra envio; entra na fila do chefe do setor do beneficiário; a partir daqui beneficiário passa a poder visualizar a requisição | 1.6, 9.1 |
+| TR-006 | Aguardando autorização -> Rascunho | Retornar para rascunho | Criador ou beneficiário | Ainda não autorizada/recusada | Remove da fila; preserva número; resolve notificação pendente; após concluir, rascunho volta a ser creator-only | 1.7, 1.8, 9.6 |
+| TR-007 | Recusada/Rascunho -> Aguardando autorização | Reenviar | Criador | Correções permitidas; ao menos um item; preserva número se existir | Retorna à fila; registra reenvio | 2.6, 9.1 |
 | TR-008 | Aguardando autorização -> Autorizada | Autorizar total | Chefe do setor do beneficiário; chefe Almoxarifado só para setor Almoxarifado | Itens ativos, sem divergência, saldo disponível atual suficiente; lock de estoque | Persiste autorização; cria reserva; não baixa físico; notifica criador, beneficiário e Almoxarifado | 2.1, 2.2, 2.7-2.10, 9.2 |
 | TR-009 | Aguardando autorização -> Autorizada | Autorizar parcial | Chefe do setor do beneficiário; chefe Almoxarifado só para setor Almoxarifado | Ao menos um item > 0; justificativa para parcial/zero; autorizado <= disponível atual; lock | Reserva apenas autorizado > 0; não baixa físico; notifica envolvidos | 2.3, 2.4, 2.7-2.10, 9.2 |
 | TR-010 | Aguardando autorização -> Aguardando autorização | Bloquear autorização inválida | Chefe do setor do beneficiário | Todos itens zerados, divergência crítica ou autorização acima do saldo atual | Não transiciona; orientar recusa, reduzir autorização ou resolver divergência | 2.5, 2.8-2.11, 7.3, 8.8 |

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -157,6 +157,7 @@ O frontend do piloto fica bloqueado até concluir:
    - `GET /api/v1/users/beneficiary-lookup/?q=...`
 3. Leituras canônicas de requisição:
    - `GET /api/v1/requisitions/`
+   - `GET /api/v1/requisitions/mine/`
    - `GET /api/v1/requisitions/{id}/`
 4. Update de rascunho:
    - ação/endpoint explícito de atualização por substituição completa do rascunho
@@ -167,7 +168,11 @@ Regras complementares:
 - mínimo de 3 caracteres;
 - retorno curto, sem paginação;
 - só usuários ativos e aptos ao fluxo;
-- `GET /api/v1/requisitions/` deve ser paginado e ter busca textual simples + filtro por status;
+- `GET /api/v1/requisitions/` continua representando visibilidade operacional ampla;
+- `GET /api/v1/requisitions/mine/` alimenta `Minhas requisições` e deve retornar:
+  - em `rascunho`: apenas requisições com `criador_id = user.id`;
+  - fora de `rascunho`: requisições com `criador_id = user.id OR beneficiario_id = user.id`;
+- ambas as listas devem ser paginadas e ter busca textual simples + filtro por status quando expostas à SPA;
 - lista de requisições usa serializer próprio e mais leve que o detalhe.
 
 ## 9. Sequência de implementação
@@ -200,8 +205,10 @@ Estado atual após a fatia #37:
 ### Minhas requisições
 
 - lista única;
+- consome `GET /api/v1/requisitions/mine/`, não a lista operacional ampla;
 - mostrar `numero_publico` ou badge `Rascunho`;
 - destacar beneficiário quando for diferente do usuário logado;
+- beneficiário terceiro só enxerga a requisição depois que ela sai de `rascunho`; se ela voltar para `rascunho`, deve sumir da lista e o detalhe passa a responder `404`;
 - ordenar por atualização mais recente;
 - filtros mínimos: busca textual e status;
 - datas exibidas são derivadas contextualmente do status.

--- a/docs/design-acesso-rapido/matriz-permissoes.md
+++ b/docs/design-acesso-rapido/matriz-permissoes.md
@@ -48,12 +48,12 @@ Valores: **Sim**, **Não**, **Apenas próprio setor**, **Qualquer setor**, **Ape
 | Criar para funcionário do próprio setor | Não | Apenas próprio setor | Apenas próprio setor | Qualquer setor | Qualquer setor | Não | Setor da requisição = setor do beneficiário. |
 | Criar para funcionário de outro setor | Não | Não | Não | Qualquer setor | Qualquer setor | Não | Almoxarifado pode criar para qualquer funcionário. |
 | Ver próprias requisições como criador | Sim | Sim | Sim | Sim | Sim | Apenas suporte/admin |  |
-| Ver próprias requisições como beneficiário | Sim | Sim | Sim | Sim | Sim | Apenas suporte/admin |  |
-| Ver requisições do setor | Não | Não | Apenas próprio setor | Qualquer setor | Qualquer setor | Apenas suporte/admin | Chefe vê setor sob responsabilidade. |
-| Ver todos os setores | Não | Não | Não | Sim | Sim | Apenas suporte/admin | Operação de Almoxarifado/suporte. |
-| Editar rascunho | Sim | Sim | Sim | Sim | Sim | Não | Só criador ou beneficiário. |
-| Enviar para autorização | Sim | Sim | Sim | Sim | Sim | Não | Só criador ou beneficiário. |
-| Retornar para rascunho | Sim | Sim | Sim | Sim | Sim | Não | Só criador ou beneficiário. |
+| Ver próprias requisições como beneficiário | Sim | Sim | Sim | Sim | Sim | Apenas suporte/admin | Exceto rascunho criado por terceiro. |
+| Ver requisições do setor | Não | Não | Apenas próprio setor | Qualquer setor | Qualquer setor | Apenas suporte/admin | Chefe vê setor sob responsabilidade; rascunho de terceiro segue creator-only. |
+| Ver todos os setores | Não | Não | Não | Sim | Sim | Apenas suporte/admin | Operação de Almoxarifado/suporte; rascunho de terceiro segue creator-only. |
+| Editar rascunho | Sim | Sim | Sim | Sim | Sim | Não | Só criador. |
+| Enviar para autorização | Sim | Sim | Sim | Sim | Sim | Não | Só criador. |
+| Retornar para rascunho | Sim | Sim | Sim | Sim | Sim | Não | Criador ou beneficiário enquanto ainda estiver em `aguardando_autorizacao`; depois do retorno, rascunho volta a ser creator-only. |
 | Cancelar aguardando autorização | Sim | Sim | Sim | Sim | Sim | Não | Só criador ou beneficiário. |
 | Cancelar autorizada | Sim | Sim | Sim | Sim | Sim | Não | Criador/beneficiário/Almoxarifado; justificativa. |
 | Copiar atendida/parcial | Sim | Sim | Sim | Sim | Sim | Não | Precisa ver origem e poder criar para beneficiário resultante. |
@@ -96,9 +96,10 @@ Valores: **Sim**, **Não**, **Apenas próprio setor**, **Qualquer setor**, **Ape
 
 ## 5. Visibilidade
 
-- Criador e beneficiário veem a própria requisição e timeline completa.
-- Chefe de setor vê requisições do setor sob sua responsabilidade.
-- Almoxarifado vê requisições de todos os setores e fila de atendimento.
+- Rascunho é visível e manipulável apenas pelo criador; ao sair de `rascunho`, o beneficiário passa a poder ver a requisição e perde esse acesso se ela voltar para `rascunho`.
+- Fora de `rascunho`, criador e beneficiário veem a própria requisição e timeline completa.
+- Chefe de setor vê requisições do setor sob sua responsabilidade, exceto rascunhos de terceiros.
+- Almoxarifado vê requisições de todos os setores fora de rascunhos de terceiros e vê a fila de atendimento.
 - Chefe de setor vê fila de autorização do próprio setor; chefe de Almoxarifado vê apenas setor Almoxarifado.
 - Superusuário vê para suporte/administração, sem ações operacionais de estoque.
 - Relatórios gerais: Almoxarifado e suporte/admin. Chefe de setor: apenas relatórios do próprio setor.

--- a/frontend/openapi/schema.json
+++ b/frontend/openapi/schema.json
@@ -1179,6 +1179,76 @@
                 }
             }
         },
+        "/api/v1/requisitions/mine/": {
+            "get": {
+                "operationId": "requisitions_mine",
+                "description": "Lista paginada das requisições pessoais do usuário autenticado. Inclui apenas requisições em que o usuário é criador ou beneficiário.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Número da página (padrão: 1)"
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Quantidade de resultados por página (padrão: 20, máximo: 100)"
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Busca textual por número público, nome do beneficiário ou nome do criador."
+                    },
+                    {
+                        "in": "query",
+                        "name": "status",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Filtro exato por status da requisição."
+                    }
+                ],
+                "tags": [
+                    "requisitions"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/RequisicaoListPaginated"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1/requisitions/pending-approvals/": {
             "get": {
                 "operationId": "requisitions_pending_approvals",

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -152,6 +152,19 @@ export function formatDateTime(value: string | null | undefined) {
   }).format(date);
 }
 
+export function formatQuantity(value: string) {
+  const fractionDigits = value.includes(".") ? value.split(".")[1].length : 0;
+  const numericValue = Number.parseFloat(value);
+  if (Number.isNaN(numericValue)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat("pt-BR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: fractionDigits,
+  }).format(numericValue);
+}
+
 export function queryErrorMessage(error: unknown, fallback: string) {
   if (error instanceof Error && error.message) {
     return error.message;

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -132,7 +132,7 @@ export function isThirdPartyBeneficiary(item: RequisicaoListItem | RequisicaoDet
 }
 
 export function displayRequisitionIdentifier(requisicao: Pick<RequisicaoListItem, "numero_publico">) {
-  return requisicao.numero_publico ?? "Rascunho";
+  return requisicao.numero_publico ?? null;
 }
 
 export function formatDateTime(value: string | null | undefined) {
@@ -140,10 +140,15 @@ export function formatDateTime(value: string | null | undefined) {
     return "Não informado";
   }
 
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Não informado";
+  }
+
   return new Intl.DateTimeFormat("pt-BR", {
     dateStyle: "medium",
     timeStyle: "short",
-  }).format(new Date(value));
+  }).format(date);
 }
 
 export function tipoEventoLabel(tipoEvento: RequisicaoTimelineEventType) {

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -1,0 +1,148 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { ApiError, type ErrorResponse } from "../auth/session";
+import { apiClient } from "../../shared/api/client";
+import type { components } from "../../shared/api/schema";
+
+export type RequisicaoListItem = components["schemas"]["RequisicaoListOutput"];
+export type RequisicaoListResponse = components["schemas"]["RequisicaoListPaginated"];
+export type RequisicaoDetail = components["schemas"]["RequisicaoDetailOutput"];
+export type RequisicaoStatus = components["schemas"]["StatusEnum"];
+export type RequisicaoTimelineEvent = components["schemas"]["RequisicaoTimelineEventOutput"];
+export type RequisicaoActionItem = components["schemas"]["RequisicaoActionOutput"];
+
+export const STATUS_OPTIONS: Array<{ value: RequisicaoStatus; label: string }> = [
+  { value: "rascunho", label: "Rascunho" },
+  { value: "aguardando_autorizacao", label: "Aguardando autorização" },
+  { value: "recusada", label: "Recusada" },
+  { value: "autorizada", label: "Autorizada" },
+  { value: "atendida_parcialmente", label: "Atendida parcialmente" },
+  { value: "atendida", label: "Atendida" },
+  { value: "cancelada", label: "Cancelada" },
+  { value: "estornada", label: "Estornada" },
+];
+
+export type RequisicoesListParams = {
+  page: number;
+  pageSize: number;
+  search?: string;
+  status?: RequisicaoStatus;
+};
+
+export const requisitionsQueryKeys = {
+  all: ["requisitions"] as const,
+  mine: (params: RequisicoesListParams) =>
+    [
+      ...requisitionsQueryKeys.all,
+      "mine",
+      {
+        page: params.page,
+        pageSize: params.pageSize,
+        search: params.search ?? "",
+        status: params.status ?? "",
+      },
+    ] as const,
+  detail: (id: number) => [...requisitionsQueryKeys.all, "detail", id] as const,
+};
+
+function messageFromError(error: ErrorResponse | undefined, fallback: string) {
+  return error?.error?.message || fallback;
+}
+
+export async function fetchMyRequisitions(params: RequisicoesListParams) {
+  const { data, error, response } = await apiClient.GET("/api/v1/requisitions/mine/", {
+    params: {
+      query: {
+        page: params.page,
+        page_size: params.pageSize,
+        search: params.search || undefined,
+        status: params.status,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar requisições."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function fetchRequisitionDetail(id: number) {
+  const { data, error, response } = await apiClient.GET("/api/v1/requisitions/{id}/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar a requisição."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export function myRequisitionsQueryOptions(params: RequisicoesListParams) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.mine(params),
+    queryFn: () => fetchMyRequisitions(params),
+    retry: false,
+  });
+}
+
+export function requisitionDetailQueryOptions(id: number) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.detail(id),
+    queryFn: () => fetchRequisitionDetail(id),
+    retry: false,
+  });
+}
+
+export function statusLabel(status: RequisicaoStatus) {
+  return STATUS_OPTIONS.find((option) => option.value === status)?.label ?? status;
+}
+
+export function isThirdPartyBeneficiary(item: RequisicaoListItem | RequisicaoDetail) {
+  return item.beneficiario.id !== item.criador.id;
+}
+
+export function displayRequisitionIdentifier(requisicao: Pick<RequisicaoListItem, "numero_publico">) {
+  return requisicao.numero_publico ?? "Rascunho";
+}
+
+export function formatDateTime(value: string | null | undefined) {
+  if (!value) {
+    return "Não informado";
+  }
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+export function contextualDateLabel(requisicao: RequisicaoListItem) {
+  if (requisicao.data_finalizacao) {
+    return `Finalizada em ${formatDateTime(requisicao.data_finalizacao)}`;
+  }
+
+  if (requisicao.data_autorizacao_ou_recusa) {
+    return `Decidida em ${formatDateTime(requisicao.data_autorizacao_ou_recusa)}`;
+  }
+
+  if (requisicao.data_envio_autorizacao) {
+    return `Enviada em ${formatDateTime(requisicao.data_envio_autorizacao)}`;
+  }
+
+  return `Atualizada em ${formatDateTime(requisicao.updated_at)}`;
+}

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -1,4 +1,4 @@
-import { queryOptions } from "@tanstack/react-query";
+import { keepPreviousData, queryOptions } from "@tanstack/react-query";
 
 import { ApiError, isAuthError, type ErrorResponse } from "../auth/session";
 import { apiClient } from "../../shared/api/client";
@@ -111,6 +111,7 @@ export function myRequisitionsQueryOptions(params: RequisicoesListParams) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.mine(params),
     queryFn: () => fetchMyRequisitions(params),
+    placeholderData: keepPreviousData,
     retry: retryUnlessClientOrAuthError,
   });
 }

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -151,6 +151,14 @@ export function formatDateTime(value: string | null | undefined) {
   }).format(date);
 }
 
+export function queryErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return fallback;
+}
+
 export function tipoEventoLabel(tipoEvento: RequisicaoTimelineEventType) {
   return TIPO_EVENTO_OPTIONS.find((option) => option.value === tipoEvento)?.label ?? tipoEvento.replaceAll("_", " ");
 }

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -1,6 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 
-import { ApiError, type ErrorResponse } from "../auth/session";
+import { ApiError, isAuthError, type ErrorResponse } from "../auth/session";
 import { apiClient } from "../../shared/api/client";
 import type { components } from "../../shared/api/schema";
 
@@ -10,6 +10,7 @@ export type RequisicaoDetail = components["schemas"]["RequisicaoDetailOutput"];
 export type RequisicaoStatus = components["schemas"]["StatusEnum"];
 export type RequisicaoTimelineEvent = components["schemas"]["RequisicaoTimelineEventOutput"];
 export type RequisicaoActionItem = components["schemas"]["RequisicaoActionOutput"];
+export type RequisicaoTimelineEventType = components["schemas"]["TipoEventoEnum"];
 
 export const STATUS_OPTIONS: Array<{ value: RequisicaoStatus; label: string }> = [
   { value: "rascunho", label: "Rascunho" },
@@ -20,6 +21,20 @@ export const STATUS_OPTIONS: Array<{ value: RequisicaoStatus; label: string }> =
   { value: "atendida", label: "Atendida" },
   { value: "cancelada", label: "Cancelada" },
   { value: "estornada", label: "Estornada" },
+];
+
+const TIPO_EVENTO_OPTIONS: Array<{ value: RequisicaoTimelineEventType; label: string }> = [
+  { value: "criacao", label: "Criação" },
+  { value: "envio_autorizacao", label: "Envio para autorização" },
+  { value: "retorno_rascunho", label: "Retorno para rascunho" },
+  { value: "reenvio_autorizacao", label: "Reenvio para autorização" },
+  { value: "autorizacao_total", label: "Autorização total" },
+  { value: "autorizacao_parcial", label: "Autorização parcial" },
+  { value: "recusa", label: "Recusa" },
+  { value: "atendimento_parcial", label: "Atendimento parcial" },
+  { value: "atendimento", label: "Atendimento" },
+  { value: "cancelamento", label: "Cancelamento" },
+  { value: "estorno", label: "Estorno" },
 ];
 
 export type RequisicoesListParams = {
@@ -96,7 +111,7 @@ export function myRequisitionsQueryOptions(params: RequisicoesListParams) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.mine(params),
     queryFn: () => fetchMyRequisitions(params),
-    retry: false,
+    retry: retryUnlessClientOrAuthError,
   });
 }
 
@@ -104,7 +119,7 @@ export function requisitionDetailQueryOptions(id: number) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.detail(id),
     queryFn: () => fetchRequisitionDetail(id),
-    retry: false,
+    retry: retryUnlessClientOrAuthError,
   });
 }
 
@@ -126,9 +141,23 @@ export function formatDateTime(value: string | null | undefined) {
   }
 
   return new Intl.DateTimeFormat("pt-BR", {
-    dateStyle: "short",
+    dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
+}
+
+export function tipoEventoLabel(tipoEvento: RequisicaoTimelineEventType) {
+  return TIPO_EVENTO_OPTIONS.find((option) => option.value === tipoEvento)?.label ?? tipoEvento.replaceAll("_", " ");
+}
+
+function retryUnlessClientOrAuthError(failureCount: number, error: unknown) {
+  if (isAuthError(error)) {
+    return false;
+  }
+  if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+    return false;
+  }
+  return failureCount < 2;
 }
 
 export function contextualDateLabel(requisicao: RequisicaoListItem) {

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -1,46 +1,332 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import { useMemo, useState } from "react";
+import { z } from "zod";
 
 import { requireSession } from "../features/auth/guards";
-import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
+import { authQueryKeys, isAuthError } from "../features/auth/session";
+import {
+  contextualDateLabel,
+  formatDateTime,
+  isThirdPartyBeneficiary,
+  myRequisitionsQueryOptions,
+  statusLabel,
+  STATUS_OPTIONS,
+  type RequisicaoListItem,
+  type RequisicaoStatus,
+} from "../features/requisitions/requisitions";
 
-export const Route = createFileRoute("/minhas-requisicoes")({
-  beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
-  component: MinhasRequisicoesPlaceholderPage,
+const DEFAULT_PAGE_SIZE = 20;
+
+const requisitionsSearchSchema = z.object({
+  page: z.coerce.number().int().min(1).optional().catch(undefined),
+  search: z.string().optional().catch(undefined),
+  status: z
+    .enum([
+      "rascunho",
+      "aguardando_autorizacao",
+      "recusada",
+      "autorizada",
+      "atendida_parcialmente",
+      "atendida",
+      "cancelada",
+      "estornada",
+    ])
+    .optional()
+    .catch(undefined),
 });
 
-function MinhasRequisicoesPlaceholderPage() {
+export const Route = createFileRoute("/minhas-requisicoes")({
+  validateSearch: requisitionsSearchSchema,
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
+  component: MinhasRequisicoesPage,
+});
+
+function queryErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Não foi possível carregar os dados.";
+}
+
+function StatusBadge({ status }: { status: RequisicaoStatus }) {
+  return <span className={`req-status req-status-${status}`}>{statusLabel(status)}</span>;
+}
+
+function IdentifierCell({ requisicao }: { requisicao: RequisicaoListItem }) {
+  if (requisicao.numero_publico) {
+    return <span className="font-semibold text-[var(--ink-strong)]">{requisicao.numero_publico}</span>;
+  }
+
+  return <span className="draft-badge">Rascunho</span>;
+}
+
+function EmptyState() {
   return (
-    <FeaturePlaceholder
-      kicker="Worklist read model"
-      title="Minhas requisições"
-      summary="Worklist canônica do solicitante e do auxiliar de setor. Estrutura visual já reservada para lista única, destaque de terceiro e filtros mínimos."
-      nextSlice="#38 — minhas requisições + detalhe canônico"
-      contracts={[
-        "GET /api/v1/requisitions/?page=&page_size=&search=&status=",
-        "GET /api/v1/requisitions/{id}/",
-      ]}
-      bullets={[
-        "Lista única com rascunhos e formais.",
-        "Destaque visual quando beneficiário != usuário logado.",
-        "Entrada no detalhe canônico sem telas paralelas.",
-      ]}
-      preview={
-        <div className="preview-panel">
-          <div className="preview-row">
-            <span>Rascunho</span>
-            <span className="preview-meta">beneficiário terceiro</span>
+    <div className="empty-state">
+      <p className="eyebrow">Sem resultados</p>
+      <h3>Nenhuma requisição encontrada</h3>
+      <p>Ajuste busca ou status para voltar à lista operacional.</p>
+    </div>
+  );
+}
+
+function MinhasRequisicoesPage() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/minhas-requisicoes" });
+  const searchParams = Route.useSearch();
+  const currentPage = searchParams.page ?? 1;
+  const currentSearch = searchParams.search ?? "";
+  const [searchDraft, setSearchDraft] = useState(currentSearch);
+  const listQuery = useQuery(
+    myRequisitionsQueryOptions({
+      page: currentPage,
+      pageSize: DEFAULT_PAGE_SIZE,
+      search: currentSearch.trim() || undefined,
+      status: searchParams.status,
+    }),
+  );
+
+  const rows = listQuery.data?.results ?? [];
+  const columns = useMemo<ColumnDef<RequisicaoListItem>[]>(
+    () => [
+      {
+        id: "identifier",
+        header: "Requisição",
+        cell: ({ row }) => (
+          <div className="min-w-[11rem]">
+            <IdentifierCell requisicao={row.original} />
+            <p className="mt-2 text-xs uppercase tracking-[0.18em] text-[var(--ink-muted)]">
+              {row.original.total_itens} item{row.original.total_itens === 1 ? "" : "s"}
+            </p>
           </div>
-          <div className="preview-row">
-            <span>REQ-2026-0001</span>
-            <span className="preview-meta">aguardando autorização</span>
+        ),
+      },
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row }) => <StatusBadge status={row.original.status} />,
+      },
+      {
+        id: "beneficiario",
+        header: "Beneficiário",
+        cell: ({ row }) => {
+          const thirdParty = isThirdPartyBeneficiary(row.original);
+
+          return (
+            <div>
+              <p className="font-semibold">{row.original.beneficiario.nome_completo}</p>
+              <p className="mt-1 text-sm text-[var(--ink-soft)]">
+                {row.original.setor_beneficiario.nome}
+              </p>
+              {thirdParty ? <span className="third-party-badge">Beneficiário terceiro</span> : null}
+            </div>
+          );
+        },
+      },
+      {
+        id: "updated_at",
+        header: "Atualização",
+        cell: ({ row }) => (
+          <div className="text-sm text-[var(--ink-soft)]">
+            <p>{contextualDateLabel(row.original)}</p>
+            <p className="mt-1 text-xs uppercase tracking-[0.16em] text-[var(--ink-muted)]">
+              criada em {formatDateTime(row.original.data_criacao)}
+            </p>
           </div>
-          <div className="preview-row">
-            <span>REQ-2026-0002</span>
-            <span className="preview-meta">atendida parcialmente</span>
-          </div>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => (
+          <Link
+            className="action-link compact-action"
+            params={{ id: String(row.original.id) }}
+            to="/requisicoes/$id"
+          >
+            Abrir
+          </Link>
+        ),
+      },
+    ],
+    [],
+  );
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    columns,
+    data: rows,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    rowCount: listQuery.data?.count ?? 0,
+    state: {
+      pagination: {
+        pageIndex: currentPage - 1,
+        pageSize: DEFAULT_PAGE_SIZE,
+      },
+    },
+  });
+
+  async function updateSearch(nextSearch: string, nextStatus: RequisicaoStatus | undefined) {
+    await navigate({
+      search: (previous) => ({
+        ...previous,
+        page: undefined,
+        search: nextSearch.trim() || undefined,
+        status: nextStatus,
+      }),
+    });
+  }
+
+  async function goToPage(page: number) {
+    await navigate({
+      search: (previous) => ({
+        ...previous,
+        page: page === 1 ? undefined : page,
+      }),
+    });
+  }
+
+  if (listQuery.isError && isAuthError(listQuery.error)) {
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: "/minhas-requisicoes",
+      },
+    });
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="worklist-header">
+        <div>
+          <p className="eyebrow">Worklist operacional</p>
+          <h1>Minhas requisições</h1>
+          <p>
+            Lista única de rascunhos e requisições formais criadas por você ou em que você é
+            beneficiário.
+          </p>
         </div>
-      }
-    />
+        <div className="status-chip">
+          <span className="status-dot" />
+          {listQuery.data ? `${listQuery.data.count} registro(s)` : "Carregando"}
+        </div>
+      </div>
+
+      <form
+        className="filters-bar"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void updateSearch(searchDraft, searchParams.status);
+        }}
+      >
+        <label className="preview-label">
+          Busca
+          <input
+            className="preview-input"
+            name="search"
+            onChange={(event) => setSearchDraft(event.target.value)}
+            placeholder="Número público, beneficiário ou criador"
+            value={searchDraft}
+          />
+        </label>
+        <label className="preview-label">
+          Status
+          <select
+            className="preview-input"
+            name="status"
+            onChange={(event) => {
+              const status = event.target.value
+                ? (event.target.value as RequisicaoStatus)
+                : undefined;
+              void updateSearch(searchDraft, status);
+            }}
+            value={searchParams.status ?? ""}
+          >
+            <option value="">Todos</option>
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button className="preview-button filters-submit" type="submit">
+          Filtrar
+        </button>
+      </form>
+
+      {listQuery.isError && !isAuthError(listQuery.error) ? (
+        <div className="error-panel">{queryErrorMessage(listQuery.error)}</div>
+      ) : null}
+
+      <div className="table-frame">
+        {listQuery.isPending ? (
+          <div className="loading-state">Carregando requisições...</div>
+        ) : rows.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <table className="operational-table">
+            <thead>
+              {table.getHeaderGroups().map((headerGroup) => (
+                <tr key={headerGroup.id}>
+                  {headerGroup.headers.map((header) => (
+                    <th key={header.id}>
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                    </th>
+                  ))}
+                </tr>
+              ))}
+            </thead>
+            <tbody>
+              {table.getRowModel().rows.map((row) => (
+                <tr key={row.id}>
+                  {row.getVisibleCells().map((cell) => (
+                    <td key={cell.id}>
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <div className="pagination-bar">
+        <button
+          className="action-link compact-action"
+          disabled={currentPage <= 1 || listQuery.isPending}
+          onClick={() => void goToPage(currentPage - 1)}
+          type="button"
+        >
+          Anterior
+        </button>
+        <span>
+          Página {listQuery.data?.page ?? currentPage} de {listQuery.data?.total_pages ?? 1}
+        </span>
+        <button
+          className="action-link compact-action"
+          disabled={
+            listQuery.isPending ||
+            !listQuery.data ||
+            currentPage >= listQuery.data.total_pages
+          }
+          onClick={() => void goToPage(currentPage + 1)}
+          type="button"
+        >
+          Próxima
+        </button>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -88,6 +88,13 @@ function MinhasRequisicoesPage() {
     }),
   );
   const authError = listQuery.isError && isAuthError(listQuery.error);
+  const recordsLabel = listQuery.isLoading
+    ? "Carregando..."
+    : listQuery.isError && !listQuery.data
+      ? "Erro ao carregar"
+      : listQuery.data
+        ? `${listQuery.data.count} ${listQuery.data.count === 1 ? "registro" : "registros"}`
+        : "0 registros";
 
   useEffect(() => {
     setSearchDraft(currentSearch);
@@ -219,7 +226,7 @@ function MinhasRequisicoesPage() {
         </div>
         <div className="status-chip">
           <span className="status-dot" />
-          {listQuery.data ? `${listQuery.data.count} registro(s)` : "Carregando"}
+          {recordsLabel}
         </div>
       </div>
 
@@ -270,38 +277,40 @@ function MinhasRequisicoesPage() {
         <div className="error-panel">{queryErrorMessage(listQuery.error)}</div>
       ) : null}
 
-      <div className="table-frame">
-        {listQuery.isPending ? (
-          <div className="loading-state">Carregando requisições...</div>
-        ) : rows.length === 0 ? (
-          <EmptyState />
-        ) : (
-          <table className="operational-table">
-            <thead>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <th key={header.id}>
-                      {flexRender(header.column.columnDef.header, header.getContext())}
-                    </th>
-                  ))}
-                </tr>
-              ))}
-            </thead>
-            <tbody>
-              {table.getRowModel().rows.map((row) => (
-                <tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <td key={cell.id}>
-                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
+      {!listQuery.isError || authError ? (
+        <div className="table-frame">
+          {listQuery.isPending ? (
+            <div className="loading-state">Carregando requisições...</div>
+          ) : rows.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <table className="operational-table">
+              <thead>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th key={header.id}>
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody>
+                {table.getRowModel().rows.map((row) => (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      ) : null}
 
       <div className="pagination-bar">
         <button

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -66,7 +66,7 @@ function EmptyState() {
   return (
     <div className="empty-state">
       <p className="eyebrow">Sem resultados</p>
-      <h3>Nenhuma requisição encontrada</h3>
+      <h2>Nenhuma requisição encontrada</h2>
       <p>Ajuste busca ou status para voltar à lista operacional.</p>
     </div>
   );

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -89,6 +89,10 @@ function MinhasRequisicoesPage() {
   );
   const authError = listQuery.isError && isAuthError(listQuery.error);
 
+  useEffect(() => {
+    setSearchDraft(currentSearch);
+  }, [currentSearch]);
+
   const rows = listQuery.data?.results ?? [];
   const columns = useMemo<ColumnDef<RequisicaoListItem>[]>(
     () => [
@@ -245,7 +249,7 @@ function MinhasRequisicoesPage() {
               const status = event.target.value
                 ? (event.target.value as RequisicaoStatus)
                 : undefined;
-              void updateSearch(searchDraft, status);
+              void updateSearch(currentSearch, status);
             }}
             value={searchParams.status ?? ""}
           >

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -16,6 +16,7 @@ import {
   formatDateTime,
   isThirdPartyBeneficiary,
   myRequisitionsQueryOptions,
+  queryErrorMessage,
   statusLabel,
   STATUS_OPTIONS,
   type RequisicaoListItem,
@@ -41,14 +42,6 @@ export const Route = createFileRoute("/minhas-requisicoes")({
     requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: MinhasRequisicoesPage,
 });
-
-function queryErrorMessage(error: unknown) {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return "Não foi possível carregar os dados.";
-}
 
 function StatusBadge({ status }: { status: RequisicaoStatus }) {
   return <span className={`req-status req-status-${status}`}>{statusLabel(status)}</span>;
@@ -274,7 +267,9 @@ function MinhasRequisicoesPage() {
       </form>
 
       {listQuery.isError && !authError ? (
-        <div className="error-panel">{queryErrorMessage(listQuery.error)}</div>
+        <div className="error-panel">
+          {queryErrorMessage(listQuery.error, "Não foi possível carregar os dados.")}
+        </div>
       ) : null}
 
       {!listQuery.isError || authError ? (

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -6,7 +6,7 @@ import {
   useReactTable,
   type ColumnDef,
 } from "@tanstack/react-table";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { z } from "zod";
 
 import { requireSession } from "../features/auth/guards";
@@ -24,22 +24,15 @@ import {
 
 const DEFAULT_PAGE_SIZE = 20;
 
+const STATUS_VALUES = STATUS_OPTIONS.map((option) => option.value) as [
+  RequisicaoStatus,
+  ...RequisicaoStatus[],
+];
+
 const requisitionsSearchSchema = z.object({
   page: z.coerce.number().int().min(1).optional().catch(undefined),
   search: z.string().optional().catch(undefined),
-  status: z
-    .enum([
-      "rascunho",
-      "aguardando_autorizacao",
-      "recusada",
-      "autorizada",
-      "atendida_parcialmente",
-      "atendida",
-      "cancelada",
-      "estornada",
-    ])
-    .optional()
-    .catch(undefined),
+  status: z.enum(STATUS_VALUES).optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/minhas-requisicoes")({
@@ -94,6 +87,7 @@ function MinhasRequisicoesPage() {
       status: searchParams.status,
     }),
   );
+  const authError = listQuery.isError && isAuthError(listQuery.error);
 
   const rows = listQuery.data?.results ?? [];
   const columns = useMemo<ColumnDef<RequisicaoListItem>[]>(
@@ -105,7 +99,7 @@ function MinhasRequisicoesPage() {
           <div className="min-w-[11rem]">
             <IdentifierCell requisicao={row.original} />
             <p className="mt-2 text-xs uppercase tracking-[0.18em] text-[var(--ink-muted)]">
-              {row.original.total_itens} item{row.original.total_itens === 1 ? "" : "s"}
+              {row.original.total_itens} {row.original.total_itens === 1 ? "item" : "itens"}
             </p>
           </div>
         ),
@@ -195,7 +189,10 @@ function MinhasRequisicoesPage() {
     });
   }
 
-  if (listQuery.isError && isAuthError(listQuery.error)) {
+  useEffect(() => {
+    if (!authError) {
+      return;
+    }
     queryClient.removeQueries({ queryKey: authQueryKeys.me });
     void navigate({
       to: "/login",
@@ -203,7 +200,7 @@ function MinhasRequisicoesPage() {
         redirect: "/minhas-requisicoes",
       },
     });
-  }
+  }, [authError, navigate, queryClient]);
 
   return (
     <section className="space-y-6">
@@ -265,7 +262,7 @@ function MinhasRequisicoesPage() {
         </button>
       </form>
 
-      {listQuery.isError && !isAuthError(listQuery.error) ? (
+      {listQuery.isError && !authError ? (
         <div className="error-panel">{queryErrorMessage(listQuery.error)}</div>
       ) : null}
 

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -123,7 +123,7 @@ function DetalheRequisicaoPage() {
       <div className="detail-hero">
         <div>
           <p className="eyebrow">Detalhe canônico</p>
-          <h1>{displayRequisitionIdentifier(requisicao)}</h1>
+          <h1>{displayRequisitionIdentifier(requisicao) ?? statusLabel(requisicao.status)}</h1>
           <p>
             {statusLabel(requisicao.status)} - {requisicao.setor_beneficiario.nome}
           </p>

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -71,6 +71,12 @@ function DetalheRequisicaoPage() {
   const { id } = Route.useParams();
   const { contexto } = Route.useSearch();
   const requisicaoId = Number(id);
+  const backTo =
+    contexto === "autorizacao"
+      ? "/autorizacoes"
+      : contexto === "atendimento"
+        ? "/atendimentos"
+        : "/minhas-requisicoes";
   const queryClient = useQueryClient();
   const navigate = useNavigate({ from: "/requisicoes/$id" });
   const detailQuery = useQuery({
@@ -127,7 +133,7 @@ function DetalheRequisicaoPage() {
         </div>
         <div className="detail-actions">
           {contexto ? <span className="context-chip">Contexto: {contexto}</span> : null}
-          <Link className="action-link compact-action" to="/minhas-requisicoes">
+          <Link className="action-link compact-action" to={backTo}>
             Voltar
           </Link>
         </div>

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -1,48 +1,272 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
 
 import { requireSession } from "../../features/auth/guards";
-import { FeaturePlaceholder } from "../../shared/ui/feature-placeholder";
+import { authQueryKeys, isAuthError } from "../../features/auth/session";
+import {
+  displayRequisitionIdentifier,
+  formatDateTime,
+  isThirdPartyBeneficiary,
+  requisitionDetailQueryOptions,
+  statusLabel,
+  type RequisicaoActionItem,
+  type RequisicaoTimelineEvent,
+} from "../../features/requisitions/requisitions";
 
-export const Route = createFileRoute("/requisicoes/$id")({
-  beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
-  component: DetalhePlaceholderPage,
+const detailSearchSchema = z.object({
+  contexto: z.enum(["autorizacao", "atendimento"]).optional().catch(undefined),
 });
 
-function DetalhePlaceholderPage() {
+export const Route = createFileRoute("/requisicoes/$id")({
+  validateSearch: detailSearchSchema,
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
+  component: DetalheRequisicaoPage,
+});
+
+function queryErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Não foi possível carregar a requisição.";
+}
+
+function QuantityBlock({ item }: { item: RequisicaoActionItem }) {
+  return (
+    <div className="quantity-grid">
+      <span>
+        Solicitado
+        <strong>
+          {item.quantidade_solicitada} {item.unidade_medida}
+        </strong>
+      </span>
+      <span>
+        Autorizado
+        <strong>
+          {item.quantidade_autorizada} {item.unidade_medida}
+        </strong>
+      </span>
+      <span>
+        Entregue
+        <strong>
+          {item.quantidade_entregue} {item.unidade_medida}
+        </strong>
+      </span>
+    </div>
+  );
+}
+
+function TimelineEvent({ event }: { event: RequisicaoTimelineEvent }) {
+  return (
+    <li className="timeline-event">
+      <div>
+        <p className="font-semibold">{event.tipo_evento.replaceAll("_", " ")}</p>
+        <p className="text-sm text-[var(--ink-soft)]">
+          {event.usuario.nome_completo} - {formatDateTime(event.data_hora)}
+        </p>
+      </div>
+      {event.observacao ? <p className="mt-2 text-sm text-[var(--ink-soft)]">{event.observacao}</p> : null}
+    </li>
+  );
+}
+
+function DetalheRequisicaoPage() {
   const { id } = Route.useParams();
+  const { contexto } = Route.useSearch();
+  const requisicaoId = Number(id);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/requisicoes/$id" });
+  const detailQuery = useQuery({
+    ...requisitionDetailQueryOptions(requisicaoId),
+    enabled: Number.isInteger(requisicaoId) && requisicaoId > 0,
+  });
+
+  if (detailQuery.isError && isAuthError(detailQuery.error)) {
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: `/requisicoes/${id}`,
+      },
+    });
+  }
+
+  if (!Number.isInteger(requisicaoId) || requisicaoId <= 0) {
+    return <div className="error-panel">Identificador de requisição inválido.</div>;
+  }
+
+  if (detailQuery.isPending) {
+    return <div className="loading-state">Carregando requisição...</div>;
+  }
+
+  if (detailQuery.isError) {
+    return <div className="error-panel">{queryErrorMessage(detailQuery.error)}</div>;
+  }
+
+  const requisicao = detailQuery.data;
+  const thirdParty = isThirdPartyBeneficiary(requisicao);
 
   return (
-    <FeaturePlaceholder
-      kicker="Canonical detail"
-      title={`Requisição ${id}`}
-      summary="Superfície canônica do piloto. Cabeçalho, itens, status e resumo de eventos já têm lugar definido, mas as ações contextuais reais entram nas próximas slices."
-      nextSlice="#38 + #40 + #41"
-      contracts={[
-        "GET /api/v1/requisitions/{id}/",
-        "query param contexto=autorizacao|atendimento",
-      ]}
-      bullets={[
-        "Corpo comum para qualquer entrada.",
-        "Ações mudam por contexto, não por rota duplicada.",
-        "Timeline e divergências visuais chegam nas fatias funcionais.",
-      ]}
-      preview={
-        <div className="preview-panel space-y-3">
-          <div className="preview-row">
-            <span>Status</span>
-            <span className="preview-meta">aguardando autorização</span>
-          </div>
-          <div className="preview-row">
-            <span>Itens</span>
-            <span className="preview-meta">solicitado / autorizado / entregue</span>
-          </div>
-          <div className="preview-row">
-            <span>Eventos</span>
-            <span className="preview-meta">timeline resumida</span>
-          </div>
+    <section className="space-y-6">
+      <div className="detail-hero">
+        <div>
+          <p className="eyebrow">Detalhe canônico</p>
+          <h1>{displayRequisitionIdentifier(requisicao)}</h1>
+          <p>
+            {statusLabel(requisicao.status)} - {requisicao.setor_beneficiario.nome}
+          </p>
         </div>
-      }
-    />
+        <div className="detail-actions">
+          {contexto ? <span className="context-chip">Contexto: {contexto}</span> : null}
+          <Link className="action-link compact-action" to="/minhas-requisicoes">
+            Voltar
+          </Link>
+        </div>
+      </div>
+
+      <div className="detail-grid">
+        <section className="detail-panel">
+          <p className="eyebrow">Pessoas</p>
+          <dl className="info-list">
+            <div>
+              <dt>Criador</dt>
+              <dd>{requisicao.criador.nome_completo}</dd>
+            </div>
+            <div>
+              <dt>Beneficiário</dt>
+              <dd>
+                {requisicao.beneficiario.nome_completo}
+                {thirdParty ? <span className="third-party-badge inline-badge">Terceiro</span> : null}
+              </dd>
+            </div>
+            <div>
+              <dt>Setor</dt>
+              <dd>{requisicao.setor_beneficiario.nome}</dd>
+            </div>
+            {requisicao.chefe_autorizador ? (
+              <div>
+                <dt>Autorizador</dt>
+                <dd>{requisicao.chefe_autorizador.nome_completo}</dd>
+              </div>
+            ) : null}
+            {requisicao.responsavel_atendimento ? (
+              <div>
+                <dt>Atendimento</dt>
+                <dd>{requisicao.responsavel_atendimento.nome_completo}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </section>
+
+        <section className="detail-panel">
+          <p className="eyebrow">Datas</p>
+          <dl className="info-list">
+            <div>
+              <dt>Criação</dt>
+              <dd>{formatDateTime(requisicao.data_criacao)}</dd>
+            </div>
+            <div>
+              <dt>Envio para autorização</dt>
+              <dd>{formatDateTime(requisicao.data_envio_autorizacao)}</dd>
+            </div>
+            <div>
+              <dt>Decisão</dt>
+              <dd>{formatDateTime(requisicao.data_autorizacao_ou_recusa)}</dd>
+            </div>
+            <div>
+              <dt>Finalização</dt>
+              <dd>{formatDateTime(requisicao.data_finalizacao)}</dd>
+            </div>
+          </dl>
+        </section>
+      </div>
+
+      {requisicao.observacao ||
+      requisicao.observacao_atendimento ||
+      requisicao.motivo_recusa ||
+      requisicao.motivo_cancelamento ||
+      requisicao.retirante_fisico ? (
+        <section className="detail-panel">
+          <p className="eyebrow">Observações</p>
+          <dl className="info-list notes-list">
+            {requisicao.observacao ? (
+              <div>
+                <dt>Geral</dt>
+                <dd>{requisicao.observacao}</dd>
+              </div>
+            ) : null}
+            {requisicao.observacao_atendimento ? (
+              <div>
+                <dt>Atendimento</dt>
+                <dd>{requisicao.observacao_atendimento}</dd>
+              </div>
+            ) : null}
+            {requisicao.motivo_recusa ? (
+              <div>
+                <dt>Recusa</dt>
+                <dd>{requisicao.motivo_recusa}</dd>
+              </div>
+            ) : null}
+            {requisicao.motivo_cancelamento ? (
+              <div>
+                <dt>Cancelamento</dt>
+                <dd>{requisicao.motivo_cancelamento}</dd>
+              </div>
+            ) : null}
+            {requisicao.retirante_fisico ? (
+              <div>
+                <dt>Retirante físico</dt>
+                <dd>{requisicao.retirante_fisico}</dd>
+              </div>
+            ) : null}
+          </dl>
+        </section>
+      ) : null}
+
+      <section className="detail-panel">
+        <p className="eyebrow">Itens</p>
+        <div className="item-list">
+          {requisicao.itens.map((item) => (
+            <article className="item-card" key={item.id}>
+              <div>
+                <h2>{item.material.nome}</h2>
+                <p>
+                  {item.material.codigo_completo} - {item.material.unidade_medida}
+                </p>
+              </div>
+              <QuantityBlock item={item} />
+              {item.observacao ||
+              item.justificativa_autorizacao_parcial ||
+              item.justificativa_atendimento_parcial ? (
+                <div className="item-notes">
+                  {item.observacao ? <p>Obs.: {item.observacao}</p> : null}
+                  {item.justificativa_autorizacao_parcial ? (
+                    <p>Autorização parcial: {item.justificativa_autorizacao_parcial}</p>
+                  ) : null}
+                  {item.justificativa_atendimento_parcial ? (
+                    <p>Atendimento parcial: {item.justificativa_atendimento_parcial}</p>
+                  ) : null}
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="detail-panel">
+        <p className="eyebrow">Timeline</p>
+        {requisicao.eventos.length > 0 ? (
+          <ol className="timeline-list">
+            {requisicao.eventos.map((event) => (
+              <TimelineEvent event={event} key={event.id} />
+            ))}
+          </ol>
+        ) : (
+          <p className="text-sm text-[var(--ink-soft)]">Nenhum evento registrado.</p>
+        )}
+      </section>
+    </section>
   );
 }

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
@@ -5,14 +6,15 @@ import { z } from "zod";
 import { requireSession } from "../../features/auth/guards";
 import { authQueryKeys, isAuthError } from "../../features/auth/session";
 import {
-  displayRequisitionIdentifier,
-  formatDateTime,
-  isThirdPartyBeneficiary,
-  requisitionDetailQueryOptions,
-  statusLabel,
-  type RequisicaoActionItem,
-  type RequisicaoTimelineEvent,
-} from "../../features/requisitions/requisitions";
+    displayRequisitionIdentifier,
+    formatDateTime,
+    isThirdPartyBeneficiary,
+    requisitionDetailQueryOptions,
+    statusLabel,
+    tipoEventoLabel,
+    type RequisicaoActionItem,
+    type RequisicaoTimelineEvent,
+  } from "../../features/requisitions/requisitions";
 
 const detailSearchSchema = z.object({
   contexto: z.enum(["autorizacao", "atendimento"]).optional().catch(undefined),
@@ -62,7 +64,7 @@ function TimelineEvent({ event }: { event: RequisicaoTimelineEvent }) {
   return (
     <li className="timeline-event">
       <div>
-        <p className="font-semibold">{event.tipo_evento.replaceAll("_", " ")}</p>
+        <p className="font-semibold">{tipoEventoLabel(event.tipo_evento)}</p>
         <p className="text-sm text-[var(--ink-soft)]">
           {event.usuario.nome_completo} - {formatDateTime(event.data_hora)}
         </p>
@@ -82,8 +84,12 @@ function DetalheRequisicaoPage() {
     ...requisitionDetailQueryOptions(requisicaoId),
     enabled: Number.isInteger(requisicaoId) && requisicaoId > 0,
   });
+  const authError = detailQuery.isError && isAuthError(detailQuery.error);
 
-  if (detailQuery.isError && isAuthError(detailQuery.error)) {
+  useEffect(() => {
+    if (!authError) {
+      return;
+    }
     queryClient.removeQueries({ queryKey: authQueryKeys.me });
     void navigate({
       to: "/login",
@@ -91,7 +97,7 @@ function DetalheRequisicaoPage() {
         redirect: `/requisicoes/${id}`,
       },
     });
-  }
+  }, [authError, id, navigate, queryClient]);
 
   if (!Number.isInteger(requisicaoId) || requisicaoId <= 0) {
     return <div className="error-panel">Identificador de requisição inválido.</div>;
@@ -99,6 +105,10 @@ function DetalheRequisicaoPage() {
 
   if (detailQuery.isPending) {
     return <div className="loading-state">Carregando requisição...</div>;
+  }
+
+  if (authError) {
+    return null;
   }
 
   if (detailQuery.isError) {

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -9,6 +9,7 @@ import {
     displayRequisitionIdentifier,
     formatDateTime,
     isThirdPartyBeneficiary,
+    queryErrorMessage,
     requisitionDetailQueryOptions,
     statusLabel,
     tipoEventoLabel,
@@ -26,14 +27,6 @@ export const Route = createFileRoute("/requisicoes/$id")({
     requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: DetalheRequisicaoPage,
 });
-
-function queryErrorMessage(error: unknown) {
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return "Não foi possível carregar a requisição.";
-}
 
 function QuantityBlock({ item }: { item: RequisicaoActionItem }) {
   return (
@@ -112,7 +105,11 @@ function DetalheRequisicaoPage() {
   }
 
   if (detailQuery.isError) {
-    return <div className="error-panel">{queryErrorMessage(detailQuery.error)}</div>;
+    return (
+      <div className="error-panel">
+        {queryErrorMessage(detailQuery.error, "Não foi possível carregar a requisição.")}
+      </div>
+    );
   }
 
   const requisicao = detailQuery.data;

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -54,6 +54,10 @@ function QuantityBlock({ item }: { item: RequisicaoActionItem }) {
   );
 }
 
+function hasText(value: string | null | undefined) {
+  return Boolean(value?.trim());
+}
+
 function TimelineEvent({ event }: { event: RequisicaoTimelineEvent }) {
   return (
     <li className="timeline-event">
@@ -197,39 +201,39 @@ function DetalheRequisicaoPage() {
         </section>
       </div>
 
-      {requisicao.observacao ||
-      requisicao.observacao_atendimento ||
-      requisicao.motivo_recusa ||
-      requisicao.motivo_cancelamento ||
-      requisicao.retirante_fisico ? (
+      {hasText(requisicao.observacao) ||
+      hasText(requisicao.observacao_atendimento) ||
+      hasText(requisicao.motivo_recusa) ||
+      hasText(requisicao.motivo_cancelamento) ||
+      hasText(requisicao.retirante_fisico) ? (
         <section className="detail-panel">
           <p className="eyebrow">Observações</p>
           <dl className="info-list notes-list">
-            {requisicao.observacao ? (
+            {hasText(requisicao.observacao) ? (
               <div>
                 <dt>Geral</dt>
                 <dd>{requisicao.observacao}</dd>
               </div>
             ) : null}
-            {requisicao.observacao_atendimento ? (
+            {hasText(requisicao.observacao_atendimento) ? (
               <div>
                 <dt>Atendimento</dt>
                 <dd>{requisicao.observacao_atendimento}</dd>
               </div>
             ) : null}
-            {requisicao.motivo_recusa ? (
+            {hasText(requisicao.motivo_recusa) ? (
               <div>
                 <dt>Recusa</dt>
                 <dd>{requisicao.motivo_recusa}</dd>
               </div>
             ) : null}
-            {requisicao.motivo_cancelamento ? (
+            {hasText(requisicao.motivo_cancelamento) ? (
               <div>
                 <dt>Cancelamento</dt>
                 <dd>{requisicao.motivo_cancelamento}</dd>
               </div>
             ) : null}
-            {requisicao.retirante_fisico ? (
+            {hasText(requisicao.retirante_fisico) ? (
               <div>
                 <dt>Retirante físico</dt>
                 <dd>{requisicao.retirante_fisico}</dd>

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -8,6 +8,7 @@ import { authQueryKeys, isAuthError } from "../../features/auth/session";
 import {
     displayRequisitionIdentifier,
     formatDateTime,
+    formatQuantity,
     isThirdPartyBeneficiary,
     queryErrorMessage,
     requisitionDetailQueryOptions,
@@ -34,19 +35,19 @@ function QuantityBlock({ item }: { item: RequisicaoActionItem }) {
       <span>
         Solicitado
         <strong>
-          {item.quantidade_solicitada} {item.unidade_medida}
+          {formatQuantity(item.quantidade_solicitada)} {item.unidade_medida}
         </strong>
       </span>
       <span>
         Autorizado
         <strong>
-          {item.quantidade_autorizada} {item.unidade_medida}
+          {formatQuantity(item.quantidade_autorizada)} {item.unidade_medida}
         </strong>
       </span>
       <span>
         Entregue
         <strong>
-          {item.quantidade_entregue} {item.unidade_medida}
+          {formatQuantity(item.quantidade_entregue)} {item.unidade_medida}
         </strong>
       </span>
     </div>

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -264,6 +264,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/requisitions/mine/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Lista paginada das requisições pessoais do usuário autenticado. Inclui apenas requisições em que o usuário é criador ou beneficiário. */
+        get: operations["requisitions_mine"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/requisitions/pending-approvals/": {
         parameters: {
             query?: never;
@@ -1489,6 +1506,42 @@ export interface operations {
                 };
             };
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    requisitions_mine: {
+        parameters: {
+            query?: {
+                /** @description Número da página (padrão: 1) */
+                page?: number;
+                /** @description Quantidade de resultados por página (padrão: 20, máximo: 100) */
+                page_size?: number;
+                /** @description Busca textual por número público, nome do beneficiário ou nome do criador. */
+                search?: string;
+                /** @description Filtro exato por status da requisição. */
+                status?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RequisicaoListPaginated"];
+                };
+            };
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -220,6 +220,314 @@ a {
   opacity: 0.82;
 }
 
+.worklist-header,
+.detail-hero {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.worklist-header h1,
+.detail-hero h1 {
+  margin-top: 0.75rem;
+  font-family: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, Georgia, serif;
+  font-size: clamp(2rem, 4vw, 3.75rem);
+  line-height: 0.95;
+  color: var(--ink-strong);
+}
+
+.worklist-header p,
+.detail-hero p {
+  max-width: 52ch;
+  color: var(--ink-soft);
+}
+
+.filters-bar {
+  display: grid;
+  grid-template-columns: minmax(14rem, 1fr) minmax(12rem, 16rem) auto;
+  gap: 1rem;
+  align-items: end;
+}
+
+.filters-submit {
+  min-width: 9rem;
+}
+
+.table-frame,
+.detail-panel {
+  overflow: hidden;
+  border: 1px solid var(--line-soft);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.84);
+}
+
+.operational-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.operational-table th {
+  border-bottom: 1px solid var(--line-soft);
+  padding: 0.95rem 1rem;
+  text-align: left;
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.operational-table td {
+  border-bottom: 1px solid var(--line-soft);
+  padding: 1rem;
+  vertical-align: middle;
+  color: var(--ink-strong);
+}
+
+.operational-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.operational-table tbody tr:hover {
+  background: rgba(255, 248, 239, 0.82);
+}
+
+.req-status,
+.draft-badge,
+.third-party-badge,
+.context-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  border: 1px solid var(--line-soft);
+  padding: 0.42rem 0.68rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.draft-badge {
+  background: rgba(82, 96, 124, 0.1);
+  color: var(--ink-soft);
+}
+
+.third-party-badge {
+  margin-top: 0.55rem;
+  background: rgba(185, 82, 44, 0.12);
+  color: #8f3d22;
+}
+
+.inline-badge {
+  margin-left: 0.5rem;
+  margin-top: 0;
+}
+
+.req-status-rascunho {
+  background: rgba(82, 96, 124, 0.1);
+  color: var(--ink-soft);
+}
+
+.req-status-aguardando_autorizacao,
+.req-status-autorizada {
+  background: rgba(194, 138, 47, 0.14);
+  color: #80560d;
+}
+
+.req-status-atendida,
+.req-status-atendida_parcialmente {
+  background: rgba(47, 120, 94, 0.14);
+  color: #1f664e;
+}
+
+.req-status-recusada,
+.req-status-cancelada,
+.req-status-estornada {
+  background: rgba(150, 44, 44, 0.12);
+  color: #8a2727;
+}
+
+.compact-action {
+  justify-content: center;
+  min-width: 6.75rem;
+  padding: 0.62rem 0.8rem;
+  font-size: 0.7rem;
+}
+
+.compact-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.pagination-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 1rem;
+  color: var(--ink-soft);
+}
+
+.loading-state,
+.empty-state,
+.error-panel {
+  padding: 2rem;
+  color: var(--ink-soft);
+}
+
+.empty-state h3 {
+  margin-top: 0.55rem;
+  font-size: 1.35rem;
+  color: var(--ink-strong);
+}
+
+.error-panel {
+  border: 1px solid rgba(150, 44, 44, 0.2);
+  border-radius: 18px;
+  background: rgba(255, 239, 235, 0.9);
+  color: #8a2727;
+}
+
+.detail-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.context-chip {
+  background: rgba(22, 35, 61, 0.08);
+  color: var(--ink-soft);
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.detail-panel {
+  padding: 1.25rem;
+}
+
+.info-list {
+  display: grid;
+  gap: 1rem;
+  margin: 1rem 0 0;
+}
+
+.info-list div {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.info-list dt {
+  font-size: 0.68rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.info-list dd {
+  margin: 0;
+  color: var(--ink-strong);
+}
+
+.notes-list dd {
+  color: var(--ink-soft);
+}
+
+.item-list,
+.timeline-list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.item-card {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: rgba(255, 252, 247, 0.86);
+  padding: 1rem;
+}
+
+.item-card h2 {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.item-card p {
+  color: var(--ink-soft);
+}
+
+.quantity-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.quantity-grid span {
+  display: grid;
+  gap: 0.35rem;
+  border-radius: 14px;
+  background: rgba(22, 35, 61, 0.05);
+  padding: 0.75rem;
+  font-size: 0.72rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.quantity-grid strong {
+  font-size: 0.95rem;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--ink-strong);
+}
+
+.item-notes {
+  display: grid;
+  gap: 0.35rem;
+  border-top: 1px solid var(--line-soft);
+  padding-top: 0.85rem;
+  font-size: 0.9rem;
+}
+
+.timeline-list {
+  list-style: none;
+  padding: 0;
+}
+
+.timeline-event {
+  border-left: 3px solid var(--accent);
+  padding: 0.2rem 0 0.2rem 1rem;
+}
+
+@media (max-width: 860px) {
+  .worklist-header,
+  .detail-hero,
+  .pagination-bar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .filters-bar,
+  .detail-grid,
+  .quantity-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .table-frame {
+    overflow-x: auto;
+  }
+
+  .operational-table {
+    min-width: 760px;
+  }
+}
+
 .preview-badge {
   margin-top: 1rem;
   display: inline-flex;

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -60,6 +60,121 @@ function sessionResponse(session = authSession()) {
   return new Response(JSON.stringify(session), { status: 200, headers: jsonHeaders });
 }
 
+function requisitionListItem(overrides = {}) {
+  return {
+    id: 101,
+    numero_publico: "REQ-2026-000101",
+    status: "aguardando_autorizacao",
+    criador: {
+      id: 10,
+      matricula_funcional: "91003",
+      nome_completo: "Usuario Piloto",
+    },
+    beneficiario: {
+      id: 10,
+      matricula_funcional: "91003",
+      nome_completo: "Usuario Piloto",
+    },
+    setor_beneficiario: {
+      id: 1,
+      nome: "Operacao",
+    },
+    data_criacao: "2026-05-01T10:00:00Z",
+    data_envio_autorizacao: "2026-05-01T11:00:00Z",
+    data_autorizacao_ou_recusa: null,
+    data_finalizacao: null,
+    updated_at: "2026-05-01T11:00:00Z",
+    total_itens: 1,
+    ...overrides,
+  };
+}
+
+function requisitionListResponse(results = [requisitionListItem()]) {
+  return new Response(
+    JSON.stringify({
+      count: results.length,
+      page: 1,
+      page_size: 20,
+      total_pages: 1,
+      next: null,
+      previous: null,
+      results,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function requisitionDetailResponse() {
+  return new Response(
+    JSON.stringify({
+      id: 101,
+      numero_publico: "REQ-2026-000101",
+      status: "autorizada",
+      criador: {
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+      },
+      beneficiario: {
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+      },
+      setor_beneficiario: {
+        id: 1,
+        nome: "Operacao",
+      },
+      chefe_autorizador: {
+        id: 20,
+        matricula_funcional: "91001",
+        nome_completo: "Chefe Piloto",
+      },
+      responsavel_atendimento: null,
+      data_criacao: "2026-05-01T10:00:00Z",
+      data_envio_autorizacao: "2026-05-01T11:00:00Z",
+      data_autorizacao_ou_recusa: "2026-05-01T12:00:00Z",
+      motivo_recusa: "",
+      motivo_cancelamento: "",
+      data_finalizacao: null,
+      retirante_fisico: "",
+      observacao: "Observacao operacional",
+      observacao_atendimento: "",
+      itens: [
+        {
+          id: 501,
+          material: {
+            id: 301,
+            codigo_completo: "010.001.001",
+            nome: "Papel sulfite A4",
+            unidade_medida: "UN",
+          },
+          unidade_medida: "UN",
+          quantidade_solicitada: "2.000",
+          quantidade_autorizada: "1.000",
+          quantidade_entregue: "0.000",
+          justificativa_autorizacao_parcial: "Saldo parcial",
+          justificativa_atendimento_parcial: "",
+          observacao: "Urgente",
+        },
+      ],
+      eventos: [
+        {
+          id: 701,
+          tipo_evento: "autorizacao_parcial",
+          usuario: {
+            id: 20,
+            matricula_funcional: "91001",
+            nome_completo: "Chefe Piloto",
+          },
+          data_hora: "2026-05-01T12:00:00Z",
+          observacao: "Autorizado parcialmente por saldo.",
+        },
+      ],
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
 function csrfResponse() {
   return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
     status: 200,
@@ -331,14 +446,172 @@ describe("frontend scaffold router", () => {
     expect(container.ownerDocument.location.search).toBe("?redirect=%2Fatendimentos");
   });
 
-  it("renders minhas requisicoes placeholder", async () => {
-    mockCurrentSession();
+  it("renders minhas requisicoes worklist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse([
+            requisitionListItem(),
+            requisitionListItem({
+              id: 102,
+              numero_publico: null,
+              status: "rascunho",
+              beneficiario: {
+                id: 11,
+                matricula_funcional: "91004",
+                nome_completo: "Beneficiario Terceiro",
+              },
+            }),
+          ]);
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
     renderRoute("/minhas-requisicoes");
 
     expect(
       await screen.findByRole("heading", { name: "Minhas requisições" }),
     ).toBeInTheDocument();
-    expect(screen.getByText("GET /api/v1/requisitions/?page=&page_size=&search=&status=")).toBeInTheDocument();
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.getAllByText("Rascunho").length).toBeGreaterThan(0);
+    expect(screen.getByText("Beneficiário terceiro")).toBeInTheDocument();
+  });
+
+  it("does not show third-party badge when creator and beneficiary are the same", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse([
+            requisitionListItem({
+              criador: {
+                id: 10,
+                matricula_funcional: "91003",
+                nome_completo: "Solicitante Operacional",
+              },
+              beneficiario: {
+                id: 10,
+                matricula_funcional: "91003",
+                nome_completo: "Solicitante Operacional",
+              },
+            }),
+          ]);
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.queryByText("Beneficiário terceiro")).not.toBeInTheDocument();
+  });
+
+  it("sends list filters from the URL to backend", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        requestedUrls.push(requestUrl(request));
+
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes?page=2&search=REQ-2026&status=rascunho");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+
+    const listUrl = new URL(requestedUrls.find((url) => url.includes("/api/v1/requisitions/mine/"))!);
+    expect(listUrl.searchParams.get("page")).toBe("2");
+    expect(listUrl.searchParams.get("page_size")).toBe("20");
+    expect(listUrl.searchParams.get("search")).toBe("REQ-2026");
+    expect(listUrl.searchParams.get("status")).toBe("rascunho");
+  });
+
+  it("updates filters in the URL and resets pagination", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/minhas-requisicoes?page=3");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Busca"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Filtrar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+      expect(container.ownerDocument.location.search).not.toContain("page=3");
+      expect(container.ownerDocument.location.search).toContain("search=papel");
+    });
+  });
+
+  it("opens canonical requisition detail from the list", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/minhas-requisicoes?search=REQ");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "Abrir" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+    });
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    expect(screen.queryByText("Terceiro")).not.toBeInTheDocument();
+    expect(screen.getByText("Papel sulfite A4")).toBeInTheDocument();
+    expect(screen.getByText("Autorização parcial: Saldo parcial")).toBeInTheDocument();
+    expect(screen.getByText("Autorizado parcialmente por saldo.")).toBeInTheDocument();
   });
 
   it("logs out from authenticated shell and returns to login", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -518,6 +518,61 @@ describe("frontend scaffold router", () => {
     expect(screen.queryByText("Beneficiário terceiro")).not.toBeInTheDocument();
   });
 
+  it("shows pluralized record count in the status chip", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse([
+            requisitionListItem(),
+            requisitionListItem({
+              id: 102,
+              numero_publico: "REQ-2026-000102",
+            }),
+          ]);
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.getByText("2 registros")).toBeInTheDocument();
+  });
+
+  it("shows only the error panel when requisitions loading fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return new Response(JSON.stringify({ detail: "Falha no backend" }), {
+            status: 422,
+            headers: jsonHeaders,
+          });
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("Erro ao carregar")).toBeInTheDocument();
+    expect(screen.getByText("Não foi possível carregar requisições.")).toBeInTheDocument();
+    expect(screen.queryByText("Nenhuma requisição encontrada")).not.toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
   it("sends list filters from the URL to backend", async () => {
     const requestedUrls: string[] = [];
     vi.stubGlobal(

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -104,7 +104,7 @@ function requisitionListResponse(results = [requisitionListItem()]) {
   );
 }
 
-function requisitionDetailResponse() {
+function requisitionDetailResponse(itemOverrides = {}) {
   return new Response(
     JSON.stringify({
       id: 101,
@@ -155,6 +155,7 @@ function requisitionDetailResponse() {
           justificativa_autorizacao_parcial: "Saldo parcial",
           justificativa_atendimento_parcial: "",
           observacao: "Urgente",
+          ...itemOverrides,
         },
       ],
       eventos: [
@@ -699,6 +700,34 @@ describe("frontend scaffold router", () => {
     await waitFor(() => {
       expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
     });
+  });
+
+  it("formats requisition quantities with pt-BR decimal rendering", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse({
+            quantidade_solicitada: "2.500",
+            quantidade_autorizada: "1.250",
+            quantidade_entregue: "0.125",
+          });
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/101");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    expect(screen.getByText("2,5 UN")).toBeInTheDocument();
+    expect(screen.getByText("1,25 UN")).toBeInTheDocument();
+    expect(screen.getByText("0,125 UN")).toBeInTheDocument();
   });
 
   it("logs out from authenticated shell and returns to login", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -667,6 +667,38 @@ describe("frontend scaffold router", () => {
     expect(screen.getByText("Papel sulfite A4")).toBeInTheDocument();
     expect(screen.getByText("Autorização parcial: Saldo parcial")).toBeInTheDocument();
     expect(screen.getByText("Autorizado parcialmente por saldo.")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("link", { name: "Voltar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+  });
+
+  it("returns from requisition detail to authorization queue when opened with authorization context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "Voltar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
   });
 
   it("logs out from authenticated shell and returns to login", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -556,10 +556,20 @@ describe("frontend scaffold router", () => {
         }
 
         if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
-          return new Response(JSON.stringify({ detail: "Falha no backend" }), {
-            status: 422,
-            headers: jsonHeaders,
-          });
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "validation_error",
+                message: "Falha no backend",
+                details: null,
+                trace_id: "trace-router-smoke",
+              },
+            }),
+            {
+              status: 422,
+              headers: jsonHeaders,
+            },
+          );
         }
 
         throw new Error(`Unexpected request: ${requestUrl(request)}`);
@@ -569,7 +579,7 @@ describe("frontend scaffold router", () => {
     renderRoute("/minhas-requisicoes");
 
     expect(await screen.findByText("Erro ao carregar")).toBeInTheDocument();
-    expect(screen.getByText("Não foi possível carregar requisições.")).toBeInTheDocument();
+    expect(screen.getByText("Falha no backend")).toBeInTheDocument();
     expect(screen.queryByText("Nenhuma requisição encontrada")).not.toBeInTheDocument();
     expect(screen.queryByRole("table")).not.toBeInTheDocument();
   });

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -80,3 +80,131 @@ test("logs in and logs out through pilot shell", async ({ page }) => {
   await expect(page).toHaveURL(/\/login$/);
   await expect(page.getByRole("heading", { name: "Entrar no piloto" })).toBeVisible();
 });
+
+test("opens minhas requisicoes and canonical detail", async ({ page }) => {
+  await page.route("**/api/v1/auth/me/", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+        papel: "solicitante",
+        setor: {
+          id: 1,
+          nome: "Operacao",
+        },
+        is_authenticated: true,
+      }),
+    });
+  });
+  await page.route("**/api/v1/requisitions/mine/?**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        count: 1,
+        page: 1,
+        page_size: 20,
+        total_pages: 1,
+        next: null,
+        previous: null,
+        results: [
+          {
+            id: 101,
+            numero_publico: "REQ-2026-000101",
+            status: "aguardando_autorizacao",
+            criador: {
+              id: 10,
+              matricula_funcional: "91003",
+              nome_completo: "Usuario Piloto",
+            },
+            beneficiario: {
+              id: 11,
+              matricula_funcional: "91004",
+              nome_completo: "Beneficiario Terceiro",
+            },
+            setor_beneficiario: {
+              id: 1,
+              nome: "Operacao",
+            },
+            data_criacao: "2026-05-01T10:00:00Z",
+            data_envio_autorizacao: "2026-05-01T11:00:00Z",
+            data_autorizacao_ou_recusa: null,
+            data_finalizacao: null,
+            updated_at: "2026-05-01T11:00:00Z",
+            total_itens: 1,
+          },
+        ],
+      }),
+    });
+  });
+  await page.route("**/api/v1/requisitions/101/", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: 101,
+        numero_publico: "REQ-2026-000101",
+        status: "autorizada",
+        criador: {
+          id: 10,
+          matricula_funcional: "91003",
+          nome_completo: "Usuario Piloto",
+        },
+        beneficiario: {
+          id: 11,
+          matricula_funcional: "91004",
+          nome_completo: "Beneficiario Terceiro",
+        },
+        setor_beneficiario: {
+          id: 1,
+          nome: "Operacao",
+        },
+        chefe_autorizador: null,
+        responsavel_atendimento: null,
+        data_criacao: "2026-05-01T10:00:00Z",
+        data_envio_autorizacao: "2026-05-01T11:00:00Z",
+        data_autorizacao_ou_recusa: "2026-05-01T12:00:00Z",
+        motivo_recusa: "",
+        motivo_cancelamento: "",
+        data_finalizacao: null,
+        retirante_fisico: "",
+        observacao: "",
+        observacao_atendimento: "",
+        itens: [
+          {
+            id: 501,
+            material: {
+              id: 301,
+              codigo_completo: "010.001.001",
+              nome: "Papel sulfite A4",
+              unidade_medida: "UN",
+            },
+            unidade_medida: "UN",
+            quantidade_solicitada: "2.000",
+            quantidade_autorizada: "1.000",
+            quantidade_entregue: "0.000",
+            justificativa_autorizacao_parcial: "Saldo parcial",
+            justificativa_atendimento_parcial: "",
+            observacao: "",
+          },
+        ],
+        eventos: [],
+      }),
+    });
+  });
+
+  await page.goto("/minhas-requisicoes?search=REQ");
+
+  await expect(page.getByRole("heading", { name: "Minhas requisições" })).toBeVisible();
+  await expect(page.getByText("REQ-2026-000101")).toBeVisible();
+  await expect(page.getByText("Beneficiário terceiro")).toBeVisible();
+
+  await page.getByRole("link", { name: "Abrir" }).click();
+
+  await expect(page).toHaveURL(/\/requisicoes\/101$/);
+  await expect(page.getByRole("heading", { name: "REQ-2026-000101" })).toBeVisible();
+  await expect(page.getByText("Papel sulfite A4")).toBeVisible();
+});

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1861,7 +1861,7 @@ class TestRequisicaoAPI:
 
     def test_fila_autorizacao_chefe_almoxarifado_retorna_apenas_setor_sob_responsabilidade(self):
         setor_almox = self._criar_setor(
-            "Almoxarifado Aprova",
+            "Almoxarifado",
             "900141",
             papel=PapelChoices.CHEFE_ALMOXARIFADO,
         )

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -1,11 +1,17 @@
 from decimal import Decimal
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.materials.models import GrupoMaterial, Material, SubgrupoMaterial
 from apps.requisitions.models import EventoTimeline, Requisicao, StatusRequisicao, TipoEvento
+from apps.requisitions.policies import (
+    pode_visualizar_requisicao,
+    queryset_requisicoes_pessoais,
+    queryset_requisicoes_visiveis,
+)
 from apps.stock.models import EstoqueMaterial, MovimentacaoEstoque, TipoMovimentacao
 from apps.users.models import PapelChoices, Setor, User
 
@@ -277,6 +283,12 @@ class TestRequisicaoAPI:
             numero_publico="REQ-2026-000111",
             observacao="Requisicao enviada",
         )
+        rascunho_terceiro_como_beneficiario = self._criar_requisicao_com_item(
+            criador=outro_usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
         self._criar_requisicao_com_item(
             criador=outro_usuario,
             beneficiario=outro_usuario,
@@ -295,6 +307,7 @@ class TestRequisicaoAPI:
         assert response.data["page_size"] == 20
         resultado_ids = [item["id"] for item in response.data["results"]]
         assert resultado_ids == [submetida.id, rascunho.id]
+        assert rascunho_terceiro_como_beneficiario.id not in resultado_ids
         assert response.data["results"][1]["numero_publico"] is None
         assert response.data["results"][0]["total_itens"] == 1
         assert "itens" not in response.data["results"][0]
@@ -326,6 +339,12 @@ class TestRequisicaoAPI:
             status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
             numero_publico="REQ-2026-000777",
         )
+        rascunho_terceiro = self._criar_requisicao_com_item(
+            criador=usuario_b,
+            beneficiario=usuario_b,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
 
         client = APIClient()
         client.force_authenticate(user=almoxarife)
@@ -334,6 +353,228 @@ class TestRequisicaoAPI:
         assert response.status_code == 200
         assert response.data["count"] >= 1
         assert any(item["id"] == requisicao.id for item in response.data["results"])
+        assert all(item["id"] != rascunho_terceiro.id for item in response.data["results"])
+
+    def test_lista_requisicoes_chefe_almoxarifado_ve_todos_os_setores(self):
+        setor_almoxarifado = self._criar_setor(
+            "Almoxarifado Chefia",
+            "9000801",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        chefe_almoxarifado = setor_almoxarifado.chefe_responsavel
+        setor_outro = self._criar_setor("Patrimonio Chefia", "9000802")
+        usuario_outro = self._criar_usuario(
+            "100091",
+            "Solicitante Patrimonio Chefia",
+            setor=setor_outro,
+        )
+        material = self._criar_material_com_estoque("001.001.151")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_outro,
+            beneficiario=usuario_outro,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000778",
+        )
+        rascunho_terceiro = self._criar_requisicao_com_item(
+            criador=usuario_outro,
+            beneficiario=usuario_outro,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_almoxarifado)
+        response = client.get(reverse("requisicao-list"))
+
+        assert response.status_code == 200
+        assert any(item["id"] == requisicao.id for item in response.data["results"])
+        assert all(item["id"] != rascunho_terceiro.id for item in response.data["results"])
+
+    def test_lista_requisicoes_chefe_setor_ve_apenas_proprio_setor_e_pessoais(self):
+        setor_a = self._criar_setor("Planejamento Lista", "9000803")
+        setor_b = self._criar_setor("Frota Lista", "9000804")
+        chefe_setor = setor_a.chefe_responsavel
+        usuario_setor_a = self._criar_usuario("100092", "Usuario Setor A", setor=setor_a)
+        usuario_setor_b = self._criar_usuario("100093", "Usuario Setor B", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.152")
+        requisicao_setor_a = self._criar_requisicao_com_item(
+            criador=usuario_setor_a,
+            beneficiario=usuario_setor_a,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000779",
+        )
+        rascunho_setor_a = self._criar_requisicao_com_item(
+            criador=usuario_setor_a,
+            beneficiario=usuario_setor_a,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        requisicao_setor_b = self._criar_requisicao_com_item(
+            criador=usuario_setor_b,
+            beneficiario=usuario_setor_b,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000780",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_setor)
+        response = client.get(reverse("requisicao-list"))
+
+        assert response.status_code == 200
+        resultado_ids = {item["id"] for item in response.data["results"]}
+        assert requisicao_setor_a.id in resultado_ids
+        assert rascunho_setor_a.id not in resultado_ids
+        assert requisicao_setor_b.id not in resultado_ids
+
+    def test_mine_lista_apenas_requisicoes_criadas_ou_como_beneficiario(self):
+        setor_a = self._criar_setor("Operacao Mine", "900081")
+        setor_b = self._criar_setor("Suporte Mine", "900082")
+        setor_almoxarifado = self._criar_setor("Almoxarifado Mine", "900083")
+        chefe_setor = setor_a.chefe_responsavel
+        almoxarife = self._criar_usuario(
+            "100092",
+            "Auxiliar Almoxarifado Mine",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_almoxarifado,
+        )
+        usuario = self._criar_usuario("100093", "Usuario Mine", setor=setor_a)
+        outro_usuario_setor_a = self._criar_usuario(
+            "100094",
+            "Outro Usuario Setor A",
+            setor=setor_a,
+        )
+        outro_usuario_setor_b = self._criar_usuario(
+            "100095",
+            "Outro Usuario Setor B",
+            setor=setor_b,
+        )
+        material = self._criar_material_com_estoque("001.001.058")
+
+        criada_pelo_usuario = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        rascunho_terceiro_como_beneficiario = self._criar_requisicao_com_item(
+            criador=outro_usuario_setor_a,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        beneficiario_usuario = self._criar_requisicao_com_item(
+            criador=outro_usuario_setor_a,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AUTORIZADA,
+            numero_publico="REQ-2026-000901",
+        )
+        terceiro_beneficiario = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=outro_usuario_setor_b,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000902",
+        )
+        apenas_setor_do_chefe = self._criar_requisicao_com_item(
+            criador=outro_usuario_setor_a,
+            beneficiario=outro_usuario_setor_a,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000903",
+        )
+        apenas_visivel_almoxarifado = self._criar_requisicao_com_item(
+            criador=outro_usuario_setor_b,
+            beneficiario=outro_usuario_setor_b,
+            material=material,
+            status=StatusRequisicao.AUTORIZADA,
+            numero_publico="REQ-2026-000904",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("requisicao-mine"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 3
+        resultado_ids = {item["id"] for item in response.data["results"]}
+        assert resultado_ids == {
+            criada_pelo_usuario.id,
+            beneficiario_usuario.id,
+            terceiro_beneficiario.id,
+        }
+        assert rascunho_terceiro_como_beneficiario.id not in resultado_ids
+        assert apenas_setor_do_chefe.id not in resultado_ids
+        assert apenas_visivel_almoxarifado.id not in resultado_ids
+
+        response_search = client.get(reverse("requisicao-mine"), {"search": "000902"})
+        assert response_search.status_code == 200
+        assert response_search.data["count"] == 1
+        assert response_search.data["results"][0]["id"] == terceiro_beneficiario.id
+
+        response_status = client.get(
+            reverse("requisicao-mine"),
+            {"status": StatusRequisicao.AUTORIZADA},
+        )
+        assert response_status.status_code == 200
+        assert response_status.data["count"] == 1
+        assert response_status.data["results"][0]["id"] == beneficiario_usuario.id
+
+        client.force_authenticate(user=chefe_setor)
+        response_chefe = client.get(reverse("requisicao-mine"))
+        assert response_chefe.status_code == 200
+        assert response_chefe.data["count"] == 0
+
+        client.force_authenticate(user=almoxarife)
+        response_almoxarife = client.get(reverse("requisicao-mine"))
+        assert response_almoxarife.status_code == 200
+        assert response_almoxarife.data["count"] == 0
+
+    def test_mine_queryset_pessoais_retorna_apenas_criador_ou_beneficiario(self):
+        setor_a = self._criar_setor("Operacao Mine Queryset", "9000831")
+        setor_b = self._criar_setor("Suporte Mine Queryset", "9000832")
+        usuario = self._criar_usuario("100094", "Usuario Mine Queryset", setor=setor_a)
+        outro_setor_a = self._criar_usuario("100095", "Outro Setor A", setor=setor_a)
+        outro_setor_b = self._criar_usuario("100096", "Outro Setor B", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.153")
+
+        criada_pelo_usuario = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=outro_setor_b,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        rascunho_terceiro_como_beneficiario = self._criar_requisicao_com_item(
+            criador=outro_setor_a,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        beneficiario_usuario = self._criar_requisicao_com_item(
+            criador=outro_setor_a,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AUTORIZADA,
+            numero_publico="REQ-2026-000905",
+        )
+        fora_escopo = self._criar_requisicao_com_item(
+            criador=outro_setor_a,
+            beneficiario=outro_setor_b,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000906",
+        )
+
+        queryset_ids = set(
+            queryset_requisicoes_pessoais(usuario, skip_prefetch=True).values_list("id", flat=True)
+        )
+
+        assert queryset_ids == {criada_pelo_usuario.id, beneficiario_usuario.id}
+        assert rascunho_terceiro_como_beneficiario.id not in queryset_ids
+        assert fora_escopo.id not in queryset_ids
 
     def test_lista_requisicoes_filtra_por_status_e_busca_textual(self):
         setor = self._criar_setor("Compras", "900074")
@@ -410,6 +651,60 @@ class TestRequisicaoAPI:
         assert response.data["eventos"][0]["usuario"]["id"] == autorizador.id
         assert response.data["eventos"][0]["observacao"] == "Autorizado parcialmente por saldo."
 
+    def test_detail_beneficiario_nao_visualiza_rascunho_de_terceiro_e_visualiza_apos_envio(self):
+        setor = self._criar_setor("Patrimonio Beneficiario", "9000751")
+        criador = self._criar_usuario(
+            "1000861",
+            "Auxiliar Patrimonio Beneficiario",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor,
+        )
+        beneficiario = self._criar_usuario("1000862", "Beneficiario Patrimonio", setor=setor)
+        material = self._criar_material_com_estoque("001.001.154")
+        rascunho = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        requisicao_enviada = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000445",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response_rascunho = client.get(reverse("requisicao-detail", args=[rascunho.id]))
+        response_enviada = client.get(reverse("requisicao-detail", args=[requisicao_enviada.id]))
+
+        assert response_rascunho.status_code == 404
+        assert response_rascunho.data["error"]["code"] == "not_found"
+        assert response_enviada.status_code == 200
+        assert response_enviada.data["id"] == requisicao_enviada.id
+
+    def test_detail_chefe_setor_visualiza_requisicao_do_proprio_setor(self):
+        setor = self._criar_setor("Patrimonio Chefia Detail", "9000752")
+        chefe_setor = setor.chefe_responsavel
+        usuario = self._criar_usuario("1000863", "Solicitante Chefia Detail", setor=setor)
+        material = self._criar_material_com_estoque("001.001.155")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000446",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_setor)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+
     def test_detail_requisicao_fora_do_escopo_retorna_404(self):
         setor_a = self._criar_setor("TI", "900076")
         setor_b = self._criar_setor("Frota", "900077")
@@ -430,6 +725,147 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 404
         assert response.data["error"]["code"] == "not_found"
+
+    def test_detail_chefe_setor_nao_visualiza_requisicao_de_outro_setor(self):
+        setor_a = self._criar_setor("TI Chefia", "9000761")
+        setor_b = self._criar_setor("Frota Chefia", "9000762")
+        chefe_setor = setor_a.chefe_responsavel
+        usuario_b = self._criar_usuario("1000881", "Solicitante Frota Chefia", setor=setor_b)
+        material = self._criar_material_com_estoque("001.001.156")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_b,
+            beneficiario=usuario_b,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000556",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_setor)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
+    def test_detail_auxiliar_almoxarifado_visualiza_requisicao_de_qualquer_setor(self):
+        setor_almoxarifado = self._criar_setor("Almoxarifado Detail", "9000763")
+        setor_outro = self._criar_setor("Frota Detail", "9000764")
+        almoxarife = self._criar_usuario(
+            "1000882",
+            "Auxiliar Almoxarifado Detail",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_almoxarifado,
+        )
+        usuario_outro = self._criar_usuario(
+            "1000883", "Solicitante Frota Detail", setor=setor_outro
+        )
+        material = self._criar_material_com_estoque("001.001.157")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_outro,
+            beneficiario=usuario_outro,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000557",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=almoxarife)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+
+    def test_detail_chefe_almoxarifado_visualiza_requisicao_de_qualquer_setor(self):
+        setor_almoxarifado = self._criar_setor(
+            "Almoxarifado Detail Chefia",
+            "9000765",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        chefe_almoxarifado = setor_almoxarifado.chefe_responsavel
+        setor_outro = self._criar_setor("Frota Detail Chefia", "9000766")
+        usuario_outro = self._criar_usuario(
+            "1000884", "Solicitante Frota Detail Chefia", setor=setor_outro
+        )
+        material = self._criar_material_com_estoque("001.001.158")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_outro,
+            beneficiario=usuario_outro,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000558",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_almoxarifado)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+
+    def test_detail_usuario_inativo_nao_visualiza_requisicao(self):
+        setor = self._criar_setor("Patrimonio Inativo", "9000767")
+        usuario_inativo = self._criar_usuario(
+            "1000885",
+            "Solicitante Inativo Detail",
+            setor=setor,
+            is_active=False,
+        )
+        material = self._criar_material_com_estoque("001.001.159")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario_inativo,
+            beneficiario=usuario_inativo,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_inativo)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
+    def test_detail_superuser_visualiza_requisicao(self):
+        setor = self._criar_setor("Patrimonio Superuser", "9000768")
+        usuario = self._criar_usuario("1000886", "Solicitante Superuser Detail", setor=setor)
+        superuser = User.objects.create_superuser(
+            matricula_funcional="99004",
+            password="testpass123",
+            nome_completo="Super Admin Detail",
+        )
+        material = self._criar_material_com_estoque("001.001.160")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000559",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["id"] == requisicao.id
+
+    def test_detail_anonimo_nao_visualiza_requisicao(self):
+        setor = self._criar_setor("Patrimonio Anonimo", "9000769")
+        usuario = self._criar_usuario("1000887", "Solicitante Anonimo Detail", setor=setor)
+        material = self._criar_material_com_estoque("001.001.161")
+        requisicao = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000560",
+        )
+
+        client = APIClient()
+        response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
 
     def test_detail_ignora_filtros_de_listagem_na_url(self):
         setor = self._criar_setor("Obras", "900078")
@@ -452,6 +888,91 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 200
         assert response.data["id"] == requisicao.id
+
+    def test_lista_requisicoes_coerente_com_pode_visualizar_detail_nos_cenarios_principais(self):
+        setor_a = self._criar_setor("Coerencia Setor A", "9000771")
+        setor_b = self._criar_setor("Coerencia Setor B", "9000772")
+        setor_almoxarifado = self._criar_setor(
+            "Coerencia Almoxarifado",
+            "9000773",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        criador = self._criar_usuario(
+            "1000888",
+            "Criador Coerencia",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor_a,
+        )
+        beneficiario = self._criar_usuario("1000889", "Beneficiario Coerencia", setor=setor_a)
+        auxiliar_setor = self._criar_usuario(
+            "1000890",
+            "Auxiliar Setor Coerencia",
+            papel=PapelChoices.AUXILIAR_SETOR,
+            setor=setor_a,
+        )
+        chefe_setor = setor_a.chefe_responsavel
+        solicitante_outro_setor = self._criar_usuario(
+            "1000891",
+            "Solicitante Outro Setor Coerencia",
+            setor=setor_b,
+        )
+        auxiliar_almoxarifado = self._criar_usuario(
+            "1000892",
+            "Auxiliar Almoxarifado Coerencia",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor_almoxarifado,
+        )
+        chefe_almoxarifado = setor_almoxarifado.chefe_responsavel
+        usuario_inativo = self._criar_usuario(
+            "1000893",
+            "Usuario Inativo Coerencia",
+            setor=setor_a,
+            is_active=False,
+        )
+        superuser = User.objects.create_superuser(
+            matricula_funcional="99005",
+            password="testpass123",
+            nome_completo="Super Admin Coerencia",
+        )
+        material = self._criar_material_com_estoque("001.001.162")
+        requisicao_rascunho = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+            status=StatusRequisicao.RASCUNHO,
+        )
+        requisicao_aguardando = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000561",
+        )
+
+        cenarios = [
+            (criador, True, True),
+            (beneficiario, False, True),
+            (chefe_setor, False, True),
+            (auxiliar_setor, False, False),
+            (solicitante_outro_setor, False, False),
+            (auxiliar_almoxarifado, False, True),
+            (chefe_almoxarifado, False, True),
+            (usuario_inativo, False, False),
+            (superuser, True, True),
+        ]
+        for user, esperado_rascunho, esperado_aguardando in cenarios:
+            queryset_ids = set(
+                queryset_requisicoes_visiveis(user, skip_prefetch=True).values_list("id", flat=True)
+            )
+            assert pode_visualizar_requisicao(user, requisicao_rascunho) is esperado_rascunho
+            assert (requisicao_rascunho.id in queryset_ids) is esperado_rascunho
+            assert pode_visualizar_requisicao(user, requisicao_aguardando) is esperado_aguardando
+            assert (requisicao_aguardando.id in queryset_ids) is esperado_aguardando
+
+        queryset_anonimo = queryset_requisicoes_visiveis(AnonymousUser(), skip_prefetch=True)
+        assert pode_visualizar_requisicao(AnonymousUser(), requisicao_rascunho) is False
+        assert pode_visualizar_requisicao(AnonymousUser(), requisicao_aguardando) is False
+        assert queryset_anonimo.count() == 0
 
     def test_submit_gera_numero_publico_e_entrada_na_fila(self):
         setor = self._criar_setor("Planejamento", "90008")
@@ -504,6 +1025,41 @@ class TestRequisicaoAPI:
             requisicao=requisicao,
             tipo_evento=TipoEvento.RETORNO_RASCUNHO,
         ).exists()
+
+    def test_return_to_draft_beneficiario_pode_retornar_mas_perde_acesso_ao_rascunho(self):
+        setor = self._criar_setor("Patrimonio Retorno Beneficiario", "90009A")
+        criador = self._criar_usuario("10010A", "Criador Retorno", setor=setor)
+        beneficiario = self._criar_usuario("10010B", "Beneficiario Retorno", setor=setor)
+        material = self._criar_material_com_estoque("001.001.177")
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario,
+            setor_beneficiario=setor,
+            numero_publico="REQ-2026-000011",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response = client.post(reverse("requisicao-return-to-draft", args=[requisicao.id]))
+
+        assert response.status_code == 200
+        assert response.data["status"] == StatusRequisicao.RASCUNHO
+        assert response.data["numero_publico"] == "REQ-2026-000011"
+
+        detail_response = client.get(reverse("requisicao-detail", args=[requisicao.id]))
+        mine_response = client.get(reverse("requisicao-mine"))
+
+        assert detail_response.status_code == 404
+        assert detail_response.data["error"]["code"] == "not_found"
+        assert mine_response.status_code == 200
+        assert mine_response.data["count"] == 0
 
     def test_update_draft_substitui_beneficiario_observacao_e_itens(self):
         setor = self._criar_setor("Patio", "900091")
@@ -648,6 +1204,28 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 404
 
+    def test_update_draft_bloqueia_beneficiario_terceiro_em_rascunho(self):
+        setor = self._criar_setor("Patio Beneficiario Rascunho", "900093A")
+        criador = self._criar_usuario("100123A", "Criador Rascunho", setor=setor)
+        beneficiario = self._criar_usuario("100123B", "Beneficiario Rascunho", setor=setor)
+        material = self._criar_material_com_estoque("001.001.178")
+        requisicao = self._criar_requisicao_com_item(
+            criador=criador,
+            beneficiario=beneficiario,
+            material=material,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response = client.put(
+            reverse("requisicao-update-draft", args=[requisicao.id]),
+            self._payload_requisicao(beneficiario_id=beneficiario.id, material_id=material.id),
+            format="json",
+        )
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
     def test_update_draft_bloqueia_chefe_almox_visivel_sem_permissao_contextual(self):
         setor = self._criar_setor("Patio Permissao Contextual", "900096")
         setor_almox = self._criar_setor(
@@ -663,6 +1241,8 @@ class TestRequisicaoAPI:
             criador=criador,
             beneficiario=beneficiario,
             material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000322",
         )
 
         client = APIClient()
@@ -743,6 +1323,25 @@ class TestRequisicaoAPI:
             tipo_evento=TipoEvento.REENVIO_AUTORIZACAO,
         ).exists()
 
+    def test_submit_beneficiario_terceiro_nao_pode_enviar_rascunho_de_outro(self):
+        setor = self._criar_setor("Frota Submit Terceiro", "90010A")
+        criador = self._criar_usuario("10011A", "Criador Submit", setor=setor)
+        beneficiario = self._criar_usuario("10011B", "Beneficiario Submit", setor=setor)
+        material = self._criar_material_com_estoque("001.001.179")
+        requisicao = Requisicao.objects.create(criador=criador, beneficiario=beneficiario)
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response = client.post(reverse("requisicao-submit", args=[requisicao.id]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+
     def test_discard_remove_rascunho_nunca_enviado(self):
         setor = self._criar_setor("Fiscal", "90011")
         usuario = self._criar_usuario("10012", "Solicitante Fiscal", setor=setor)
@@ -760,6 +1359,26 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 204
         assert not Requisicao.objects.filter(pk=requisicao.pk).exists()
+
+    def test_discard_beneficiario_terceiro_nao_pode_descartar_rascunho_de_outro(self):
+        setor = self._criar_setor("Fiscal Terceiro", "90011A")
+        criador = self._criar_usuario("10012A", "Criador Fiscal", setor=setor)
+        beneficiario = self._criar_usuario("10012B", "Beneficiario Fiscal", setor=setor)
+        material = self._criar_material_com_estoque("001.001.180")
+        requisicao = Requisicao.objects.create(criador=criador, beneficiario=beneficiario)
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response = client.delete(reverse("requisicao-discard", args=[requisicao.id]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+        assert Requisicao.objects.filter(pk=requisicao.pk).exists()
 
     def test_discard_rascunho_formalizado_retorna_domain_conflict(self):
         setor = self._criar_setor("Fiscal Formalizado", "900111")
@@ -810,6 +1429,33 @@ class TestRequisicaoAPI:
         assert response.status_code == 200
         assert response.data["status"] == StatusRequisicao.CANCELADA
         assert response.data["numero_publico"] == "REQ-2026-000200"
+
+    def test_cancel_beneficiario_terceiro_nao_pode_cancelar_rascunho_numerado_de_outro(self):
+        setor = self._criar_setor("Almox Interno Terceiro", "90012A")
+        criador = self._criar_usuario("10013A", "Criador Almox", setor=setor)
+        beneficiario = self._criar_usuario("10013B", "Beneficiario Almox", setor=setor)
+        material = self._criar_material_com_estoque("001.001.181")
+        requisicao = Requisicao.objects.create(
+            criador=criador,
+            beneficiario=beneficiario,
+            numero_publico="REQ-2026-000201",
+            status=StatusRequisicao.RASCUNHO,
+            data_envio_autorizacao="2026-04-30T10:00:00Z",
+        )
+        requisicao.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=beneficiario)
+        response = client.post(reverse("requisicao-cancel", args=[requisicao.id]))
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"
+        requisicao.refresh_from_db()
+        assert requisicao.status == StatusRequisicao.RASCUNHO
 
     def test_authorize_total_reserva_estoque_e_define_autorizador(self):
         setor = self._criar_setor("Producao", "90016")
@@ -1074,6 +1720,8 @@ class TestRequisicaoAPI:
             criador=requisitante,
             beneficiario=requisitante,
             setor_beneficiario=setor,
+            status=StatusRequisicao.CANCELADA,
+            numero_publico="REQ-2026-000404",
         )
         item = requisicao.itens.create(
             material=material,
@@ -1163,6 +1811,52 @@ class TestRequisicaoAPI:
         assert response.data["results"][0]["numero_publico"] == "REQ-2026-000300"
         assert response.data["results"][0]["total_itens"] == 1
         assert req_b.id not in [item["id"] for item in response.data["results"]]
+
+    def test_fila_autorizacao_chefe_almoxarifado_retorna_apenas_setor_sob_responsabilidade(self):
+        setor_almox = self._criar_setor(
+            "Almoxarifado Aprova",
+            "900141",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+        )
+        setor_outro = self._criar_setor("Obras Aprova", "900142")
+        chefe_almox = setor_almox.chefe_responsavel
+        solicitante_almox = self._criar_usuario("100141", "Solicitante Almox", setor=setor_almox)
+        solicitante_outro = self._criar_usuario("100142", "Solicitante Obras", setor=setor_outro)
+        material = self._criar_material_com_estoque("001.001.112")
+
+        req_almox = Requisicao.objects.create(
+            criador=solicitante_almox,
+            beneficiario=solicitante_almox,
+            numero_publico="REQ-2026-000302",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T12:00:00Z",
+        )
+        req_almox.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+        req_outro = Requisicao.objects.create(
+            criador=solicitante_outro,
+            beneficiario=solicitante_outro,
+            numero_publico="REQ-2026-000303",
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            data_envio_autorizacao="2026-04-30T13:00:00Z",
+        )
+        req_outro.itens.create(
+            material=material,
+            unidade_medida=material.unidade_medida,
+            quantidade_solicitada=Decimal("1"),
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=chefe_almox)
+        response = client.get(reverse("requisicao-pending-approvals"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 1
+        assert response.data["results"][0]["id"] == req_almox.id
+        assert req_outro.id not in [item["id"] for item in response.data["results"]]
 
     def test_fila_autorizacao_bloqueia_papel_sem_permissao(self):
         setor = self._criar_setor("Gabinete", "90015")

--- a/tests/requisitions/test_api.py
+++ b/tests/requisitions/test_api.py
@@ -388,6 +388,7 @@ class TestRequisicaoAPI:
         response = client.get(reverse("requisicao-list"))
 
         assert response.status_code == 200
+        assert response.data["count"] == 1
         assert any(item["id"] == requisicao.id for item in response.data["results"])
         assert all(item["id"] != rascunho_terceiro.id for item in response.data["results"])
 
@@ -425,6 +426,7 @@ class TestRequisicaoAPI:
 
         assert response.status_code == 200
         resultado_ids = {item["id"] for item in response.data["results"]}
+        assert response.data["count"] == len(resultado_ids) == 1
         assert requisicao_setor_a.id in resultado_ids
         assert rascunho_setor_a.id not in resultado_ids
         assert requisicao_setor_b.id not in resultado_ids
@@ -575,6 +577,42 @@ class TestRequisicaoAPI:
         assert queryset_ids == {criada_pelo_usuario.id, beneficiario_usuario.id}
         assert rascunho_terceiro_como_beneficiario.id not in queryset_ids
         assert fora_escopo.id not in queryset_ids
+
+    def test_mine_queryset_superuser_nao_trata_base_inteira_como_pessoal(self):
+        setor = self._criar_setor("Operacao Super Mine", "9000833")
+        usuario = self._criar_usuario("100097", "Usuario Super Mine", setor=setor)
+        superuser = User.objects.create_superuser(
+            matricula_funcional="99003",
+            password="testpass123",
+            nome_completo="Super Mine",
+        )
+        superuser.setor = setor
+        superuser.save(update_fields=["setor"])
+        material = self._criar_material_com_estoque("001.001.154")
+
+        requisicao_superuser = self._criar_requisicao_com_item(
+            criador=superuser,
+            beneficiario=superuser,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000907",
+        )
+        requisicao_outro = self._criar_requisicao_com_item(
+            criador=usuario,
+            beneficiario=usuario,
+            material=material,
+            status=StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            numero_publico="REQ-2026-000908",
+        )
+
+        queryset_ids = set(
+            queryset_requisicoes_pessoais(superuser, skip_prefetch=True).values_list(
+                "id", flat=True
+            )
+        )
+
+        assert queryset_ids == {requisicao_superuser.id}
+        assert requisicao_outro.id not in queryset_ids
 
     def test_lista_requisicoes_filtra_por_status_e_busca_textual(self):
         setor = self._criar_setor("Compras", "900074")
@@ -964,10 +1002,19 @@ class TestRequisicaoAPI:
             queryset_ids = set(
                 queryset_requisicoes_visiveis(user, skip_prefetch=True).values_list("id", flat=True)
             )
-            assert pode_visualizar_requisicao(user, requisicao_rascunho) is esperado_rascunho
-            assert (requisicao_rascunho.id in queryset_ids) is esperado_rascunho
-            assert pode_visualizar_requisicao(user, requisicao_aguardando) is esperado_aguardando
-            assert (requisicao_aguardando.id in queryset_ids) is esperado_aguardando
+            user_id = getattr(user, "matricula_funcional", "<anon>")
+            assert pode_visualizar_requisicao(user, requisicao_rascunho) is esperado_rascunho, (
+                f"user={user_id} rascunho pode_visualizar esperado={esperado_rascunho}"
+            )
+            assert (requisicao_rascunho.id in queryset_ids) is esperado_rascunho, (
+                f"user={user_id} rascunho queryset esperado={esperado_rascunho}"
+            )
+            assert pode_visualizar_requisicao(user, requisicao_aguardando) is esperado_aguardando, (
+                f"user={user_id} aguardando pode_visualizar esperado={esperado_aguardando}"
+            )
+            assert (requisicao_aguardando.id in queryset_ids) is esperado_aguardando, (
+                f"user={user_id} aguardando queryset esperado={esperado_aguardando}"
+            )
 
         queryset_anonimo = queryset_requisicoes_visiveis(AnonymousUser(), skip_prefetch=True)
         assert pode_visualizar_requisicao(AnonymousUser(), requisicao_rascunho) is False

--- a/tests/requisitions/test_seed_pilot_minimo_command.py
+++ b/tests/requisitions/test_seed_pilot_minimo_command.py
@@ -32,24 +32,29 @@ class TestSeedPilotMinimoCommand:
             for user in User.objects.select_related("setor").order_by("matricula_funcional")
         }
         assert set(usuarios) == {
-            "91001",
             "91002",
-            "91003",
-            "91004",
-            "91005",
-            "91006",
-            "91998",
-            "91999",
+            "auxiliar-almox",
+            "auxiliar-setor-2",
+            "chefe-almox",
+            "chefe-setor",
+            "chefe-setor-2",
+            "inativo",
+            "solicitante1",
+            "solicitante2",
+            "solicitante3",
+            "super",
         }
-        assert usuarios["91001"].papel == PapelChoices.CHEFE_SETOR
         assert usuarios["91002"].papel == PapelChoices.AUXILIAR_SETOR
-        assert usuarios["91003"].papel == PapelChoices.SOLICITANTE
-        assert usuarios["91004"].papel == PapelChoices.SOLICITANTE
-        assert usuarios["91005"].papel == PapelChoices.CHEFE_ALMOXARIFADO
-        assert usuarios["91006"].papel == PapelChoices.AUXILIAR_ALMOXARIFADO
-        assert usuarios["91998"].is_superuser is True
-        assert usuarios["91998"].is_staff is True
-        assert usuarios["91999"].is_active is False
+        assert usuarios["chefe-setor"].papel == PapelChoices.CHEFE_SETOR
+        assert usuarios["chefe-setor-2"].papel == PapelChoices.CHEFE_SETOR
+        assert usuarios["solicitante1"].papel == PapelChoices.SOLICITANTE
+        assert usuarios["solicitante2"].papel == PapelChoices.SOLICITANTE
+        assert usuarios["solicitante3"].papel == PapelChoices.SOLICITANTE
+        assert usuarios["chefe-almox"].papel == PapelChoices.CHEFE_ALMOXARIFADO
+        assert usuarios["auxiliar-almox"].papel == PapelChoices.AUXILIAR_ALMOXARIFADO
+        assert usuarios["super"].is_superuser is True
+        assert usuarios["super"].is_staff is True
+        assert usuarios["inativo"].is_active is False
 
         materiais = {
             material.codigo_completo: material
@@ -60,10 +65,16 @@ class TestSeedPilotMinimoCommand:
             "010.001.002",
             "010.001.003",
             "010.001.004",
+            "010.001.005",
+            "010.001.006",
+            "010.001.007",
         }
         assert materiais["010.001.001"].estoque.saldo_fisico == 50
         assert not hasattr(materiais["010.001.003"], "estoque")
         assert materiais["010.001.004"].is_active is False
+        assert materiais["010.001.005"].estoque.saldo_fisico == 12
+        assert materiais["010.001.006"].estoque.saldo_fisico == 19
+        assert materiais["010.001.007"].estoque.saldo_fisico == 13
 
         requisicoes = list(
             Requisicao.objects.select_related(
@@ -75,31 +86,60 @@ class TestSeedPilotMinimoCommand:
             .prefetch_related("itens__material", "eventos__usuario")
             .order_by("id")
         )
+        assert len(requisicoes) == 14
         assert [requisicao.status for requisicao in requisicoes] == [
             StatusRequisicao.RASCUNHO,
             StatusRequisicao.AGUARDANDO_AUTORIZACAO,
             StatusRequisicao.AUTORIZADA,
             StatusRequisicao.ATENDIDA_PARCIALMENTE,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.AUTORIZADA,
+            StatusRequisicao.ATENDIDA_PARCIALMENTE,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.AUTORIZADA,
+            StatusRequisicao.ATENDIDA,
         ]
 
-        rascunho, aguardando, autorizada_parcial, atendida_parcial = requisicoes
+        (
+            rascunho,
+            aguardando,
+            autorizada_parcial,
+            atendida_parcial,
+            _rascunho_setor_secundario,
+            _aguardando_setor_secundario,
+            rascunho_manutencao_terceiro,
+            _aguardando_manutencao,
+            _autorizada_manutencao,
+            _atendida_manutencao,
+            _rascunho_manutencao_puro,
+            _aguardando_secundario_terceiro,
+            _autorizada_secundario,
+            atendida_secundario,
+        ) = requisicoes
 
         assert rascunho.criador_id != rascunho.beneficiario_id
         assert rascunho.criador.matricula_funcional == "91002"
-        assert rascunho.beneficiario.matricula_funcional == "91004"
+        assert rascunho.beneficiario.matricula_funcional == "solicitante2"
         assert rascunho.numero_publico is None
+        assert rascunho_manutencao_terceiro.criador.matricula_funcional == "91002"
+        assert rascunho_manutencao_terceiro.beneficiario.matricula_funcional == "solicitante2"
 
         assert aguardando.numero_publico is not None
         assert autorizada_parcial.numero_publico is not None
         assert atendida_parcial.numero_publico is not None
+        assert atendida_secundario.numero_publico is not None
 
         item_autorizado = autorizada_parcial.itens.get()
         assert item_autorizado.quantidade_autorizada < item_autorizado.quantidade_solicitada
-        assert autorizada_parcial.chefe_autorizador.matricula_funcional == "91001"
+        assert autorizada_parcial.chefe_autorizador.matricula_funcional == "chefe-setor"
 
         item_atendido = atendida_parcial.itens.get()
         assert item_atendido.quantidade_entregue < item_atendido.quantidade_autorizada
-        assert atendida_parcial.responsavel_atendimento.matricula_funcional == "91006"
+        assert atendida_parcial.responsavel_atendimento.matricula_funcional == "auxiliar-almox"
 
         material_baixo = materiais["010.001.002"]
         estoque_baixo = EstoqueMaterial.objects.get(material=material_baixo)
@@ -112,9 +152,9 @@ class TestSeedPilotMinimoCommand:
         call_command("seed_pilot_minimo")
         call_command("seed_pilot_minimo")
 
-        assert User.objects.count() == 8
-        assert Material.objects.count() == 4
-        assert Requisicao.objects.count() == 4
+        assert User.objects.count() == 11
+        assert Material.objects.count() == 7
+        assert Requisicao.objects.count() == 14
         assert list(
             Requisicao.objects.filter(observacao__startswith="SEED_PILOT_MINIMO")
             .values_list("status", flat=True)
@@ -124,4 +164,14 @@ class TestSeedPilotMinimoCommand:
             StatusRequisicao.AGUARDANDO_AUTORIZACAO,
             StatusRequisicao.AUTORIZADA,
             StatusRequisicao.ATENDIDA_PARCIALMENTE,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.AUTORIZADA,
+            StatusRequisicao.ATENDIDA_PARCIALMENTE,
+            StatusRequisicao.RASCUNHO,
+            StatusRequisicao.AGUARDANDO_AUTORIZACAO,
+            StatusRequisicao.AUTORIZADA,
+            StatusRequisicao.ATENDIDA,
         ]

--- a/tests/requisitions/test_seed_pilot_minimo_command.py
+++ b/tests/requisitions/test_seed_pilot_minimo_command.py
@@ -54,6 +54,8 @@ class TestSeedPilotMinimoCommand:
         assert usuarios["auxiliar-almox"].papel == PapelChoices.AUXILIAR_ALMOXARIFADO
         assert usuarios["super"].is_superuser is True
         assert usuarios["super"].is_staff is True
+        assert usuarios["super"].setor_id is None
+        assert usuarios["super"].papel == PapelChoices.SOLICITANTE
         assert usuarios["inativo"].is_active is False
 
         materiais = {
@@ -175,3 +177,20 @@ class TestSeedPilotMinimoCommand:
             StatusRequisicao.AUTORIZADA,
             StatusRequisicao.ATENDIDA,
         ]
+
+    def test_seed_reconcilia_beneficiario_do_cenario_secundario_terceiro(self):
+        call_command("seed_pilot_minimo")
+
+        requisicao = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:aguardando_secundario_terceiro"
+        )
+        beneficiario_errado = User.objects.get(matricula_funcional="solicitante2")
+        Requisicao.objects.filter(pk=requisicao.pk).update(beneficiario=beneficiario_errado)
+
+        call_command("seed_pilot_minimo")
+
+        requisicao_corrigida = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:aguardando_secundario_terceiro"
+        )
+        assert requisicao_corrigida.status == StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        assert requisicao_corrigida.beneficiario.matricula_funcional == "solicitante3"

--- a/tests/requisitions/test_seed_pilot_minimo_command.py
+++ b/tests/requisitions/test_seed_pilot_minimo_command.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from io import StringIO
 
 import pytest
@@ -199,3 +200,33 @@ class TestSeedPilotMinimoCommand:
         assert requisicao_corrigida.eventos.filter(
             tipo_evento=TipoEvento.REENVIO_AUTORIZACAO
         ).exists()
+
+    def test_seed_reconcilia_rascunho_manutencao_terceiro_quando_item_diverge(self):
+        call_command("seed_pilot_minimo")
+
+        requisicao = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:rascunho_manutencao_terceiro"
+        )
+        beneficiario_errado = User.objects.get(matricula_funcional="solicitante1")
+        material_errado = Material.objects.get(codigo_completo="010.001.001")
+        requisicao.beneficiario = beneficiario_errado
+        requisicao.setor_beneficiario = beneficiario_errado.setor
+        requisicao.save(update_fields=["beneficiario", "setor_beneficiario", "updated_at"])
+        requisicao.itens.update(
+            material=material_errado,
+            unidade_medida=material_errado.unidade_medida,
+            quantidade_solicitada=Decimal("2"),
+            observacao="Item desatualizado do seed",
+        )
+
+        call_command("seed_pilot_minimo")
+
+        requisicao_corrigida = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:rascunho_manutencao_terceiro"
+        )
+        item_corrigido = requisicao_corrigida.itens.get()
+
+        assert requisicao_corrigida.beneficiario.matricula_funcional == "solicitante2"
+        assert item_corrigido.material.codigo_completo == "010.001.006"
+        assert item_corrigido.quantidade_solicitada == Decimal("1")
+        assert item_corrigido.observacao == "Rascunho de manutencao com beneficiario de terceiro"

--- a/tests/requisitions/test_seed_pilot_minimo_command.py
+++ b/tests/requisitions/test_seed_pilot_minimo_command.py
@@ -6,7 +6,7 @@ from django.core.management.base import CommandError
 from django.test import override_settings
 
 from apps.materials.models import Material
-from apps.requisitions.models import Requisicao, StatusRequisicao
+from apps.requisitions.models import Requisicao, StatusRequisicao, TipoEvento
 from apps.requisitions.seed_pilot_minimo import carregar_seed_pilot_minimo
 from apps.stock.models import EstoqueMaterial
 from apps.users.models import PapelChoices, User
@@ -194,3 +194,8 @@ class TestSeedPilotMinimoCommand:
         )
         assert requisicao_corrigida.status == StatusRequisicao.AGUARDANDO_AUTORIZACAO
         assert requisicao_corrigida.beneficiario.matricula_funcional == "solicitante3"
+        assert requisicao_corrigida.setor_beneficiario == requisicao_corrigida.beneficiario.setor
+        assert requisicao_corrigida.eventos.filter(tipo_evento=TipoEvento.RETORNO_RASCUNHO).exists()
+        assert requisicao_corrigida.eventos.filter(
+            tipo_evento=TipoEvento.REENVIO_AUTORIZACAO
+        ).exists()

--- a/tests/requisitions/test_seed_pilot_minimo_command.py
+++ b/tests/requisitions/test_seed_pilot_minimo_command.py
@@ -201,6 +201,36 @@ class TestSeedPilotMinimoCommand:
             tipo_evento=TipoEvento.REENVIO_AUTORIZACAO
         ).exists()
 
+    def test_seed_reconcilia_aguardando_secundario_terceiro_quando_item_diverge(self):
+        call_command("seed_pilot_minimo")
+
+        requisicao = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:aguardando_secundario_terceiro"
+        )
+        material_errado = Material.objects.get(codigo_completo="010.001.001")
+        requisicao.itens.update(
+            material=material_errado,
+            unidade_medida=material_errado.unidade_medida,
+            quantidade_solicitada=Decimal("9"),
+            observacao="Item divergente do seed",
+        )
+
+        call_command("seed_pilot_minimo")
+
+        requisicao_corrigida = Requisicao.objects.get(
+            observacao="SEED_PILOT_MINIMO:aguardando_secundario_terceiro"
+        )
+        item_corrigido = requisicao_corrigida.itens.get()
+
+        assert requisicao_corrigida.status == StatusRequisicao.AGUARDANDO_AUTORIZACAO
+        assert item_corrigido.material.codigo_completo == "010.001.007"
+        assert item_corrigido.quantidade_solicitada == Decimal("2")
+        assert item_corrigido.observacao == "Aguardando autorizacao com terceiro beneficiario"
+        assert requisicao_corrigida.eventos.filter(tipo_evento=TipoEvento.RETORNO_RASCUNHO).exists()
+        assert requisicao_corrigida.eventos.filter(
+            tipo_evento=TipoEvento.REENVIO_AUTORIZACAO
+        ).exists()
+
     def test_seed_reconcilia_rascunho_manutencao_terceiro_quando_item_diverge(self):
         call_command("seed_pilot_minimo")
 

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -141,6 +141,7 @@ class TestOpenAPISchema:
         assert "/api/v1/materials/" in paths
         assert "/api/v1/requisitions/" in paths
         assert "/api/v1/requisitions/{id}/" in paths
+        assert "/api/v1/requisitions/mine/" in paths
         assert "/api/v1/requisitions/{id}/draft/" in paths
         assert "/api/v1/requisitions/{id}/submit/" in paths
         assert "/api/v1/requisitions/{id}/return-to-draft/" in paths
@@ -187,6 +188,19 @@ class TestOpenAPISchema:
             == error_ref
         )
         assert "PaginatedRequisicaoListPaginatedList" not in schema["components"]["schemas"]
+
+        mine_operation = paths["/api/v1/requisitions/mine/"]["get"]
+        mine_parameters = {param["name"]: param for param in mine_operation["parameters"]}
+        assert set(mine_parameters) >= {"page", "page_size", "search", "status"}
+        assert mine_operation["operationId"] == "requisitions_mine"
+        assert (
+            mine_operation["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+            == "#/components/schemas/RequisicaoListPaginated"
+        )
+        assert (
+            mine_operation["responses"]["403"]["content"]["application/json"]["schema"]["$ref"]
+            == error_ref
+        )
 
         detail_operation = paths["/api/v1/requisitions/{id}/"]["get"]
         assert detail_operation["operationId"] == "requisitions_retrieve"

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -507,6 +507,13 @@ class TestAuthAPI:
             password="senha-segura-123",
             nome_completo="Super Admin Lookup",
         )
+        superuser_com_setor = User.objects.create_superuser(
+            matricula_funcional="99902",
+            password="senha-segura-123",
+            nome_completo="Super Admin Lookup Setor",
+        )
+        superuser_com_setor.setor = setor_ti
+        superuser_com_setor.save(update_fields=["setor"])
 
         self._criar_usuario(
             matricula="22503",
@@ -527,6 +534,13 @@ class TestAuthAPI:
 
         client = APIClient()
         client.force_authenticate(user=superuser)
+
+        response = client.get(reverse("user-beneficiary-lookup"), {"q": "Carla"})
+
+        assert response.status_code == 200
+        assert response.data == []
+
+        client.force_authenticate(user=superuser_com_setor)
 
         response = client.get(reverse("user-beneficiary-lookup"), {"q": "Carla"})
 

--- a/tests/users/test_auth_api.py
+++ b/tests/users/test_auth_api.py
@@ -483,7 +483,7 @@ class TestAuthAPI:
         assert response.status_code == 200
         assert response.data == []
 
-    def test_beneficiary_lookup_para_superusuario_retorna_visibilidade_ampla_elegivel(self):
+    def test_beneficiary_lookup_para_superusuario_retorna_lista_vazia(self):
         chefe_ti = self._criar_usuario(
             matricula="22501",
             nome_completo="Chefe TI Super",
@@ -531,10 +531,7 @@ class TestAuthAPI:
         response = client.get(reverse("user-beneficiary-lookup"), {"q": "Carla"})
 
         assert response.status_code == 200
-        assert [item["nome_completo"] for item in response.data] == [
-            "Carla RH",
-            "Carla TI",
-        ]
+        assert response.data == []
 
     def test_beneficiary_lookup_sem_autenticacao_retorna_401(self):
         client = APIClient()

--- a/tests/users/test_papeis_policies.py
+++ b/tests/users/test_papeis_policies.py
@@ -270,7 +270,7 @@ class TestPodeAutorizarSetor:
     def test_per05_chefe_almoxarifado_pode_autorizar_setor_sob_responsabilidade(self):
         """PER-05 — Chefe de Almoxarifado usa o setor onde é chefe responsável."""
         chefe_alm = _criar_user("600041", PapelChoices.CHEFE_ALMOXARIFADO)
-        setor_alm = _criar_setor("Almoxarifado Central", chefe_alm)
+        setor_alm = _criar_setor("Almoxarifado", chefe_alm)
         chefe_alm.setor = setor_alm
         chefe_alm.save(update_fields=["setor"])
 

--- a/tests/users/test_papeis_policies.py
+++ b/tests/users/test_papeis_policies.py
@@ -20,6 +20,7 @@ from apps.users.policies import (
     pode_operar_estoque,
     pode_operar_estoque_chefia,
     pode_ver_fila_atendimento,
+    queryset_beneficiarios_lookup_para,
     setor_responsavel_chefia,
     usuario_almoxarifado,
     usuario_chefe_almoxarifado,
@@ -221,6 +222,19 @@ class TestPodeCriarRequisicaoPara:
             nome_completo="Super Admin",
         )
         assert pode_criar_requisicao_para(superuser, superuser) is False
+
+    def test_per06_superusuario_nao_recebe_lookup_de_beneficiarios(self):
+        """PER-06 — Superusuário não recebe lookup operacional de beneficiários."""
+        superuser = User.objects.create_superuser(
+            matricula_funcional="99002",
+            password="testpass123",
+            nome_completo="Super Admin Lookup",
+        )
+        chefe = _criar_user("20016", PapelChoices.CHEFE_SETOR)
+        setor = _criar_setor("Almoxarifado Aux", chefe)
+        _criar_user("20017", PapelChoices.SOLICITANTE, setor=setor)
+
+        assert queryset_beneficiarios_lookup_para(superuser).count() == 0
 
     def test_usuario_inativo_nao_pode_criar_requisicao(self):
         """USR-03 — Usuário inativo não opera."""

--- a/tests/users/test_papeis_policies.py
+++ b/tests/users/test_papeis_policies.py
@@ -269,12 +269,21 @@ class TestPodeAutorizarSetor:
 
     def test_per05_chefe_almoxarifado_pode_autorizar_setor_sob_responsabilidade(self):
         """PER-05 — Chefe de Almoxarifado usa o setor onde é chefe responsável."""
-        chefe_alm = _criar_user("600041", PapelChoices.CHEFE_ALMOXARIFADO)
+        chefe_alm = _criar_user("60041", PapelChoices.CHEFE_ALMOXARIFADO)
         setor_alm = _criar_setor("Almoxarifado", chefe_alm)
         chefe_alm.setor = setor_alm
         chefe_alm.save(update_fields=["setor"])
 
         assert pode_autorizar_setor(chefe_alm, setor_alm) is True
+
+    def test_per05_chefe_almoxarifado_nao_pode_autorizar_setor_nao_canonico_mesmo_sob_chefia(self):
+        chefe_alm = _criar_user("60042", PapelChoices.CHEFE_ALMOXARIFADO)
+        setor_alm = _criar_setor("Almoxarifado Central", chefe_alm)
+        chefe_alm.setor = setor_alm
+        chefe_alm.save(update_fields=["setor"])
+
+        assert setor_responsavel_chefia(chefe_alm) is None
+        assert pode_autorizar_setor(chefe_alm, setor_alm) is False
 
     def test_per06_superusuario_nao_pode_autorizar_setor(self):
         """PER-06 — Superusuário não autoriza requisições operacionais."""

--- a/tests/users/test_papeis_policies.py
+++ b/tests/users/test_papeis_policies.py
@@ -11,6 +11,7 @@ Cobre os invariantes:
 """
 
 import pytest
+from django.contrib.auth.models import AnonymousUser
 
 from apps.users.models import PapelChoices, Setor, User
 from apps.users.policies import (
@@ -19,6 +20,10 @@ from apps.users.policies import (
     pode_operar_estoque,
     pode_operar_estoque_chefia,
     pode_ver_fila_atendimento,
+    setor_responsavel_chefia,
+    usuario_almoxarifado,
+    usuario_chefe_almoxarifado,
+    usuario_operacional_ativo,
 )
 
 # ---------------------------------------------------------------------------
@@ -56,6 +61,59 @@ class TestPapelDefault:
             nome_completo="Usuário Padrão",
         )
         assert user.papel == PapelChoices.SOLICITANTE
+
+
+@pytest.mark.django_db
+class TestPredicadosGenericosUsuario:
+    def test_anonymous_nao_e_operacional_nem_almoxarifado(self):
+        user = AnonymousUser()
+
+        assert usuario_operacional_ativo(user) is False
+        assert usuario_almoxarifado(user) is False
+        assert usuario_chefe_almoxarifado(user) is False
+
+    def test_usuario_inativo_nao_e_operacional(self):
+        user = _criar_user("00002", is_active=False)
+
+        assert usuario_operacional_ativo(user) is False
+
+    def test_superuser_nao_e_operacional(self):
+        user = User.objects.create_superuser(
+            matricula_funcional="00003",
+            password="testpass123",
+            nome_completo="Super Admin Predicado",
+        )
+
+        assert usuario_operacional_ativo(user) is False
+        assert usuario_almoxarifado(user) is False
+        assert usuario_chefe_almoxarifado(user) is False
+
+    def test_auxiliar_almoxarifado_cai_no_predicado_correto(self):
+        user = _criar_user("00004", PapelChoices.AUXILIAR_ALMOXARIFADO)
+
+        assert usuario_operacional_ativo(user) is True
+        assert usuario_almoxarifado(user) is True
+        assert usuario_chefe_almoxarifado(user) is False
+
+    def test_chefe_almoxarifado_cai_no_predicado_correto(self):
+        user = _criar_user("00005", PapelChoices.CHEFE_ALMOXARIFADO)
+
+        assert usuario_operacional_ativo(user) is True
+        assert usuario_almoxarifado(user) is True
+        assert usuario_chefe_almoxarifado(user) is True
+
+    def test_setor_responsavel_chefia_retorna_setor_para_chefia(self):
+        chefe = _criar_user("00006", PapelChoices.CHEFE_SETOR)
+        setor = _criar_setor("Planejamento Predicado", chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+
+        assert setor_responsavel_chefia(chefe) == setor
+
+    def test_setor_responsavel_chefia_retorna_none_para_papel_sem_chefia(self):
+        user = _criar_user("00007", PapelChoices.SOLICITANTE)
+
+        assert setor_responsavel_chefia(user) is None
 
 
 # ---------------------------------------------------------------------------
@@ -208,6 +266,15 @@ class TestPodeAutorizarSetor:
         setor_outro = _criar_setor("Obras", chefe_outro)
 
         assert pode_autorizar_setor(chefe_alm, setor_outro) is False
+
+    def test_per05_chefe_almoxarifado_pode_autorizar_setor_sob_responsabilidade(self):
+        """PER-05 — Chefe de Almoxarifado usa o setor onde é chefe responsável."""
+        chefe_alm = _criar_user("600041", PapelChoices.CHEFE_ALMOXARIFADO)
+        setor_alm = _criar_setor("Almoxarifado Central", chefe_alm)
+        chefe_alm.setor = setor_alm
+        chefe_alm.save(update_fields=["setor"])
+
+        assert pode_autorizar_setor(chefe_alm, setor_alm) is True
 
     def test_per06_superusuario_nao_pode_autorizar_setor(self):
         """PER-06 — Superusuário não autoriza requisições operacionais."""

--- a/tests/users/test_setor_model.py
+++ b/tests/users/test_setor_model.py
@@ -202,6 +202,66 @@ class TestSetorModel:
         with pytest.raises(ValidationError):
             setor_a.full_clean()
 
+    def test_clean_aceita_quando_auxiliar_pertence_ao_proprio_setor(self):
+        chefe = User.objects.create_user(
+            matricula_funcional="12346",
+            password="testpass123",
+            nome_completo="Chefe Setor",
+        )
+        auxiliar = User.objects.create_user(
+            matricula_funcional="54322",
+            password="testpass123",
+            nome_completo="Auxiliar Setor",
+        )
+        setor = Setor.objects.create(
+            nome="Expedicao",
+            chefe_responsavel=chefe,
+            auxiliar_responsavel=auxiliar,
+        )
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        auxiliar.setor = setor
+        auxiliar.save(update_fields=["setor"])
+
+        setor.full_clean()
+
+    def test_clean_rejeita_quando_auxiliar_pertence_a_outro_setor(self):
+        chefe_a = User.objects.create_user(
+            matricula_funcional="12347",
+            password="testpass123",
+            nome_completo="Chefe A",
+        )
+        chefe_b = User.objects.create_user(
+            matricula_funcional="54323",
+            password="testpass123",
+            nome_completo="Chefe B",
+        )
+        auxiliar = User.objects.create_user(
+            matricula_funcional="54324",
+            password="testpass123",
+            nome_completo="Auxiliar B",
+        )
+        setor_a = Setor.objects.create(
+            nome="Expedicao A",
+            chefe_responsavel=chefe_a,
+            auxiliar_responsavel=auxiliar,
+        )
+        setor_b = Setor.objects.create(
+            nome="Expedicao B",
+            chefe_responsavel=chefe_b,
+        )
+        chefe_a.setor = setor_a
+        chefe_a.save(update_fields=["setor"])
+        chefe_b.setor = setor_b
+        chefe_b.save(update_fields=["setor"])
+        auxiliar.setor = setor_b
+        auxiliar.save(update_fields=["setor"])
+
+        with pytest.raises(ValidationError):
+            setor_a.clean()
+        with pytest.raises(ValidationError):
+            setor_a.full_clean()
+
     def test_full_clean_rejeita_setor_sem_chefe_responsavel(self):
         setor = Setor(nome="Almoxarifado", chefe_responsavel=None)
 


### PR DESCRIPTION
# Contexto

## O que este PR faz
- implementa o fluxo de `Minhas requisições` na SPA, incluindo listagem, detalhe e smoke/e2e coverage do shell atualizado;
- ajusta contracts, schema OpenAPI e camada frontend tipada para o fluxo de requisições pessoais;
- endurece policies/backend para alinhar escopo de visualização e permissões de requisições, incluindo rascunho creator-only e visibilidade do beneficiário apenas após sair de `rascunho`;
- atualiza seeds, docs canônicas e memórias Serena para refletir o contrato vigente.

## Por que esta mudança é necessária
A fatia do piloto precisava sair do bootstrap da SPA e entregar a primeira worklist real de requisições, com backend e frontend alinhados no contrato de visibilidade. Sem isso, a tela de `Minhas requisições` ficava incompleta e ainda havia vazamento de rascunhos criados por terceiros para beneficiários e papéis operacionais que não deveriam enxergá-los.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [x] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Regressão de visibilidade/permissão no fluxo de requisições: esconder demais worklists pessoais ou abrir brecha para rascunhos de terceiros se frontend e backend divergirem no status `rascunho`.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: `rascunho` passa a ser creator-only; beneficiário terceiro só ganha acesso após o envio; chefia/almox deixam de ver rascunhos de terceiros.
- máquina de estados / aprovação / cotas / entregas: retorno para `rascunho` revoga novamente a visibilidade do beneficiário terceiro.

---

# Testes e validação

## Cenários validados
1. `rtk proxy pytest tests/requisitions/test_api.py -q`
2. `rtk ruff check apps/requisitions/policies.py apps/requisitions/services.py tests/requisitions/test_api.py`
3. `git diff --check`

## Como validar manualmente
1. Autenticar na SPA com um usuário que possua requisições próprias e abrir `/minhas-requisicoes`.
2. Confirmar que rascunho criado pelo próprio usuário aparece, mas rascunho criado por terceiro com esse usuário como beneficiário não aparece.
3. Enviar uma requisição criada para terceiro para `aguardando_autorizacao` e confirmar que o beneficiário passa a enxergá-la; retornar para `rascunho` e confirmar que ela some novamente da worklist e do detalhe para o beneficiário.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{
  "status": "rascunho | aguardando_autorizacao",
  "expected_visibility": {
    "creator": true,
    "third_party_beneficiary": false
  }
}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Objetivo: Implementar o fluxo "Minhas requisições" (lista paginada + detalhe) na SPA e na API (GET /api/v1/requisitions/mine/), adicionar tipagens/OpenAPI/frontend, smoke/e2e, seeds expandidos e endurecer políticas de visibilidade/permissões para RASCUNHO (rascunho = apenas criador; beneficiário terceiro vê só após saída; retornar a rascunho revoga visibilidade).

- Apps Django impactados:
  - apps/requisitions: policies (refactor, novos helpers/querysets: queryset_requisicoes_pessoais, user_is_creator*), views (action mine), services (mensagens PermissionDenied), seed_pilot_minimo (novos cenários), muitos testes API.
  - apps/users: models (Setor: chefe.related_name → setor_como_chefe; novo auxiliar_responsavel OneToOne), policies (usuario_operacional_ativo, usuario_almoxarifado, usuario_chefe_almoxarifado, setor_responsavel_chefia), validação de modelo e testes.
  - frontend: OpenAPI/schema + typings, util formatQuantity, rotas/páginas (minhas-requisicoes, requisicoes/$id), estilos, testes unitários e e2e.
  - docs/.serena e docs/design-acesso-rapido atualizados.

- Risco funcional (prioritário):
  - Divergência frontend↔backend na semântica RASCUNHO pode vazar rascunhos de terceiros ou causar erros UX/autorização durante transições.
  - Mudanças de modelo (auxiliar_responsavel / related_name) exigem migrations; ausência rompe seeds/tests/deploy.
  - Autorizações inconsistentes (uso de pode_visualizar_requisicao) podem expor dados sensíveis de rascunho.
  - Transições estado (enviar/autorizar/retornar/descartar/cancelar) aumentam risco de corrida, reservas duplicadas ou saldo negativo se não houver locks/transaction.atomic adequados.
  - Superuser-bypass e nova resolução de setor para chefia podem alterar visibilidade/autorização esperadas.

- Impacto em regras de negócio:
  - RASCUNHO: ações (listar/ver/editar/enviar/descartar/cancelar) restringidas ao criador; beneficiário terceiro só ganha visibilidade após a saída de rascunho; retornar a rascunho revoga visibilidade.
  - Matriz de transições e eventos atualizadas (envio_autorizacao, retorno_rascunho, reenvio_autorizacao); vários atores trocados para Criador.
  - Efeitos colaterais documentados em seeds e memórias (serena).

- Impacto em autenticação/autorizações, escopo por perfil e setor:
  - Introduz predicados reutilizáveis (usuario_operacional_ativo, usuario_almoxarifado, usuario_chefe_almoxarifado) e setor_responsavel_chefia para derivar setor de chefia.
  - CHEFE_SETOR/CHEFE_ALMOXARIFADO usam setor_responsavel_chefia — pode restringir ou ampliar escopo observável versus implementação antiga.
  - Almoxarifado tratado distintamente (visão mais ampla); anon/inativos e chefia fora do setor cobertos em testes.
  - Mensagens PermissionDenied mudadas para enfatizar "Apenas criador…" em fluxos de rascunho — confirmar mapeamento HTTP (403 vs 404) e comportamento frontend.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI:
  - Novo endpoint GET /api/v1/requisitions/mine/ adicionado ao OpenAPI/schema e typings; parâmetros: page, page_size, search, status; testes de schema atualizados.
  - Serializers/views devem aplicar visibilidade por status e request.user — confirmar uso consistente de políticas para evitar 200 com dados indevidos.
  - Mensagens de PermissionDenied alteram conteúdo do envelope de erro retornado; validar consumíveis pelo frontend (erro auth vs autorização).

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade:
  - Setor: novo campo auxiliar_responsavel + related_name alterado → migrations + validações (Setor.clean refatorado); verificar admin/fixtures/seeds.
  - Retorno a rascunho deve revogar visibilidade sem perder timeline/eventos — garantir que eventos (RETORNO_RASCUNHO, REENVIO_AUTORIZACAO) sejam gravados e auditáveis.
  - Seeds expandidos e testes de reconciliação alteram o conjunto de dados de referência; confirmar idempotência e que correções geram eventos auditáveis.

- Impacto em transações, concorrência, idempotência, saldo físico/reservado/disponível:
  - Fluxos que afetam reservas/saldos requerem transaction.atomic e, possivelmente, locks para evitar reservas acima do disponível ou saldo negativo.
  - Rascunhos não devem afetar saldos; testes de concorrência e retried requests recomendados para prevenir reprocessamento indevido.
  - Atenção especial para atendimento parcial e atualização de reservas nos novos cenários de seed.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque:
  - Novas variações e materiais nos seeds podem divergir do catálogo oficial — validar códigos/IDs contra pipeline SCPI antes de promover para produção para evitar inconsistências de estoque/mapeamento.

- Impacto em configuração, CI, lint, testes ou ambiente efêmero:
  - Testes aumentados (backend pytest; frontend unit + e2e); CI precisa rodar suíte completa e ruff checks.
  - Migrations para apps/users obrigatórias antes de rodar seeds/CI.
  - Possível N+1 em list/detail (skip_prefetch flag presente) — revisar select_related/prefetch nos novos querysets.

- Como validar manualmente via API, admin, comando e testes:
  - API (fluxo mínimo):
    1. Criar requisição em RASCUNHO (criador A, beneficiário B).
    2. Como B: GET /api/v1/requisitions/mine/ NÃO deve listar; GET /api/v1/requisitions/{id}/ deve negar (403/404 conforme política).
    3. Como A: enviar para autorização; como B: /mine e detalhe DEVEM retornar 200.
    4. Como A: retornar para RASCUNHO; como B: visibilidade deve ser revogada novamente.
  - Admin: testar Setor.full_clean() com auxiliar_responsavel e chefe_responsavel (mesmo/diferente setor); verificar related_name aplicável.
  - Seeds: executar carregar_seed_pilot_minimo, conferir contagens esperadas (users, materials, requisicoes), idempotência e eventos gerados.
  - Testes automatizados: rodar pytest tests/requisitions/test_api.py, pytest tests/test_api_schema.py; frontend: router-smoke.test.tsx e e2e shell.spec.ts.
  - SPA: navegar /minhas-requisicoes; validar filtros (page/search/status), badge "Rascunho", indicador beneficiário terceiro e navegação para detalhe com comportamento de auth/error.

- Recomendações imediatas:
  - Aplicar e revisar migrations para apps/users antes do deploy; atualizar fixtures/seeds correspondentes.
  - Auditoria completa das views/serializers para garantir uso consistente de pode_visualizar_requisicao e evitar exposição de rascunhos.
  - Adicionar/rever testes de concorrência e transacionais para fluxos que afetam reservas/saldo.
  - Reconciliar e alinhar implementação com docs/design-acesso-rapido/*; corrigir discrepâncias antes do deploy.
  - Verificar select_related/prefetch nos novos querysets (evitar N+1 em list/detail).
  - Documentar comportamento de superuser-bypass e a lógica de derivação de setor para chefia.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->