### PR TITLE
Implementar editor de rascunho para requisições

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ run: ## Subir servidor de desenvolvimento
 $(FRONTEND_DEPS_STAMP): $(FRONTEND_DIR)/package.json $(FRONTEND_DIR)/pnpm-lock.yaml
 	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)
 	cd $(FRONTEND_DIR) && $(PNPM) install
+	touch $(FRONTEND_DEPS_STAMP)
 
 frontend-deps: $(FRONTEND_DEPS_STAMP) ## Instalar dependências do frontend quando necessário
 	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ MANAGE_PY ?= manage.py
 DJANGO_ADMIN ?= $(PYTHON) $(MANAGE_PY)
 FRONTEND_DIR ?= frontend
 FRONTEND_SCHEMA_FILE ?= $(FRONTEND_DIR)/openapi/schema.json
+FRONTEND_DEPS_STAMP ?= $(FRONTEND_DIR)/node_modules/.modules.yaml
 
 DJANGO_SETTINGS_MODULE ?= config.settings.dev
 TEST_SETTINGS_MODULE ?= config.settings.test
@@ -123,12 +124,18 @@ seed-pilot-minimo: ## Carregar seed minima oficial do piloto
 run: ## Subir servidor de desenvolvimento
 	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) runserver
 
-frontend-init: ## Instalar dependências do frontend e preparar Playwright
+$(FRONTEND_DEPS_STAMP): $(FRONTEND_DIR)/package.json $(FRONTEND_DIR)/pnpm-lock.yaml
 	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)
 	cd $(FRONTEND_DIR) && $(PNPM) install
+
+frontend-deps: $(FRONTEND_DEPS_STAMP) ## Instalar dependências do frontend quando necessário
+	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)
+
+frontend-init: frontend-deps ## Instalar dependências do frontend e preparar Playwright
+	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)
 	cd $(FRONTEND_DIR) && ./node_modules/.bin/playwright install chromium
 
-frontend-gen-api: frontend-init ## Exportar OpenAPI do backend e regenerar tipos do frontend
+frontend-gen-api: frontend-deps ## Exportar OpenAPI do backend e regenerar tipos do frontend
 	@test -d $(FRONTEND_DIR) || (echo "Diretório $(FRONTEND_DIR) não encontrado" && exit 1)
 	mkdir -p $(FRONTEND_DIR)/openapi
 	DJANGO_SETTINGS_MODULE=$(DJANGO_SETTINGS_MODULE) $(DJANGO_ADMIN) spectacular --format openapi-json --file $(FRONTEND_SCHEMA_FILE)
@@ -153,5 +160,5 @@ frontend-test: frontend-gen-api ## Rodar smoke tests unitários/integration do f
 frontend-e2e: frontend-gen-api ## Rodar smoke E2E do frontend com Playwright
 	cd $(FRONTEND_DIR) && ./node_modules/.bin/playwright test
 
-.PHONY: help prepare init setup clean cleanall veryclean test seed-pilot-minimo run resetdb resetpostgres frontend-init frontend-gen-api frontend-dev frontend-build frontend-lint frontend-test frontend-e2e
+.PHONY: help prepare init setup clean cleanall veryclean test seed-pilot-minimo run resetdb resetpostgres frontend-deps frontend-init frontend-gen-api frontend-dev frontend-build frontend-lint frontend-test frontend-e2e
 .EXPORT_ALL_VARIABLES:

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -144,6 +144,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     name: "itens",
   });
   const beneficiaryMode = useWatch({ control: form.control, name: "beneficiaryMode" }) ?? "self";
+  const previousBeneficiaryModeRef = useRef(beneficiaryMode);
   const beneficiaryLabelValue = useWatch({ control: form.control, name: "beneficiaryLabel" });
   const beneficiarySearch =
     useWatch({ control: form.control, name: "beneficiarySearch" })?.trim() ?? "";
@@ -179,7 +180,11 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       const self = currentUserBeneficiary(session);
       form.setValue("beneficiaryId", String(self.id));
       form.setValue("beneficiaryLabel", beneficiaryLabel(self));
+    } else if (previousBeneficiaryModeRef.current === "self") {
+      form.setValue("beneficiaryId", "");
+      form.setValue("beneficiaryLabel", "");
     }
+    previousBeneficiaryModeRef.current = beneficiaryMode;
   }, [beneficiaryMode, form, session]);
 
   function afterMutationSuccess(requisition: RequisicaoDetail) {

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -109,7 +109,12 @@ function hasPositiveStock(material: MaterialListItem) {
 }
 
 function normalizeQuantity(value: string) {
-  return value.trim().replace(",", ".");
+  return value.trim().replace(/,/g, ".");
+}
+
+function isPositiveQuantity(value: string) {
+  const quantity = Number(normalizeQuantity(value));
+  return Number.isFinite(quantity) && quantity > 0;
 }
 
 function selectedBeneficiary(values: DraftFormValues) {
@@ -136,8 +141,36 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [formError, setFormError] = useState<string | null>(null);
+  const [submitConfirmationValues, setSubmitConfirmationValues] = useState<DraftFormValues | null>(null);
+  const sessionSetorId = session.setor?.id ?? null;
+  const sessionSetorNome = session.setor?.nome ?? null;
+  const stableSession = useMemo(
+    () =>
+      ({
+        id: session.id,
+        matricula_funcional: session.matricula_funcional,
+        nome_completo: session.nome_completo,
+        papel: session.papel,
+        setor: sessionSetorId !== null && sessionSetorNome !== null
+          ? {
+              id: sessionSetorId,
+              nome: sessionSetorNome,
+            }
+          : null,
+        is_authenticated: session.is_authenticated,
+      }) satisfies AuthSession,
+    [
+      session.id,
+      session.is_authenticated,
+      session.matricula_funcional,
+      session.nome_completo,
+      session.papel,
+      sessionSetorId,
+      sessionSetorNome,
+    ],
+  );
   const form = useForm<DraftFormValues>({
-    defaultValues: formValuesFromRequisition(initialRequisition, session),
+    defaultValues: formValuesFromRequisition(initialRequisition, stableSession),
   });
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -145,6 +178,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   });
   const beneficiaryMode = useWatch({ control: form.control, name: "beneficiaryMode" }) ?? "self";
   const previousBeneficiaryModeRef = useRef(beneficiaryMode);
+  const beneficiaryIdValue = useWatch({ control: form.control, name: "beneficiaryId" }) ?? "";
   const beneficiaryLabelValue = useWatch({ control: form.control, name: "beneficiaryLabel" });
   const beneficiarySearch =
     useWatch({ control: form.control, name: "beneficiarySearch" })?.trim() ?? "";
@@ -159,7 +193,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     ...draftBeneficiariesQueryOptions(beneficiarySearch),
     enabled:
       beneficiaryMode === "third_party" &&
-      canRequestForThirdParty(session) &&
+      canRequestForThirdParty(stableSession) &&
       beneficiarySearch.length >= 3,
   });
   const materialsQuery = useQuery({
@@ -167,17 +201,17 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     enabled: materialSearch.length >= 2,
   });
   const canSubmitForm =
-    selectedBeneficiary(form.getValues()) > 0 &&
+    Number.parseInt(beneficiaryIdValue, 10) > 0 &&
     selectedItems.length > 0 &&
-    selectedItems.every((item) => Number.parseFloat(normalizeQuantity(item.quantidadeSolicitada)) > 0);
+    selectedItems.every((item) => isPositiveQuantity(item.quantidadeSolicitada));
 
   useEffect(() => {
-    form.reset(formValuesFromRequisition(initialRequisition, session));
-  }, [form, initialRequisition, session]);
+    form.reset(formValuesFromRequisition(initialRequisition, stableSession));
+  }, [form, initialRequisition, stableSession]);
 
   useEffect(() => {
     if (beneficiaryMode === "self") {
-      const self = currentUserBeneficiary(session);
+      const self = currentUserBeneficiary(stableSession);
       form.setValue("beneficiaryId", String(self.id));
       form.setValue("beneficiaryLabel", beneficiaryLabel(self));
     } else if (previousBeneficiaryModeRef.current === "self") {
@@ -185,10 +219,11 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       form.setValue("beneficiaryLabel", "");
     }
     previousBeneficiaryModeRef.current = beneficiaryMode;
-  }, [beneficiaryMode, form, session]);
+  }, [beneficiaryMode, form, stableSession]);
 
   function afterMutationSuccess(requisition: RequisicaoDetail) {
     queryClient.setQueryData(requisitionsQueryKeys.detail(requisition.id), requisition);
+    // Editor routes do not keep worklists mounted; inactive refetch avoids overwriting this detail cache.
     void queryClient.invalidateQueries({
       queryKey: requisitionsQueryKeys.all,
       refetchType: "inactive",
@@ -196,6 +231,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   }
 
   function handleMutationError(error: unknown) {
+    setSubmitConfirmationValues(null);
     if (isAuthError(error)) {
       queryClient.removeQueries({ queryKey: authQueryKeys.me });
       void navigate({
@@ -225,6 +261,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   });
   const submitMutation = useMutation({
     mutationFn: async (input: RequisicaoDraftInput) => {
+      // Submit requires the latest draft persisted first; if submit fails, the saved draft remains retryable.
       const draft = initialRequisition
         ? await updateDraftRequisition(initialRequisition.id, input)
         : await createDraftRequisition(input);
@@ -232,6 +269,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     },
     onSuccess: async (requisition) => {
       setFormError(null);
+      setSubmitConfirmationValues(null);
       afterMutationSuccess(requisition);
       await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
     },
@@ -302,15 +340,19 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     saveMutation.mutate(payloadFromValues(valuesToSave));
   }
 
-  function submitDraft(valuesToSubmit: DraftFormValues) {
+  function requestSubmitDraft(valuesToSubmit: DraftFormValues) {
     if (!canSubmitForm) {
       setFormError("Informe beneficiário e ao menos um item com quantidade maior que zero.");
       return;
     }
-    if (!globalThis.confirm("Enviar rascunho para autorização?")) {
+    setSubmitConfirmationValues(valuesToSubmit);
+  }
+
+  function confirmSubmitDraft() {
+    if (!submitConfirmationValues) {
       return;
     }
-    submitMutation.mutate(payloadFromValues(valuesToSubmit));
+    submitMutation.mutate(payloadFromValues(submitConfirmationValues));
   }
 
   return (
@@ -341,7 +383,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
               <input type="radio" value="self" {...form.register("beneficiaryMode")} />
               Para mim
             </label>
-            {canRequestForThirdParty(session) ? (
+            {canRequestForThirdParty(stableSession) ? (
               <label className="draft-choice">
                 <input type="radio" value="third_party" {...form.register("beneficiaryMode")} />
                 Para terceiro
@@ -349,7 +391,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             ) : null}
           </div>
           <p className="selected-summary">Selecionado: {beneficiaryLabelValue}</p>
-          {beneficiaryMode === "third_party" && canRequestForThirdParty(session) ? (
+          {beneficiaryMode === "third_party" && canRequestForThirdParty(stableSession) ? (
             <div className="draft-lookup">
               <label className="preview-label">
                 Buscar beneficiário
@@ -426,7 +468,6 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
                       : formatQuantity(String(material.saldo_disponivel))}{" "}
                     {material.unidade_medida}
                   </span>
-                  <span className="sr-only">Adicionar {material.nome}</span>
                 </button>
               );
             })}
@@ -442,13 +483,13 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
               {fields.map((field, index) => (
                 <article className="draft-item-card" key={field.id}>
                   <div>
-                    <h2>{form.getValues(`itens.${index}.materialLabel`)}</h2>
+                    <h2>{field.materialLabel}</h2>
                     <p>
                       Saldo{" "}
-                      {form.getValues(`itens.${index}.saldoDisponivel`) === null
+                      {field.saldoDisponivel === null
                         ? "não exibido"
-                        : formatQuantity(String(form.getValues(`itens.${index}.saldoDisponivel`)))}{" "}
-                      {form.getValues(`itens.${index}.unidadeMedida`)}
+                        : formatQuantity(String(field.saldoDisponivel))}{" "}
+                      {field.unidadeMedida}
                     </p>
                   </div>
                   <div className="draft-item-fields">
@@ -465,6 +506,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
                       <input className="preview-input" {...form.register(`itens.${index}.observacao`)} />
                     </label>
                     <button
+                      aria-label={`Remover ${field.materialLabel}`}
                       className="action-link compact-action"
                       onClick={() => remove(index)}
                       type="button"
@@ -496,7 +538,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             className="preview-button draft-primary"
             disabled={pending}
             onClick={(event) => {
-              void form.handleSubmit(submitDraft)(event);
+              void form.handleSubmit(requestSubmitDraft)(event);
             }}
             type="button"
           >
@@ -504,6 +546,39 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
           </button>
         </div>
       </form>
+
+      {submitConfirmationValues ? (
+        <div
+          aria-labelledby="draft-submit-confirmation-title"
+          aria-modal="true"
+          className="draft-confirmation-backdrop"
+          role="dialog"
+        >
+          <section className="draft-confirmation-panel">
+            <p className="eyebrow">Confirmação</p>
+            <h2 id="draft-submit-confirmation-title">Enviar rascunho para autorização?</h2>
+            <p>Após o envio, a requisição sai do modo rascunho e segue para avaliação do autorizador.</p>
+            <div className="draft-actions">
+              <button
+                className="action-link compact-action"
+                disabled={pending}
+                onClick={() => setSubmitConfirmationValues(null)}
+                type="button"
+              >
+                Voltar ao rascunho
+              </button>
+              <button
+                className="preview-button draft-primary"
+                disabled={pending}
+                onClick={confirmSubmitDraft}
+                type="button"
+              >
+                Confirmar envio
+              </button>
+            </div>
+          </section>
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -1,0 +1,504 @@
+import { useEffect, useMemo, useState } from "react";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Link, useNavigate } from "@tanstack/react-router";
+
+import { authQueryKeys, isAuthError, type AuthSession } from "../auth/session";
+import {
+  cancelDraftRequisition,
+  createDraftRequisition,
+  discardDraftRequisition,
+  displayRequisitionIdentifier,
+  draftBeneficiariesQueryOptions,
+  draftMaterialsQueryOptions,
+  formatQuantity,
+  queryErrorMessage,
+  requisitionsQueryKeys,
+  statusLabel,
+  submitDraftRequisition,
+  updateDraftRequisition,
+  type BeneficiaryLookupItem,
+  type MaterialListItem,
+  type RequisicaoDetail,
+  type RequisicaoDraftInput,
+} from "./requisitions";
+
+type DraftItemForm = {
+  materialId: string;
+  materialLabel: string;
+  materialCode: string;
+  unidadeMedida: string;
+  saldoDisponivel: number | null;
+  quantidadeSolicitada: string;
+  observacao: string;
+};
+
+type DraftFormValues = {
+  beneficiaryMode: "self" | "third_party";
+  beneficiaryId: string;
+  beneficiaryLabel: string;
+  beneficiarySearch: string;
+  materialSearch: string;
+  observacao: string;
+  itens: DraftItemForm[];
+};
+
+const EMPTY_DRAFT_ITEMS: DraftItemForm[] = [];
+
+type DraftRequisitionEditorProps = {
+  initialRequisition?: RequisicaoDetail;
+  session: AuthSession;
+};
+
+function currentUserBeneficiary(session: AuthSession) {
+  return {
+    id: session.id,
+    nome_completo: session.nome_completo,
+    matricula_funcional: session.matricula_funcional,
+    setor: session.setor,
+  };
+}
+
+function beneficiaryLabel(beneficiary: Pick<BeneficiaryLookupItem, "matricula_funcional" | "nome_completo">) {
+  return `${beneficiary.nome_completo} (${beneficiary.matricula_funcional})`;
+}
+
+function materialLabel(material: MaterialListItem) {
+  return `${material.codigo_completo} - ${material.nome}`;
+}
+
+function formValuesFromRequisition(
+  requisition: RequisicaoDetail | undefined,
+  session: AuthSession,
+): DraftFormValues {
+  const beneficiary = requisition?.beneficiario ?? currentUserBeneficiary(session);
+
+  return {
+    beneficiaryMode: beneficiary.id === session.id ? "self" : "third_party",
+    beneficiaryId: String(beneficiary.id),
+    beneficiaryLabel: beneficiaryLabel(beneficiary),
+    beneficiarySearch: "",
+    materialSearch: "",
+    observacao: requisition?.observacao ?? "",
+    itens:
+      requisition?.itens.map((item) => ({
+        materialId: String(item.material.id),
+        materialLabel: materialLabel({
+          id: item.material.id,
+          codigo_completo: item.material.codigo_completo,
+          nome: item.material.nome,
+          descricao: "",
+          unidade_medida: item.material.unidade_medida,
+          saldo_disponivel: null,
+        }),
+        materialCode: item.material.codigo_completo,
+        unidadeMedida: item.unidade_medida,
+        saldoDisponivel: null,
+        quantidadeSolicitada: item.quantidade_solicitada,
+        observacao: item.observacao,
+      })) ?? [],
+  };
+}
+
+function canRequestForThirdParty(session: AuthSession) {
+  return session.papel !== "solicitante";
+}
+
+function hasPositiveStock(material: MaterialListItem) {
+  return material.saldo_disponivel !== null && material.saldo_disponivel > 0;
+}
+
+function normalizeQuantity(value: string) {
+  return value.trim().replace(",", ".");
+}
+
+function selectedBeneficiary(values: DraftFormValues) {
+  return Number.parseInt(values.beneficiaryId, 10);
+}
+
+function payloadFromValues(values: DraftFormValues): RequisicaoDraftInput {
+  return {
+    beneficiario_id: selectedBeneficiary(values),
+    observacao: values.observacao.trim(),
+    itens: values.itens.map((item) => ({
+      material_id: Number.parseInt(item.materialId, 10),
+      quantidade_solicitada: normalizeQuantity(item.quantidadeSolicitada),
+      observacao: item.observacao.trim(),
+    })),
+  };
+}
+
+function mutationErrorMessage(error: unknown) {
+  return queryErrorMessage(error, "Não foi possível concluir a ação.");
+}
+
+export function DraftRequisitionEditor({ initialRequisition, session }: DraftRequisitionEditorProps) {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+  const [formError, setFormError] = useState<string | null>(null);
+  const form = useForm<DraftFormValues>({
+    defaultValues: formValuesFromRequisition(initialRequisition, session),
+  });
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: "itens",
+  });
+  const beneficiaryMode = useWatch({ control: form.control, name: "beneficiaryMode" }) ?? "self";
+  const beneficiaryLabelValue = useWatch({ control: form.control, name: "beneficiaryLabel" });
+  const beneficiarySearch =
+    useWatch({ control: form.control, name: "beneficiarySearch" })?.trim() ?? "";
+  const materialSearch = useWatch({ control: form.control, name: "materialSearch" })?.trim() ?? "";
+  const selectedItems = useWatch({ control: form.control, name: "itens" }) ?? EMPTY_DRAFT_ITEMS;
+  const isEdit = Boolean(initialRequisition);
+  const title = isEdit ? "Editar rascunho" : "Nova requisição";
+  const identifier = initialRequisition
+    ? (displayRequisitionIdentifier(initialRequisition) ?? statusLabel(initialRequisition.status))
+    : "Novo rascunho";
+  const beneficiaryQuery = useQuery({
+    ...draftBeneficiariesQueryOptions(beneficiarySearch),
+    enabled:
+      beneficiaryMode === "third_party" &&
+      canRequestForThirdParty(session) &&
+      beneficiarySearch.length >= 3,
+  });
+  const materialsQuery = useQuery({
+    ...draftMaterialsQueryOptions(materialSearch),
+    enabled: materialSearch.length >= 2,
+  });
+  const canSubmitForm =
+    selectedBeneficiary(form.getValues()) > 0 &&
+    selectedItems.length > 0 &&
+    selectedItems.every((item) => Number.parseFloat(normalizeQuantity(item.quantidadeSolicitada)) > 0);
+
+  useEffect(() => {
+    form.reset(formValuesFromRequisition(initialRequisition, session));
+  }, [form, initialRequisition, session]);
+
+  useEffect(() => {
+    if (beneficiaryMode === "self") {
+      const self = currentUserBeneficiary(session);
+      form.setValue("beneficiaryId", String(self.id));
+      form.setValue("beneficiaryLabel", beneficiaryLabel(self));
+    }
+  }, [beneficiaryMode, form, session]);
+
+  function afterMutationSuccess(requisition: RequisicaoDetail) {
+    queryClient.setQueryData(requisitionsQueryKeys.detail(requisition.id), requisition);
+    void queryClient.invalidateQueries({
+      queryKey: requisitionsQueryKeys.all,
+      refetchType: "inactive",
+    });
+  }
+
+  function handleMutationError(error: unknown) {
+    if (isAuthError(error)) {
+      queryClient.removeQueries({ queryKey: authQueryKeys.me });
+      void navigate({
+        to: "/login",
+        search: {
+          redirect: isEdit && initialRequisition ? `/requisicoes/${initialRequisition.id}` : "/requisicoes/nova",
+        },
+      });
+      return;
+    }
+    setFormError(mutationErrorMessage(error));
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: async (input: RequisicaoDraftInput) =>
+      initialRequisition
+        ? updateDraftRequisition(initialRequisition.id, input)
+        : createDraftRequisition(input),
+    onSuccess: async (requisition) => {
+      setFormError(null);
+      afterMutationSuccess(requisition);
+      if (!initialRequisition) {
+        await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
+      }
+    },
+    onError: handleMutationError,
+  });
+  const submitMutation = useMutation({
+    mutationFn: async (input: RequisicaoDraftInput) => {
+      const draft = initialRequisition
+        ? await updateDraftRequisition(initialRequisition.id, input)
+        : await createDraftRequisition(input);
+      return submitDraftRequisition(draft.id);
+    },
+    onSuccess: async (requisition) => {
+      setFormError(null);
+      afterMutationSuccess(requisition);
+      await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
+    },
+    onError: handleMutationError,
+  });
+  const discardMutation = useMutation<RequisicaoDetail | undefined, unknown, void>({
+    mutationFn: async () => {
+      if (!initialRequisition) {
+        throw new Error("Rascunho ainda não salvo.");
+      }
+      if (initialRequisition.numero_publico) {
+        return cancelDraftRequisition(initialRequisition.id);
+      }
+      await discardDraftRequisition(initialRequisition.id);
+      return undefined;
+    },
+    onSuccess: async (requisition) => {
+      setFormError(null);
+      if (initialRequisition) {
+        queryClient.removeQueries({
+          queryKey: requisitionsQueryKeys.detail(initialRequisition.id),
+        });
+      }
+      await queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.all });
+      if (requisition) {
+        queryClient.setQueryData(requisitionsQueryKeys.detail(requisition.id), requisition);
+      }
+      await navigate({ to: "/minhas-requisicoes" });
+    },
+    onError: handleMutationError,
+  });
+  const pending = saveMutation.isPending || submitMutation.isPending || discardMutation.isPending;
+  const materials = materialsQuery.data?.results ?? [];
+  const beneficiaries = beneficiaryQuery.data ?? [];
+
+  const selectedMaterialIds = useMemo(
+    () => new Set(selectedItems.map((item) => Number.parseInt(item.materialId, 10))),
+    [selectedItems],
+  );
+
+  function addMaterial(material: MaterialListItem) {
+    if (!hasPositiveStock(material) || selectedMaterialIds.has(material.id)) {
+      return;
+    }
+    append({
+      materialId: String(material.id),
+      materialLabel: materialLabel(material),
+      materialCode: material.codigo_completo,
+      unidadeMedida: material.unidade_medida,
+      saldoDisponivel: material.saldo_disponivel,
+      quantidadeSolicitada: "1",
+      observacao: "",
+    });
+    form.setValue("materialSearch", "");
+  }
+
+  function chooseBeneficiary(beneficiary: BeneficiaryLookupItem) {
+    form.setValue("beneficiaryId", String(beneficiary.id));
+    form.setValue("beneficiaryLabel", beneficiaryLabel(beneficiary));
+    form.setValue("beneficiarySearch", "");
+  }
+
+  function saveDraft(valuesToSave: DraftFormValues) {
+    if (!canSubmitForm) {
+      setFormError("Informe beneficiário e ao menos um item com quantidade maior que zero.");
+      return;
+    }
+    saveMutation.mutate(payloadFromValues(valuesToSave));
+  }
+
+  function submitDraft(valuesToSubmit: DraftFormValues) {
+    if (!canSubmitForm) {
+      setFormError("Informe beneficiário e ao menos um item com quantidade maior que zero.");
+      return;
+    }
+    if (!globalThis.confirm("Enviar rascunho para autorização?")) {
+      return;
+    }
+    submitMutation.mutate(payloadFromValues(valuesToSubmit));
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="worklist-header">
+        <div>
+          <p className="eyebrow">Rascunho operacional</p>
+          <h1>{title}</h1>
+          <p>{identifier}</p>
+        </div>
+        <Link className="action-link compact-action" to="/minhas-requisicoes">
+          Voltar
+        </Link>
+      </div>
+
+      {formError ? <div className="error-panel">{formError}</div> : null}
+
+      <form
+        className="draft-editor"
+        onSubmit={(event) => {
+          void form.handleSubmit(saveDraft)(event);
+        }}
+      >
+        <section className="detail-panel draft-section">
+          <p className="eyebrow">Beneficiário</p>
+          <div className="draft-choice-grid">
+            <label className="draft-choice">
+              <input type="radio" value="self" {...form.register("beneficiaryMode")} />
+              Para mim
+            </label>
+            {canRequestForThirdParty(session) ? (
+              <label className="draft-choice">
+                <input type="radio" value="third_party" {...form.register("beneficiaryMode")} />
+                Para terceiro
+              </label>
+            ) : null}
+          </div>
+          <p className="selected-summary">Selecionado: {beneficiaryLabelValue}</p>
+          {beneficiaryMode === "third_party" && canRequestForThirdParty(session) ? (
+            <div className="draft-lookup">
+              <label className="preview-label">
+                Buscar beneficiário
+                <input
+                  className="preview-input"
+                  placeholder="Nome com ao menos 3 letras"
+                  {...form.register("beneficiarySearch")}
+                />
+              </label>
+              {beneficiarySearch.length > 0 && beneficiarySearch.length < 3 ? (
+                <p className="helper-text">Digite ao menos 3 caracteres.</p>
+              ) : null}
+              <div className="lookup-results">
+                {beneficiaries.map((beneficiary) => (
+                  <button
+                    className="lookup-result"
+                    key={beneficiary.id}
+                    onClick={() => chooseBeneficiary(beneficiary)}
+                    type="button"
+                  >
+                    <strong>{beneficiary.nome_completo}</strong>
+                    <span>
+                      {beneficiary.matricula_funcional} - {beneficiary.setor.nome}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </section>
+
+        <section className="detail-panel draft-section">
+          <p className="eyebrow">Observação</p>
+          <label className="preview-label">
+            Observação geral
+            <textarea
+              className="preview-input draft-textarea"
+              rows={3}
+              {...form.register("observacao")}
+            />
+          </label>
+        </section>
+
+        <section className="detail-panel draft-section">
+          <p className="eyebrow">Materiais</p>
+          <label className="preview-label">
+            Buscar material
+            <input
+              className="preview-input"
+              placeholder="Código, nome ou descrição"
+              {...form.register("materialSearch")}
+            />
+          </label>
+          {materialsQuery.isError ? (
+            <p className="helper-text">{queryErrorMessage(materialsQuery.error, "Erro na busca.")}</p>
+          ) : null}
+          <div className="lookup-results">
+            {materials.map((material) => {
+              const disabled = !hasPositiveStock(material) || selectedMaterialIds.has(material.id);
+              return (
+                <button
+                  aria-label={`Adicionar ${material.nome}`}
+                  className="lookup-result"
+                  disabled={disabled}
+                  key={material.id}
+                  onClick={() => addMaterial(material)}
+                  type="button"
+                >
+                  <strong>{material.nome}</strong>
+                  <span>
+                    {material.codigo_completo} - saldo{" "}
+                    {material.saldo_disponivel === null
+                      ? "indisponível"
+                      : formatQuantity(String(material.saldo_disponivel))}{" "}
+                    {material.unidade_medida}
+                  </span>
+                  <span className="sr-only">Adicionar {material.nome}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="detail-panel draft-section">
+          <p className="eyebrow">Itens solicitados</p>
+          {fields.length === 0 ? (
+            <p className="helper-text">Nenhum material adicionado.</p>
+          ) : (
+            <div className="draft-items">
+              {fields.map((field, index) => (
+                <article className="draft-item-card" key={field.id}>
+                  <div>
+                    <h2>{form.getValues(`itens.${index}.materialLabel`)}</h2>
+                    <p>
+                      Saldo{" "}
+                      {form.getValues(`itens.${index}.saldoDisponivel`) === null
+                        ? "não exibido"
+                        : formatQuantity(String(form.getValues(`itens.${index}.saldoDisponivel`)))}{" "}
+                      {form.getValues(`itens.${index}.unidadeMedida`)}
+                    </p>
+                  </div>
+                  <div className="draft-item-fields">
+                    <label className="preview-label">
+                      Quantidade solicitada
+                      <input
+                        className="preview-input"
+                        inputMode="decimal"
+                        {...form.register(`itens.${index}.quantidadeSolicitada`)}
+                      />
+                    </label>
+                    <label className="preview-label">
+                      Observação do item
+                      <input className="preview-input" {...form.register(`itens.${index}.observacao`)} />
+                    </label>
+                    <button
+                      className="action-link compact-action"
+                      onClick={() => remove(index)}
+                      type="button"
+                    >
+                      Remover
+                    </button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <div className="draft-actions">
+          {initialRequisition ? (
+            <button
+              className="action-link compact-action danger-action"
+              disabled={pending}
+              onClick={() => discardMutation.mutate()}
+              type="button"
+            >
+              {initialRequisition.numero_publico ? "Cancelar requisição" : "Descartar rascunho"}
+            </button>
+          ) : null}
+          <button className="preview-button draft-primary" disabled={pending} type="submit">
+            {saveMutation.isPending ? "Salvando..." : "Salvar rascunho"}
+          </button>
+          <button
+            className="preview-button draft-primary"
+            disabled={pending}
+            onClick={(event) => {
+              void form.handleSubmit(submitDraft)(event);
+            }}
+            type="button"
+          >
+            {submitMutation.isPending ? "Enviando..." : "Enviar para autorização"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
@@ -49,6 +49,15 @@ type DraftRequisitionEditorProps = {
   initialRequisition?: RequisicaoDetail;
   session: AuthSession;
 };
+
+type ConfirmAction =
+  | {
+      type: "submit";
+      values: DraftFormValues;
+    }
+  | {
+      type: "discard" | "cancel";
+    };
 
 function currentUserBeneficiary(session: AuthSession) {
   return {
@@ -141,7 +150,10 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [formError, setFormError] = useState<string | null>(null);
-  const [submitConfirmationValues, setSubmitConfirmationValues] = useState<DraftFormValues | null>(null);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
+  const cancelConfirmationButtonRef = useRef<HTMLButtonElement | null>(null);
+  const pendingRef = useRef(false);
   const sessionSetorId = session.setor?.id ?? null;
   const sessionSetorNome = session.setor?.nome ?? null;
   const stableSession = useMemo(
@@ -178,7 +190,6 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   });
   const beneficiaryMode = useWatch({ control: form.control, name: "beneficiaryMode" }) ?? "self";
   const previousBeneficiaryModeRef = useRef(beneficiaryMode);
-  const beneficiaryIdValue = useWatch({ control: form.control, name: "beneficiaryId" }) ?? "";
   const beneficiaryLabelValue = useWatch({ control: form.control, name: "beneficiaryLabel" });
   const beneficiarySearch =
     useWatch({ control: form.control, name: "beneficiarySearch" })?.trim() ?? "";
@@ -200,14 +211,39 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     ...draftMaterialsQueryOptions(materialSearch),
     enabled: materialSearch.length >= 2,
   });
-  const canSubmitForm =
-    Number.parseInt(beneficiaryIdValue, 10) > 0 &&
-    selectedItems.length > 0 &&
-    selectedItems.every((item) => isPositiveQuantity(item.quantidadeSolicitada));
+  const resetIdentity = `${initialRequisition?.id ?? "new"}:${stableSession.id}`;
+  const resetIdentityRef = useRef(resetIdentity);
 
   useEffect(() => {
+    if (resetIdentityRef.current === resetIdentity) {
+      return;
+    }
+    resetIdentityRef.current = resetIdentity;
     form.reset(formValuesFromRequisition(initialRequisition, stableSession));
-  }, [form, initialRequisition, stableSession]);
+  }, [form, initialRequisition, resetIdentity, stableSession]);
+
+  useEffect(() => {
+    if (!confirmAction) {
+      return;
+    }
+    cancelConfirmationButtonRef.current?.focus();
+  }, [confirmAction]);
+
+  useEffect(() => {
+    if (!confirmAction) {
+      return undefined;
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape" && !pendingRef.current) {
+        event.preventDefault();
+        setConfirmAction(null);
+      }
+    }
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [confirmAction]);
 
   useEffect(() => {
     if (beneficiaryMode === "self") {
@@ -231,7 +267,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   }
 
   function handleMutationError(error: unknown) {
-    setSubmitConfirmationValues(null);
+    setConfirmAction(null);
     if (isAuthError(error)) {
       queryClient.removeQueries({ queryKey: authQueryKeys.me });
       void navigate({
@@ -269,7 +305,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     },
     onSuccess: async (requisition) => {
       setFormError(null);
-      setSubmitConfirmationValues(null);
+      setConfirmAction(null);
       afterMutationSuccess(requisition);
       await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
     },
@@ -305,6 +341,10 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   const materials = materialsQuery.data?.results ?? [];
   const beneficiaries = beneficiaryQuery.data ?? [];
 
+  useEffect(() => {
+    pendingRef.current = pending;
+  }, [pending]);
+
   const selectedMaterialIds = useMemo(
     () => new Set(selectedItems.map((item) => Number.parseInt(item.materialId, 10))),
     [selectedItems],
@@ -332,28 +372,131 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     form.setValue("beneficiarySearch", "");
   }
 
+  function chooseBeneficiaryMode(mode: DraftFormValues["beneficiaryMode"]) {
+    form.setValue("beneficiaryMode", mode, { shouldDirty: true });
+    if (mode === "self") {
+      const self = currentUserBeneficiary(stableSession);
+      form.setValue("beneficiaryId", String(self.id), { shouldDirty: true });
+      form.setValue("beneficiaryLabel", beneficiaryLabel(self), { shouldDirty: true });
+      form.setValue("beneficiarySearch", "");
+      return;
+    }
+    form.setValue("beneficiaryId", "", { shouldDirty: true });
+    form.setValue("beneficiaryLabel", "", { shouldDirty: true });
+  }
+
+  function closeConfirmation() {
+    if (!pending) {
+      setConfirmAction(null);
+    }
+  }
+
+  function validationErrorMessage(values: DraftFormValues) {
+    const selectedBeneficiaryId = Number.parseInt(values.beneficiaryId, 10);
+    if (
+      !values.beneficiaryId ||
+      !Number.isFinite(selectedBeneficiaryId) ||
+      selectedBeneficiaryId <= 0 ||
+      (values.beneficiaryMode === "third_party" && selectedBeneficiaryId === stableSession.id)
+    ) {
+      return "Informe beneficiário.";
+    }
+    if (values.itens.length === 0) {
+      return "Adicione ao menos um item.";
+    }
+    const invalidItemIndex = values.itens.findIndex(
+      (item) => !isPositiveQuantity(item.quantidadeSolicitada),
+    );
+    if (invalidItemIndex >= 0) {
+      const item = values.itens[invalidItemIndex];
+      return `Quantidade inválida no item ${item.materialLabel || invalidItemIndex + 1}: use um número válido maior que zero.`;
+    }
+    return null;
+  }
+
   function saveDraft(valuesToSave: DraftFormValues) {
-    if (!canSubmitForm) {
-      setFormError("Informe beneficiário e ao menos um item com quantidade maior que zero.");
+    const validationError = validationErrorMessage(valuesToSave);
+    if (validationError) {
+      setFormError(validationError);
       return;
     }
     saveMutation.mutate(payloadFromValues(valuesToSave));
   }
 
   function requestSubmitDraft(valuesToSubmit: DraftFormValues) {
-    if (!canSubmitForm) {
-      setFormError("Informe beneficiário e ao menos um item com quantidade maior que zero.");
+    const validationError = validationErrorMessage(valuesToSubmit);
+    if (validationError) {
+      setFormError(validationError);
       return;
     }
-    setSubmitConfirmationValues(valuesToSubmit);
+    setConfirmAction({ type: "submit", values: valuesToSubmit });
   }
 
-  function confirmSubmitDraft() {
-    if (!submitConfirmationValues) {
+  function requestDiscardOrCancel() {
+    setConfirmAction({ type: initialRequisition?.numero_publico ? "cancel" : "discard" });
+  }
+
+  function confirmSelectedAction() {
+    if (!confirmAction) {
       return;
     }
-    submitMutation.mutate(payloadFromValues(submitConfirmationValues));
+    if (confirmAction.type === "submit") {
+      submitMutation.mutate(payloadFromValues(confirmAction.values));
+      return;
+    }
+    discardMutation.mutate();
   }
+
+  function confirmationContent() {
+    switch (confirmAction?.type) {
+      case "submit":
+        return {
+          title: "Enviar rascunho para autorização?",
+          message: "Após o envio, a requisição sai do modo rascunho e segue para avaliação do autorizador.",
+          confirmLabel: "Confirmar envio",
+        };
+      case "cancel":
+        return {
+          title: "Cancelar requisição?",
+          message: "A requisição numerada será encerrada e não poderá voltar ao modo rascunho.",
+          confirmLabel: "Confirmar cancelamento",
+        };
+      case "discard":
+        return {
+          title: "Descartar rascunho?",
+          message: "O rascunho ainda sem número será removido e os dados não salvos serão perdidos.",
+          confirmLabel: "Confirmar descarte",
+        };
+      default:
+        return null;
+    }
+  }
+
+  function trapDialogFocus(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab" || !dialogRef.current) {
+      return;
+    }
+    const focusableElements = dialogRef.current.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [href], input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    );
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (!firstElement || !lastElement) {
+      return;
+    }
+    if (event.shiftKey && document.activeElement === firstElement) {
+      event.preventDefault();
+      lastElement.focus();
+      return;
+    }
+    if (!event.shiftKey && document.activeElement === lastElement) {
+      event.preventDefault();
+      firstElement.focus();
+    }
+  }
+
+  const confirmation = confirmationContent();
 
   return (
     <section className="space-y-6">
@@ -378,14 +521,29 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       >
         <section className="detail-panel draft-section">
           <p className="eyebrow">Beneficiário</p>
+          <input type="hidden" {...form.register("beneficiaryMode")} />
+          <input type="hidden" {...form.register("beneficiaryId")} />
+          <input type="hidden" {...form.register("beneficiaryLabel")} />
           <div className="draft-choice-grid">
             <label className="draft-choice">
-              <input type="radio" value="self" {...form.register("beneficiaryMode")} />
+              <input
+                checked={beneficiaryMode === "self"}
+                name="beneficiaryModeChoice"
+                onChange={() => chooseBeneficiaryMode("self")}
+                type="radio"
+                value="self"
+              />
               Para mim
             </label>
             {canRequestForThirdParty(stableSession) ? (
               <label className="draft-choice">
-                <input type="radio" value="third_party" {...form.register("beneficiaryMode")} />
+                <input
+                  checked={beneficiaryMode === "third_party"}
+                  name="beneficiaryModeChoice"
+                  onChange={() => chooseBeneficiaryMode("third_party")}
+                  type="radio"
+                  value="third_party"
+                />
                 Para terceiro
               </label>
             ) : null}
@@ -525,7 +683,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             <button
               className="action-link compact-action danger-action"
               disabled={pending}
-              onClick={() => discardMutation.mutate()}
+              onClick={requestDiscardOrCancel}
               type="button"
             >
               {initialRequisition.numero_publico ? "Cancelar requisição" : "Descartar rascunho"}
@@ -547,22 +705,26 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
         </div>
       </form>
 
-      {submitConfirmationValues ? (
+      {confirmation ? (
         <div
           aria-labelledby="draft-submit-confirmation-title"
           aria-modal="true"
           className="draft-confirmation-backdrop"
+          onClick={closeConfirmation}
+          onKeyDown={trapDialogFocus}
+          ref={dialogRef}
           role="dialog"
         >
-          <section className="draft-confirmation-panel">
+          <section className="draft-confirmation-panel" onClick={(event) => event.stopPropagation()}>
             <p className="eyebrow">Confirmação</p>
-            <h2 id="draft-submit-confirmation-title">Enviar rascunho para autorização?</h2>
-            <p>Após o envio, a requisição sai do modo rascunho e segue para avaliação do autorizador.</p>
+            <h2 id="draft-submit-confirmation-title">{confirmation.title}</h2>
+            <p>{confirmation.message}</p>
             <div className="draft-actions">
               <button
                 className="action-link compact-action"
                 disabled={pending}
-                onClick={() => setSubmitConfirmationValues(null)}
+                onClick={closeConfirmation}
+                ref={cancelConfirmationButtonRef}
                 type="button"
               >
                 Voltar ao rascunho
@@ -570,10 +732,10 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
               <button
                 className="preview-button draft-primary"
                 disabled={pending}
-                onClick={confirmSubmitDraft}
+                onClick={confirmSelectedAction}
                 type="button"
               >
-                Confirmar envio
+                {confirmation.confirmLabel}
               </button>
             </div>
           </section>

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -11,6 +11,7 @@ import {
   displayRequisitionIdentifier,
   draftBeneficiariesQueryOptions,
   draftMaterialsQueryOptions,
+  fetchMaterialsForDraft,
   formatQuantity,
   queryErrorMessage,
   requisitionsQueryKeys,
@@ -103,7 +104,7 @@ function formValuesFromRequisition(
         materialCode: item.material.codigo_completo,
         unidadeMedida: item.unidade_medida,
         saldoDisponivel: null,
-        quantidadeSolicitada: item.quantidade_solicitada,
+        quantidadeSolicitada: quantityInputValue(item.quantidade_solicitada),
         observacao: item.observacao,
       })) ?? [],
   };
@@ -121,7 +122,18 @@ function normalizeQuantity(value: string) {
   return value.trim().replace(/,/g, ".");
 }
 
+function quantityInputValue(value: string) {
+  const trimmedValue = value.trim();
+  if (!trimmedValue.includes(".")) {
+    return trimmedValue;
+  }
+  return trimmedValue.replace(/0+$/, "").replace(/\.$/, "").replace(".", ",");
+}
+
 function isPositiveQuantity(value: string) {
+  if (!/^\d+(,\d+)?$/.test(value.trim())) {
+    return false;
+  }
   const quantity = Number(normalizeQuantity(value));
   return Number.isFinite(quantity) && quantity > 0;
 }
@@ -290,7 +302,15 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       setFormError(null);
       afterMutationSuccess(requisition);
       if (initialRequisition) {
-        form.reset(formValuesFromRequisition(requisition, stableSession));
+        const currentItems = form.getValues("itens");
+        const nextValues = formValuesFromRequisition(requisition, stableSession);
+        nextValues.itens = nextValues.itens.map((item) => ({
+          ...item,
+          saldoDisponivel:
+            currentItems.find((currentItem) => currentItem.materialId === item.materialId)?.saldoDisponivel ??
+            item.saldoDisponivel,
+        }));
+        form.reset(nextValues);
       }
       if (!initialRequisition) {
         await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
@@ -343,10 +363,52 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   const pending = saveMutation.isPending || submitMutation.isPending || discardMutation.isPending;
   const materials = materialsQuery.data?.results ?? [];
   const beneficiaries = beneficiaryQuery.data ?? [];
+  const missingStockSignature = selectedItems
+    .filter((item) => item.saldoDisponivel === null)
+    .map((item) => `${item.materialId}:${item.materialCode}`)
+    .join("|");
 
   useEffect(() => {
     pendingRef.current = pending;
   }, [pending]);
+
+  useEffect(() => {
+    if (!initialRequisition || !missingStockSignature) {
+      return;
+    }
+    const itemsToHydrate = form
+      .getValues("itens")
+      .map((item, index) => ({ item, index }))
+      .filter(({ item }) => item.saldoDisponivel === null);
+
+    if (itemsToHydrate.length === 0) {
+      return;
+    }
+
+    let ignore = false;
+
+    void Promise.all(
+      itemsToHydrate.map(async ({ item, index }) => {
+        try {
+          const materialPage = await fetchMaterialsForDraft(item.materialCode);
+          const material = materialPage.results.find(
+            (candidate) => candidate.id === Number.parseInt(item.materialId, 10),
+          );
+          if (!ignore && material) {
+            form.setValue(`itens.${index}.saldoDisponivel`, material.saldo_disponivel, {
+              shouldDirty: false,
+            });
+          }
+        } catch {
+          // Best effort: saved drafts still work if stock lookup is temporarily unavailable.
+        }
+      }),
+    );
+
+    return () => {
+      ignore = true;
+    };
+  }, [form, initialRequisition, missingStockSignature]);
 
   const selectedMaterialIds = useMemo(
     () => new Set(selectedItems.map((item) => Number.parseInt(item.materialId, 10))),
@@ -660,48 +722,49 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             <p className="helper-text">Nenhum material adicionado.</p>
           ) : (
             <div className="draft-items">
-              {fields.map((field, index) => (
-                <article className="draft-item-card" key={field.id}>
-                  <div>
-                    <h2>{field.materialLabel}</h2>
-                    <p>
-                      Saldo{" "}
-                      {field.saldoDisponivel === null
-                        ? "não exibido"
-                        : formatQuantity(String(field.saldoDisponivel))}{" "}
-                      {field.unidadeMedida}
-                    </p>
-                  </div>
-                  <div className="draft-item-fields">
-                    <label className="preview-label">
-                      Quantidade solicitada
-                      <input
-                        className="preview-input"
+              {fields.map((field, index) => {
+                const item = selectedItems[index] ?? field;
+                return (
+                  <article className="draft-item-card" key={field.id}>
+                    <div>
+                      <h2>{field.materialLabel}</h2>
+                      <p>
+                        {item.saldoDisponivel === null
+                          ? "Saldo carregando..."
+                          : `Saldo ${formatQuantity(String(item.saldoDisponivel))} ${field.unidadeMedida}`}
+                      </p>
+                    </div>
+                    <div className="draft-item-fields">
+                      <label className="preview-label">
+                        Quantidade solicitada
+                        <input
+                          className="preview-input"
+                          disabled={pending}
+                          inputMode="decimal"
+                          {...form.register(`itens.${index}.quantidadeSolicitada`)}
+                        />
+                      </label>
+                      <label className="preview-label">
+                        Observação do item
+                        <input
+                          className="preview-input"
+                          disabled={pending}
+                          {...form.register(`itens.${index}.observacao`)}
+                        />
+                      </label>
+                      <button
+                        aria-label={`Remover ${field.materialLabel}`}
+                        className="action-link compact-action"
                         disabled={pending}
-                        inputMode="decimal"
-                        {...form.register(`itens.${index}.quantidadeSolicitada`)}
-                      />
-                    </label>
-                    <label className="preview-label">
-                      Observação do item
-                      <input
-                        className="preview-input"
-                        disabled={pending}
-                        {...form.register(`itens.${index}.observacao`)}
-                      />
-                    </label>
-                    <button
-                      aria-label={`Remover ${field.materialLabel}`}
-                      className="action-link compact-action"
-                      disabled={pending}
-                      onClick={() => removeMaterial(index)}
-                      type="button"
-                    >
-                      Remover
-                    </button>
-                  </div>
-                </article>
-              ))}
+                        onClick={() => removeMaterial(index)}
+                        type="button"
+                      >
+                        Remover
+                      </button>
+                    </div>
+                  </article>
+                );
+              })}
             </div>
           )}
         </section>

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -289,6 +289,9 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     onSuccess: async (requisition) => {
       setFormError(null);
       afterMutationSuccess(requisition);
+      if (initialRequisition) {
+        form.reset(formValuesFromRequisition(requisition, stableSession));
+      }
       if (!initialRequisition) {
         await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
       }
@@ -351,7 +354,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   );
 
   function addMaterial(material: MaterialListItem) {
-    if (!hasPositiveStock(material) || selectedMaterialIds.has(material.id)) {
+    if (pending || !hasPositiveStock(material) || selectedMaterialIds.has(material.id)) {
       return;
     }
     append({
@@ -367,12 +370,18 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   }
 
   function chooseBeneficiary(beneficiary: BeneficiaryLookupItem) {
+    if (pending) {
+      return;
+    }
     form.setValue("beneficiaryId", String(beneficiary.id));
     form.setValue("beneficiaryLabel", beneficiaryLabel(beneficiary));
     form.setValue("beneficiarySearch", "");
   }
 
   function chooseBeneficiaryMode(mode: DraftFormValues["beneficiaryMode"]) {
+    if (pending) {
+      return;
+    }
     form.setValue("beneficiaryMode", mode, { shouldDirty: true });
     if (mode === "self") {
       const self = currentUserBeneficiary(stableSession);
@@ -383,6 +392,13 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     }
     form.setValue("beneficiaryId", "", { shouldDirty: true });
     form.setValue("beneficiaryLabel", "", { shouldDirty: true });
+  }
+
+  function removeMaterial(index: number) {
+    if (pending) {
+      return;
+    }
+    remove(index);
   }
 
   function closeConfirmation() {
@@ -528,6 +544,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             <label className="draft-choice">
               <input
                 checked={beneficiaryMode === "self"}
+                disabled={pending}
                 name="beneficiaryModeChoice"
                 onChange={() => chooseBeneficiaryMode("self")}
                 type="radio"
@@ -539,6 +556,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
               <label className="draft-choice">
                 <input
                   checked={beneficiaryMode === "third_party"}
+                  disabled={pending}
                   name="beneficiaryModeChoice"
                   onChange={() => chooseBeneficiaryMode("third_party")}
                   type="radio"
@@ -555,6 +573,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
                 Buscar beneficiário
                 <input
                   className="preview-input"
+                  disabled={pending}
                   placeholder="Nome com ao menos 3 letras"
                   {...form.register("beneficiarySearch")}
                 />
@@ -566,6 +585,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
                 {beneficiaries.map((beneficiary) => (
                   <button
                     className="lookup-result"
+                    disabled={pending}
                     key={beneficiary.id}
                     onClick={() => chooseBeneficiary(beneficiary)}
                     type="button"
@@ -587,6 +607,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             Observação geral
             <textarea
               className="preview-input draft-textarea"
+              disabled={pending}
               rows={3}
               {...form.register("observacao")}
             />
@@ -599,6 +620,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
             Buscar material
             <input
               className="preview-input"
+              disabled={pending}
               placeholder="Código, nome ou descrição"
               {...form.register("materialSearch")}
             />
@@ -608,7 +630,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
           ) : null}
           <div className="lookup-results">
             {materials.map((material) => {
-              const disabled = !hasPositiveStock(material) || selectedMaterialIds.has(material.id);
+              const disabled = pending || !hasPositiveStock(material) || selectedMaterialIds.has(material.id);
               return (
                 <button
                   aria-label={`Adicionar ${material.nome}`}
@@ -655,18 +677,24 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
                       Quantidade solicitada
                       <input
                         className="preview-input"
+                        disabled={pending}
                         inputMode="decimal"
                         {...form.register(`itens.${index}.quantidadeSolicitada`)}
                       />
                     </label>
                     <label className="preview-label">
                       Observação do item
-                      <input className="preview-input" {...form.register(`itens.${index}.observacao`)} />
+                      <input
+                        className="preview-input"
+                        disabled={pending}
+                        {...form.register(`itens.${index}.observacao`)}
+                      />
                     </label>
                     <button
                       aria-label={`Remover ${field.materialLabel}`}
                       className="action-link compact-action"
-                      onClick={() => remove(index)}
+                      disabled={pending}
+                      onClick={() => removeMaterial(index)}
                       type="button"
                     >
                       Remover

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -11,6 +11,10 @@ export type RequisicaoStatus = components["schemas"]["StatusEnum"];
 export type RequisicaoTimelineEvent = components["schemas"]["RequisicaoTimelineEventOutput"];
 export type RequisicaoActionItem = components["schemas"]["RequisicaoActionOutput"];
 export type RequisicaoTimelineEventType = components["schemas"]["TipoEventoEnum"];
+export type RequisicaoDraftInput = components["schemas"]["RequisicaoCreateInput"];
+export type MaterialListItem = components["schemas"]["MaterialListOutput"];
+export type MaterialListResponse = components["schemas"]["MaterialListPaginated"];
+export type BeneficiaryLookupItem = components["schemas"]["BeneficiaryLookupOutput"];
 
 export const STATUS_OPTIONS: Array<{ value: RequisicaoStatus; label: string }> = [
   { value: "rascunho", label: "Rascunho" },
@@ -58,6 +62,9 @@ export const requisitionsQueryKeys = {
       },
     ] as const,
   detail: (id: number) => [...requisitionsQueryKeys.all, "detail", id] as const,
+  materials: (search: string) => [...requisitionsQueryKeys.all, "materials", search] as const,
+  beneficiaries: (search: string) =>
+    [...requisitionsQueryKeys.all, "beneficiaries", search] as const,
 };
 
 function messageFromError(error: ErrorResponse | undefined, fallback: string) {
@@ -107,6 +114,145 @@ export async function fetchRequisitionDetail(id: number) {
   return data;
 }
 
+export async function fetchMaterialsForDraft(search: string) {
+  const { data, error, response } = await apiClient.GET("/api/v1/materials/", {
+    params: {
+      query: {
+        search,
+        page_size: 10,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível buscar materiais."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function fetchBeneficiariesForDraft(search: string) {
+  const { data, error, response } = await apiClient.GET("/api/v1/users/beneficiary-lookup/", {
+    params: {
+      query: {
+        q: search,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível buscar beneficiários."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function createDraftRequisition(input: RequisicaoDraftInput) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/", {
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível salvar o rascunho."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function updateDraftRequisition(id: number, input: RequisicaoDraftInput) {
+  const { data, error, response } = await apiClient.PUT("/api/v1/requisitions/{id}/draft/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível atualizar o rascunho."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function submitDraftRequisition(id: number) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/submit/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível enviar para autorização."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function discardDraftRequisition(id: number) {
+  const { error, response } = await apiClient.DELETE("/api/v1/requisitions/{id}/discard/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+  });
+
+  if (error) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível descartar o rascunho."),
+      response.status,
+      error,
+    );
+  }
+}
+
+export async function cancelDraftRequisition(id: number) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/cancel/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: {
+      motivo_cancelamento: "",
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível cancelar a requisição."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
 export function myRequisitionsQueryOptions(params: RequisicoesListParams) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.mine(params),
@@ -120,6 +266,22 @@ export function requisitionDetailQueryOptions(id: number) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.detail(id),
     queryFn: () => fetchRequisitionDetail(id),
+    retry: retryUnlessClientOrAuthError,
+  });
+}
+
+export function draftMaterialsQueryOptions(search: string) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.materials(search),
+    queryFn: () => fetchMaterialsForDraft(search),
+    retry: retryUnlessClientOrAuthError,
+  });
+}
+
+export function draftBeneficiariesQueryOptions(search: string) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.beneficiaries(search),
+    queryFn: () => fetchBeneficiariesForDraft(search),
     retry: retryUnlessClientOrAuthError,
   });
 }

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -4,7 +4,8 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { requireSession } from "../../features/auth/guards";
-import { authQueryKeys, isAuthError } from "../../features/auth/session";
+import { authQueryKeys, isAuthError, meQueryOptions } from "../../features/auth/session";
+import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 import {
     displayRequisitionIdentifier,
     formatDateTime,
@@ -88,6 +89,7 @@ function DetalheRequisicaoPage() {
     ...requisitionDetailQueryOptions(requisicaoId),
     enabled: Number.isInteger(requisicaoId) && requisicaoId > 0,
   });
+  const sessionQuery = useQuery(meQueryOptions);
   const authError = detailQuery.isError && isAuthError(detailQuery.error);
 
   useEffect(() => {
@@ -124,6 +126,13 @@ function DetalheRequisicaoPage() {
   }
 
   const requisicao = detailQuery.data;
+  if (requisicao.status === "rascunho") {
+    if (!sessionQuery.data) {
+      return <div className="loading-state">Carregando sessão...</div>;
+    }
+    return <DraftRequisitionEditor initialRequisition={requisicao} session={sessionQuery.data} />;
+  }
+
   const thirdParty = isThirdPartyBeneficiary(requisicao);
 
   return (

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -127,8 +127,18 @@ function DetalheRequisicaoPage() {
 
   const requisicao = detailQuery.data;
   if (requisicao.status === "rascunho") {
-    if (!sessionQuery.data) {
+    if (sessionQuery.isLoading) {
       return <div className="loading-state">Carregando sessão...</div>;
+    }
+    if (sessionQuery.isError) {
+      return (
+        <div className="error-panel">
+          {queryErrorMessage(sessionQuery.error, "Não foi possível carregar a sessão.")}
+        </div>
+      );
+    }
+    if (!sessionQuery.data) {
+      return <div className="error-panel">Sessão indisponível.</div>;
     }
     return <DraftRequisitionEditor initialRequisition={requisicao} session={sessionQuery.data} />;
   }

--- a/frontend/src/routes/requisicoes/nova.tsx
+++ b/frontend/src/routes/requisicoes/nova.tsx
@@ -1,45 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 
 import { requireSession } from "../../features/auth/guards";
-import { FeaturePlaceholder } from "../../shared/ui/feature-placeholder";
+import { meQueryOptions } from "../../features/auth/session";
+import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 
 export const Route = createFileRoute("/requisicoes/nova")({
   beforeLoad: ({ context, location }) =>
     requireSession({ queryClient: context.queryClient, locationHref: location.href }),
-  component: NovaRequisicaoPlaceholderPage,
+  component: NovaRequisicaoPage,
 });
 
-function NovaRequisicaoPlaceholderPage() {
-  return (
-    <FeaturePlaceholder
-      kicker="Draft editor"
-      title="Nova requisição"
-      summary="Tela-base reservada para criação e edição do mesmo rascunho. O scaffold não envia nada ainda, mas fixa o espaço para fluxo único de draft."
-      nextSlice="#39 — criação, edição e envio de rascunho"
-      contracts={[
-        "GET /api/v1/users/beneficiary-lookup/?q=...",
-        "PUT /api/v1/requisitions/{id}/draft/",
-      ]}
-      bullets={[
-        "Beneficiário por busca curta, nunca diretório infinito.",
-        "Mesma tela para criar, salvar e editar rascunho.",
-        "Substituição completa de itens no update explícito.",
-      ]}
-      preview={
-        <div className="preview-panel space-y-3">
-          <div className="preview-row">
-            <span>Beneficiário</span>
-            <span className="preview-meta">lookup por nome</span>
-          </div>
-          <div className="preview-row">
-            <span>Itens</span>
-            <span className="preview-meta">replace total no draft</span>
-          </div>
-          <button className="preview-button" disabled type="button">
-            Salvar rascunho chega em #39
-          </button>
-        </div>
-      }
-    />
-  );
+function NovaRequisicaoPage() {
+  const sessionQuery = useQuery(meQueryOptions);
+
+  if (!sessionQuery.data) {
+    return <div className="loading-state">Carregando sessão...</div>;
+  }
+
+  return <DraftRequisitionEditor session={sessionQuery.data} />;
 }

--- a/frontend/src/routes/requisicoes/nova.tsx
+++ b/frontend/src/routes/requisicoes/nova.tsx
@@ -14,8 +14,23 @@ export const Route = createFileRoute("/requisicoes/nova")({
 function NovaRequisicaoPage() {
   const sessionQuery = useQuery(meQueryOptions);
 
-  if (!sessionQuery.data) {
+  if (sessionQuery.isLoading) {
     return <div className="loading-state">Carregando sessão...</div>;
+  }
+
+  if (sessionQuery.isError) {
+    return (
+      <div className="error-panel">
+        <p>Erro carregando sessão.</p>
+        <button className="compact-action" type="button" onClick={() => void sessionQuery.refetch()}>
+          Tentar novamente
+        </button>
+      </div>
+    );
+  }
+
+  if (!sessionQuery.data) {
+    return <div className="error-panel">Sessão indisponível.</div>;
   }
 
   return <DraftRequisitionEditor session={sessionQuery.data} />;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -505,6 +505,108 @@ a {
   padding: 0.2rem 0 0.2rem 1rem;
 }
 
+.draft-editor,
+.draft-section,
+.draft-lookup,
+.lookup-results,
+.draft-items,
+.draft-item-fields {
+  display: grid;
+  gap: 1rem;
+}
+
+.draft-choice-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.draft-choice {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.84);
+  padding: 0.7rem 0.9rem;
+  color: var(--ink-soft);
+}
+
+.selected-summary,
+.helper-text {
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.draft-textarea {
+  resize: vertical;
+}
+
+.lookup-results {
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+}
+
+.lookup-result {
+  display: grid;
+  gap: 0.35rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: rgba(255, 252, 247, 0.9);
+  padding: 0.9rem 1rem;
+  text-align: left;
+  color: var(--ink-soft);
+}
+
+.lookup-result strong {
+  color: var(--ink-strong);
+}
+
+.lookup-result:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.draft-item-card {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 16px;
+  background: rgba(255, 252, 247, 0.86);
+  padding: 1rem;
+}
+
+.draft-item-card h2 {
+  font-weight: 700;
+  color: var(--ink-strong);
+}
+
+.draft-item-card p {
+  color: var(--ink-soft);
+}
+
+.draft-item-fields {
+  grid-template-columns: minmax(10rem, 14rem) minmax(14rem, 1fr) auto;
+  align-items: end;
+}
+
+.draft-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.draft-primary {
+  width: auto;
+  min-width: 13rem;
+}
+
+.danger-action {
+  border-color: rgba(150, 44, 44, 0.22);
+  color: #8a2727;
+}
+
 @media (max-width: 860px) {
   .worklist-header,
   .detail-hero,
@@ -515,7 +617,8 @@ a {
 
   .filters-bar,
   .detail-grid,
-  .quantity-grid {
+  .quantity-grid,
+  .draft-item-fields {
     grid-template-columns: 1fr;
   }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -12,6 +12,7 @@
   --ink-muted: #73809b;
   --accent: #b9522c;
   --accent-soft: rgba(185, 82, 44, 0.14);
+  --danger: #8a2727;
 
   font-family: "Avenir Next", "Segoe UI", sans-serif;
   line-height: 1.5;
@@ -604,7 +605,36 @@ a {
 
 .danger-action {
   border-color: rgba(150, 44, 44, 0.22);
-  color: #8a2727;
+  color: var(--danger);
+}
+
+.draft-confirmation-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+  background: rgba(22, 35, 61, 0.42);
+}
+
+.draft-confirmation-panel {
+  width: min(100%, 32rem);
+  padding: 1.5rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 1.25rem;
+  background: var(--panel-strong);
+  box-shadow: 0 1.5rem 4rem rgba(22, 35, 61, 0.22);
+}
+
+.draft-confirmation-panel h2 {
+  margin: 0 0 0.5rem;
+  color: var(--ink-strong);
+  font-size: 1.35rem;
+}
+
+.draft-confirmation-panel p {
+  color: var(--ink-soft);
 }
 
 @media (max-width: 860px) {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -176,6 +176,103 @@ function requisitionDetailResponse(itemOverrides = {}) {
   );
 }
 
+function draftRequisitionDetailResponse(overrides = {}) {
+  return new Response(
+    JSON.stringify({
+      id: 101,
+      numero_publico: null,
+      status: "rascunho",
+      criador: {
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+      },
+      beneficiario: {
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+      },
+      setor_beneficiario: {
+        id: 1,
+        nome: "Operacao",
+      },
+      chefe_autorizador: null,
+      responsavel_atendimento: null,
+      data_criacao: "2026-05-01T10:00:00Z",
+      data_envio_autorizacao: null,
+      data_autorizacao_ou_recusa: null,
+      motivo_recusa: "",
+      motivo_cancelamento: "",
+      data_finalizacao: null,
+      retirante_fisico: "",
+      observacao: "Observacao antiga",
+      observacao_atendimento: "",
+      itens: [
+        {
+          id: 501,
+          material: {
+            id: 301,
+            codigo_completo: "010.001.001",
+            nome: "Papel sulfite A4",
+            unidade_medida: "UN",
+          },
+          unidade_medida: "UN",
+          quantidade_solicitada: "2.000",
+          quantidade_autorizada: "0.000",
+          quantidade_entregue: "0.000",
+          justificativa_autorizacao_parcial: "",
+          justificativa_atendimento_parcial: "",
+          observacao: "Item antigo",
+        },
+      ],
+      eventos: [],
+      ...overrides,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function materialListResponse(results = [
+  {
+    id: 301,
+    codigo_completo: "010.001.001",
+    nome: "Papel sulfite A4",
+    descricao: "Pacote com 500 folhas",
+    unidade_medida: "UN",
+    saldo_disponivel: 12,
+  },
+]) {
+  return new Response(
+    JSON.stringify({
+      count: results.length,
+      page: 1,
+      page_size: 10,
+      total_pages: 1,
+      next: null,
+      previous: null,
+      results,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function beneficiaryLookupResponse() {
+  return new Response(
+    JSON.stringify([
+      {
+        id: 11,
+        matricula_funcional: "91004",
+        nome_completo: "Beneficiario Terceiro",
+        setor: {
+          id: 1,
+          nome: "Operacao",
+        },
+      },
+    ]),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
 function csrfResponse() {
   return new Response(JSON.stringify({ csrf_token: "csrf-token" }), {
     status: 200,
@@ -738,6 +835,315 @@ describe("frontend scaffold router", () => {
     expect(screen.getByText("2,5 UN")).toBeInTheDocument();
     expect(screen.getByText("1,25 UN")).toBeInTheDocument();
     expect(screen.getByText("0,125 UN")).toBeInTheDocument();
+  });
+
+  it("creates draft requisition for the current user", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (requestUrl(request).includes("/api/v1/materials/")) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return requisitionDetailResponse({
+          quantidade_solicitada: "3.000",
+        });
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
+      target: { value: "3" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+    });
+    expect(createdPayload).toEqual({
+      beneficiario_id: 10,
+      observacao: "",
+      itens: [
+        {
+          material_id: 301,
+          quantidade_solicitada: "3",
+          observacao: "",
+        },
+      ],
+    });
+  });
+
+  it("creates draft requisition for a third-party beneficiary when allowed", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("auxiliar_setor"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/users/beneficiary-lookup/")) {
+        return beneficiaryLookupResponse();
+      }
+
+      if (requestUrl(request).includes("/api/v1/materials/")) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return requisitionDetailResponse();
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Para terceiro"));
+    fireEvent.change(screen.getByLabelText("Buscar beneficiário"), {
+      target: { value: "Beneficiario" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /Beneficiario Terceiro/ }));
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    await waitFor(() => {
+      expect(createdPayload).toEqual({
+        beneficiario_id: 11,
+        observacao: "",
+        itens: [
+          {
+            material_id: 301,
+            quantidade_solicitada: "1",
+            observacao: "",
+          },
+        ],
+      });
+    });
+  });
+
+  it("updates an existing draft with full replacement payload", async () => {
+    let updatedPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return draftRequisitionDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/draft/")) {
+        updatedPayload = await request.json();
+        return draftRequisitionDetailResponse({ observacao: "Observacao nova" });
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101");
+
+    expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Observação geral"), {
+      target: { value: "Observacao nova" },
+    });
+    fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
+      target: { value: "4" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    await waitFor(() => {
+      expect(updatedPayload).toEqual({
+        beneficiario_id: 10,
+        observacao: "Observacao nova",
+        itens: [
+          {
+            material_id: 301,
+            quantidade_solicitada: "4",
+            observacao: "Item antigo",
+          },
+        ],
+      });
+    });
+    expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+  });
+
+  it("confirms and submits a draft to authorization", async () => {
+    let updatedPayload: unknown;
+    let submitCalled = false;
+    const confirmMock = vi.fn(() => true);
+    vi.stubGlobal("confirm", confirmMock);
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return draftRequisitionDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/draft/")) {
+        updatedPayload = await request.json();
+        return draftRequisitionDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/submit/")) {
+        submitCalled = true;
+        return requisitionDetailResponse();
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/101");
+
+    expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Enviar para autorização" }));
+
+    await waitFor(() => {
+      expect(confirmMock).toHaveBeenCalledWith("Enviar rascunho para autorização?");
+      expect(updatedPayload).toEqual({
+        beneficiario_id: 10,
+        observacao: "Observacao antiga",
+        itens: [
+          {
+            material_id: 301,
+            quantidade_solicitada: "2.000",
+            observacao: "Item antigo",
+          },
+        ],
+      });
+      expect(submitCalled).toBe(true);
+    });
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+  });
+
+  it("discards an unnumbered draft", async () => {
+    let discardCalled = false;
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return draftRequisitionDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/discard/")) {
+        discardCalled = true;
+        return new Response(null, { status: 204 });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+        return requisitionListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101");
+
+    expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Descartar rascunho" }));
+
+    await waitFor(() => {
+      expect(discardCalled).toBe(true);
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+  });
+
+  it("cancels a numbered draft instead of discarding it", async () => {
+    let cancelPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return draftRequisitionDetailResponse({ numero_publico: "REQ-2026-000050" });
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/cancel/")) {
+        cancelPayload = await request.json();
+        return requisitionDetailResponse({ status: "cancelada" });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+        return requisitionListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101");
+
+    expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição" }));
+
+    await waitFor(() => {
+      expect(cancelPayload).toEqual({ motivo_cancelamento: "" });
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+  });
+
+  it("shows material stock and blocks adding material without positive stock", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/materials/")) {
+          return materialListResponse([
+            {
+              id: 302,
+              codigo_completo: "010.001.002",
+              nome: "Caneta sem estoque",
+              descricao: "Caneta azul",
+              unidade_medida: "UN",
+              saldo_disponivel: 0,
+            },
+          ]);
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "caneta" },
+    });
+
+    const addButton = await screen.findByRole("button", { name: "Adicionar Caneta sem estoque" });
+    expect(addButton).toBeDisabled();
+    expect(screen.getByText(/saldo 0 UN/i)).toBeInTheDocument();
+    expect(screen.getByText("Nenhum material adicionado.")).toBeInTheDocument();
   });
 
   it("logs out from authenticated shell and returns to login", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -930,7 +930,9 @@ describe("frontend scaffold router", () => {
     fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
 
     expect(
-      await screen.findByText("Informe beneficiário e ao menos um item com quantidade maior que zero."),
+      await screen.findByText(
+        "Quantidade inválida no item 010.001.001 - Papel sulfite A4: use um número válido maior que zero.",
+      ),
     ).toBeInTheDocument();
     expect(createdPayload).toBeUndefined();
   });
@@ -1024,9 +1026,7 @@ describe("frontend scaffold router", () => {
     fireEvent.click(screen.getByLabelText("Para terceiro"));
     fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
 
-    expect(
-      await screen.findByText("Informe beneficiário e ao menos um item com quantidade maior que zero."),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Informe beneficiário.")).toBeInTheDocument();
     expect(createdPayload).toBeUndefined();
   });
 
@@ -1107,7 +1107,9 @@ describe("frontend scaffold router", () => {
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Enviar para autorização" }));
-    expect(await screen.findByRole("dialog")).toHaveTextContent("Enviar rascunho para autorização?");
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Enviar rascunho para autorização?");
+    expect(screen.getByRole("button", { name: "Voltar ao rascunho" })).toHaveFocus();
     fireEvent.click(screen.getByRole("button", { name: "Confirmar envio" }));
 
     await waitFor(() => {
@@ -1155,6 +1157,8 @@ describe("frontend scaffold router", () => {
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Descartar rascunho" }));
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Descartar rascunho?");
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar descarte" }));
 
     await waitFor(() => {
       expect(discardCalled).toBe(true);
@@ -1190,6 +1194,8 @@ describe("frontend scaffold router", () => {
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição" }));
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Cancelar requisição?");
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
 
     await waitFor(() => {
       expect(cancelPayload).toEqual({ motivo_cancelamento: "" });

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -940,6 +940,42 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("requires selecting a beneficiary after switching from self to third-party", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("auxiliar_setor"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/materials/")) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return requisitionDetailResponse();
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.click(screen.getByLabelText("Para terceiro"));
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    expect(
+      await screen.findByText("Informe beneficiário e ao menos um item com quantidade maior que zero."),
+    ).toBeInTheDocument();
+    expect(createdPayload).toBeUndefined();
+  });
+
   it("updates an existing draft with full replacement payload", async () => {
     let updatedPayload: unknown;
     const fetchMock = vi.fn(async (request: Request) => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -28,6 +28,10 @@ function requestUrl(request: Request) {
   return request.url;
 }
 
+function requestSearchParam(request: Request, name: string) {
+  return new URL(requestUrl(request)).searchParams.get(name);
+}
+
 function authSession(papel = "solicitante") {
   return {
     id: 10,
@@ -844,7 +848,10 @@ describe("frontend scaffold router", () => {
         return sessionResponse();
       }
 
-      if (requestUrl(request).includes("/api/v1/materials/")) {
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
         return materialListResponse();
       }
 
@@ -887,6 +894,47 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("rejects malformed decimal quantities before saving a draft", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return requisitionDetailResponse();
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
+      target: { value: "1,0,0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    expect(
+      await screen.findByText("Informe beneficiário e ao menos um item com quantidade maior que zero."),
+    ).toBeInTheDocument();
+    expect(createdPayload).toBeUndefined();
+  });
+
   it("creates draft requisition for a third-party beneficiary when allowed", async () => {
     let createdPayload: unknown;
     const fetchMock = vi.fn(async (request: Request) => {
@@ -898,7 +946,10 @@ describe("frontend scaffold router", () => {
         return beneficiaryLookupResponse();
       }
 
-      if (requestUrl(request).includes("/api/v1/materials/")) {
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
         return materialListResponse();
       }
 
@@ -947,7 +998,10 @@ describe("frontend scaffold router", () => {
         return sessionResponse(authSession("auxiliar_setor"));
       }
 
-      if (requestUrl(request).includes("/api/v1/materials/")) {
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
         return materialListResponse();
       }
 
@@ -1026,8 +1080,6 @@ describe("frontend scaffold router", () => {
   it("confirms and submits a draft to authorization", async () => {
     let updatedPayload: unknown;
     let submitCalled = false;
-    const confirmMock = vi.fn(() => true);
-    vi.stubGlobal("confirm", confirmMock);
     const fetchMock = vi.fn(async (request: Request) => {
       if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
         return sessionResponse();
@@ -1055,9 +1107,10 @@ describe("frontend scaffold router", () => {
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Enviar para autorização" }));
+    expect(await screen.findByRole("dialog")).toHaveTextContent("Enviar rascunho para autorização?");
+    fireEvent.click(screen.getByRole("button", { name: "Confirmar envio" }));
 
     await waitFor(() => {
-      expect(confirmMock).toHaveBeenCalledWith("Enviar rascunho para autorização?");
       expect(updatedPayload).toEqual({
         beneficiario_id: 10,
         observacao: "Observacao antiga",
@@ -1152,7 +1205,10 @@ describe("frontend scaffold router", () => {
           return sessionResponse();
         }
 
-        if (requestUrl(request).includes("/api/v1/materials/")) {
+        if (
+          requestUrl(request).includes("/api/v1/materials/") &&
+          requestSearchParam(request, "search") === "caneta"
+        ) {
           return materialListResponse([
             {
               id: 302,

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -911,7 +911,7 @@ describe("frontend scaffold router", () => {
     });
   });
 
-  it("rejects malformed decimal quantities before saving a draft", async () => {
+  it("rejects quantities with dot decimal separator before saving a draft", async () => {
     let createdPayload: unknown;
     const fetchMock = vi.fn(async (request: Request) => {
       if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
@@ -942,7 +942,7 @@ describe("frontend scaffold router", () => {
     });
     fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
     fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
-      target: { value: "1,0,0" },
+      target: { value: "1.5" },
     });
     fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
 
@@ -1058,6 +1058,13 @@ describe("frontend scaffold router", () => {
         return draftRequisitionDetailResponse();
       }
 
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "010.001.001"
+      ) {
+        return materialListResponse();
+      }
+
       if (requestUrl(request).endsWith("/api/v1/requisitions/101/draft/")) {
         updatedPayload = await request.json();
         return draftRequisitionDetailResponse({ observacao: "Observacao nova" });
@@ -1070,6 +1077,9 @@ describe("frontend scaffold router", () => {
     const { container } = renderRoute("/requisicoes/101");
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Quantidade solicitada")).toHaveValue("2");
+    expect(screen.queryByText(/Saldo não exibido/)).not.toBeInTheDocument();
+    expect(await screen.findByText("Saldo 12 UN")).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Observação geral"), {
       target: { value: "Observacao nova" },
     });
@@ -1136,7 +1146,7 @@ describe("frontend scaffold router", () => {
         itens: [
           {
             material_id: 301,
-            quantidade_solicitada: "2.000",
+            quantidade_solicitada: "2",
             observacao: "Item antigo",
           },
         ],

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -857,8 +857,25 @@ describe("frontend scaffold router", () => {
 
       if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
         createdPayload = await request.json();
-        return requisitionDetailResponse({
-          quantidade_solicitada: "3.000",
+        return draftRequisitionDetailResponse({
+          itens: [
+            {
+              id: 501,
+              material: {
+                id: 301,
+                codigo_completo: "010.001.001",
+                nome: "Papel sulfite A4",
+                unidade_medida: "UN",
+              },
+              unidade_medida: "UN",
+              quantidade_solicitada: "3.000",
+              quantidade_autorizada: "0.000",
+              quantidade_entregue: "0.000",
+              justificativa_autorizacao_parcial: "",
+              justificativa_atendimento_parcial: "",
+              observacao: "",
+            },
+          ],
         });
       }
 


### PR DESCRIPTION
# Contexto

## O que este PR faz
- Substitui o placeholder de `/requisicoes/nova` por um editor real de rascunho.
- Reutiliza o mesmo editor em `/requisicoes/:id` quando a requisição carregada está com `status="rascunho"`.
- Consome os endpoints existentes para buscar beneficiários, buscar materiais, criar/atualizar rascunho, enviar, descartar e cancelar.
- Adiciona testes de rota cobrindo criação, edição, envio, descarte/cancelamento e bloqueio local de material sem saldo.

## Por que esta mudança é necessária
Atende a issue #39, habilitando o fluxo operacional mínimo de nova requisição no frontend do piloto: criar rascunho, editar rascunho existente e enviar para autorização. A validação final de domínio, permissão, saldo e transições permanece no backend.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
O principal risco é divergência entre o estado otimista/cacheado do frontend e a resposta real do backend após salvar, enviar, descartar ou cancelar rascunhos. O PR mitiga isso centralizando os helpers de API, invalidando caches de requisições e mantendo o backend como fonte final de permissão e validação.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: o modo "Para terceiro" só aparece para papéis diferentes de `solicitante`; o backend segue validando a permissão real.
- dados / migration / constraints: não se aplica.
- transação / concorrência / idempotência: não se aplica.
- máquina de estados / aprovação / cotas / entregas: o frontend passa a acionar endpoints já existentes de envio/cancelamento, sem alterar regras de transição no backend.
- configuração / CI / dependências: não se aplica.

---

# Testes e validação

## Cenários validados
1. Criar rascunho para o próprio usuário em `/requisicoes/nova`, com payload correto e navegação para `/requisicoes/:id`.
2. Criar rascunho para terceiro em papel permitido, usando lookup de beneficiário.
3. Reabrir rascunho em `/requisicoes/:id`, alterar beneficiário, observação e itens, e salvar via substituição completa.
4. Enviar rascunho para autorização somente após confirmação explícita.
5. Descartar rascunho sem número via `DELETE /discard/` e cancelar rascunho numerado via `POST /cancel/`.
6. Buscar material, exibir saldo disponível e bloquear seleção local de item sem saldo positivo.

## Como validar manualmente
1. Entrar na SPA autenticado e acessar `/requisicoes/nova`.
2. Buscar um material com saldo positivo, informar quantidade maior que zero e salvar rascunho.
3. Confirmar que a tela navega para `/requisicoes/:id` e permite editar o rascunho.
4. Enviar o rascunho para autorização e confirmar que a tela volta para o detalhe canônico.
5. Criar ou abrir outro rascunho e validar as ações de descartar ou cancelar conforme presença de `numero_publico`.

## Payloads / exemplos de uso

```json
{
  "beneficiario": 1,
  "observacao": "Uso no setor operacional",
  "itens": [
    {
      "material": 10,
      "quantidade_solicitada": "2",
      "observacao": ""
    }
  ]
}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR — Editor de Rascunho de Requisições

- Objetivo
  - Implementar editor de rascunho no frontend para /requisicoes/nova e reutilizá‑lo em /requisicoes/:id quando status="rascunho".
  - Consumir endpoints DRF existentes para lookup (materiais, beneficiários), criar/atualizar rascunho, enviar para autorização, descartar e cancelar.
  - Validar saldo localmente, exibir saldo_disponivel e bloquear seleção de material sem saldo positivo; fornecer confirmações para ações destrutivas/enviar.

- Apps Django impactados
  - Nenhum diretamente — mudanças são frontend-only e consomem endpoints existentes (requisitions, materials, beneficiaries).

- Risco funcional
  - Baixo–moderado (frontend): não altera regras de negócio no backend, mas aumenta superfície de UX (estado otimista, confirmações, cache invalidation) e depende da consistência entre listagem de saldo e validação backend.
  - Testes adicionados cobrem criação, edição, envio, descarte/cancelamento e bloqueio por saldo.

- Impacto em regras de negócio
  - Não altera transições de estado, migrações ou modelos backend; usa os fluxos já existentes (draft → submit → autorização/cancelamento).
  - Risco operacional se o frontend mascarar erros backend (ex.: submit recusado por saldo atualizado).

- Impacto em autenticação, autorização, escopo por perfil e setor
  - Política permanece no backend; frontend aplica condicionais de UI (ex.: só exibe opção "para terceiro" se papel permitir).
  - Atenção: backend deve continuar validando permissões/filters (lookup de beneficiários, _draft_owner_filter etc.) — frontend não deve ser fonte de verdade.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Sem mudanças contratuais detectadas: frontend consome endpoints/serializers atuais (materiais com saldo_disponivel, beneficiário lookup, draft create/update/submit/discard/cancel).
  - Verificar compatibilidade se formatos de erro/dados mudarem; UI espera campos específicos (ex.: saldo_disponivel em materiais).

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Não altera persistência; risco principal é perda de rastreabilidade se o frontend suprimir ou não propagar corretamente erros do backend.
  - Garantir que submit/discard/cancel acionem os mesmos registros de auditoria/histórico que o fluxo backend já produz.

- Impacto em transações, concorrência, idempotência, saldo físico/reservado/disponível
  - Atualização de rascunho no backend é tratada como substituição completa (semântico de DELETE antigos + bulk_create na UI/backend observado) — operação não é idempotente e pode causar perda de versão em retries ou concorrência.
  - Criação/edição de rascunho não afeta saldos físicos/reservados; somente o submit altera reservas/estoque.
  - Possibilidade real de rejeição no submit se saldo mudar entre lookup e envio — comport. esperado; UI já tenta mitigar com invalidação de cache e confirmação, mas deve tratar erros de domínio no retorno.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque
  - Nenhum direto; porém UI exibe saldo_disponivel do endpoint de materiais — divergências entre fonte oficial (SCPI/integração) e cache/listagem podem causar reprovações no submit.

- Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero
  - Adiciona cobertura de testes frontend (router-smoke.test.tsx) e ajuste no Makefile para instalação idempotente de deps frontend (FRONTEND_DEPS_STAMP).
  - Sem mudanças em CI backend, migrations ou dependências servidoras.

- Como validar manualmente (UI / API / testes)
  - UI (fluxos principais):
    1. /requisicoes/nova → selecionar "Para mim" → buscar material com saldo>0 → adicionar quantidade → Salvar → confirmar navegação para rascunho criado (/requisicoes/:id).
    2. /requisicoes/nova → "Para terceiro" → buscar e selecionar beneficiário (mínimo chars) → Salvar → checar beneficiario_id no payload enviado.
    3. /requisicoes/:id (status="rascunho") → reabrir editor → editar itens → Salvar → confirmar que substitui itens anteriores.
    4. Enviar: acionar Submit → confirmar modal → verificar chamadas de API (PUT/POST submit) e navegação para detalhe; reproduzir caso de saldo insuficiente para ver erro backend.
    5. Descartar rascunho sem número público: chamar DELETE /discard/ → navegar para /minhas-requisicoes.
    6. Cancelar rascunho numerado: chamar POST /cancel/ com motivo → navegar para /minhas-requisicoes.
    7. Material com saldo_disponivel = 0: botão "Adicionar" desabilitado e mensagem exibida.
  - API / Admin:
    - Verificar endpoints de draft respeitam permissões e que submit/ cancel/ discard geram eventos de histórico/auditoria esperados.
  - Testes automatizados:
    - Executar e revisar novos casos em frontend/src/tests/router-smoke.test.tsx; adicionar cenários de retry/concorrência para PUT draft se necessário.

- Pontos de atenção críticos (prioridade)
  1. Não‑idempotência do update de rascunho (substituição completa) — risco de perda de versão em retries/concurrency; considerar controle de versão, merge parcial, ou estratégia idempotente no backend.
  2. Backend deve continuar a validar permissões/filters (beneficiário para terceiro, visibilidade por setor) — evitar confiar apenas nas condicionais de UI.
  3. Comunicação UX e tratamento de erro no submit quando saldo mudou entre lookup e envio — evitar falsos positivos para o usuário.
  4. Garantir que submit/discard/cancel mantenham registros de auditoria/histórico e não quebrem imutabilidade de movimentos aplicados.
  5. Revisar performance/queries do backend para lookups de materiais/beneficiários em cenários com muitos registros (possível necessidade de select_related/prefetch).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->