### PR TITLE
[codex] Frontend piloto: CI inicial com tipos, lint e build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,20 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: saep
+          POSTGRES_PASSWORD: saep
+          POSTGRES_DB: test_wms_saep
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     env:
       SECRET_KEY: test-secret-key-for-ci
       DATABASE_URL: postgres://saep:saep@localhost:5432/test_wms_saep

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
 
   frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:16
@@ -106,12 +107,16 @@ jobs:
       - name: Install backend dependencies
         run: uv sync --locked
       - name: Install frontend dependencies
-        run: make frontend-deps PNPM="$PNPM"
+        run: make frontend-deps
       - name: Generate frontend API types
-        run: make frontend-gen-api PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+        run: make frontend-gen-api
       - name: Lint frontend
-        run: make frontend-lint PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+        run: make frontend-lint
       - name: Build frontend
-        run: make frontend-build PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+        run: make frontend-build
       - name: Check generated frontend API contract
-        run: git diff --exit-code -- frontend/openapi/schema.json frontend/src/shared/api/schema.d.ts
+        run: |
+          git diff --exit-code -- frontend/openapi/schema.json frontend/src/shared/api/schema.d.ts || {
+            echo "Run 'make frontend-gen-api' locally and commit the updated files."
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,40 @@ jobs:
         run: uv run python manage.py check
       - name: Run pytest
         run: make test DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
+
+  frontend:
+    runs-on: ubuntu-latest
+    env:
+      SECRET_KEY: test-secret-key-for-ci
+      DATABASE_URL: postgres://saep:saep@localhost:5432/test_wms_saep
+      DJANGO_SETTINGS_MODULE: config.settings.test
+      TEST_SETTINGS_MODULE: config.settings.test
+      PNPM: pnpm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install backend dependencies
+        run: uv sync --locked
+      - name: Install frontend dependencies
+        run: make frontend-deps PNPM="$PNPM"
+      - name: Generate frontend API types
+        run: make frontend-gen-api PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+      - name: Lint frontend
+        run: make frontend-lint PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+      - name: Build frontend
+        run: make frontend-build PNPM="$PNPM" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY" DATABASE_URL="$DATABASE_URL"
+      - name: Check generated frontend API contract
+        run: git diff --exit-code -- frontend/openapi/schema.json frontend/src/shared/api/schema.d.ts

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -331,7 +331,7 @@ Implementada no workflow `CI`, job `frontend`:
 
 ### Fase 2
 
-Escopo da issue `#43`:
+Escopo da issue #43:
 
 - subir backend com bloco 0 estável
 - carregar `seed_pilot_minimo`

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -321,12 +321,17 @@ Entrada em duas fases:
 
 ### Fase 1
 
+Implementada no workflow `CI`, job `frontend`:
+
 - instalar dependências do frontend
 - gerar tipos OpenAPI
 - lint
 - build
+- não roda Playwright
 
 ### Fase 2
+
+Escopo da issue `#43`:
 
 - subir backend com bloco 0 estável
 - carregar `seed_pilot_minimo`


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Adiciona trilho inicial de CI para o frontend do piloto.
- O workflow instala dependências de forma reprodutível, gera tipos OpenAPI, roda lint e build da SPA.
- Atualiza a documentação do frontend para registrar esta primeira fase de CI.

## Por que esta mudança é necessária
- Fecha a issue #42 e cria a base de validação automática para o frontend sem depender ainda de Playwright no CI.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [ ] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [x] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
- CI falhar por desalinhamento entre instalação do frontend, geração de tipos OpenAPI e build/lint da SPA.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor:
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências: workflow GitHub Actions e sequência de validação do frontend.

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `ruby -e require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "workflow ok"` passou.
3. Branch publicada em GitHub.

## Como validar manualmente
- Abrir o workflow em um PR e confirmar os jobs de lint, test e frontend.
- Conferir se `make frontend-gen-api`, `make frontend-lint` e `make frontend-build` são as etapas do job `frontend`.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumo — PR #56: Frontend Piloto — CI Inicial com Tipos, Lint e Build

**Objetivo da mudança**
- Implementar Fase 1 da CI do frontend piloto com workflow GitHub Actions
- Validar reprodutibilidade de instalação, geração de tipos OpenAPI, lint e build da SPA

**Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero**
- **Novo job `frontend` no workflow CI** executado em paralelo às jobs `lint` e `test` do backend
- **Provisionamento Node.js**: `pnpm/action-setup` v4 (pnpm 10.15.1) + `actions/setup-node` v6 (Node 24) com cache
- **Provisionamento Python**: reutiliza `uv sync` para instalar dependências backend (necessário para geração de tipos OpenAPI via `django-spectacular`)
- **Sequência de validação frontend**: 
  1. Instala deps backend (`uv sync --locked`)
  2. Instala deps frontend (`make frontend-deps`)
  3. Gera tipos TypeScript a partir do contrato OpenAPI (`make frontend-gen-api`) — requer backend provisionado
  4. Roda lint + type-check (`make frontend-lint`)
  5. Build SPA (`make frontend-build`)
  6. Valida que artefatos gerados não sofreram drift (`git diff --exit-code` contra `frontend/openapi/schema.json` e `frontend/src/shared/api/schema.d.ts`)
- **Escopo explícito Fase 1**: NÃO inclui Playwright E2E; Fase 2 será governada por issue #43

**Risco funcional**
- **Falha potencial por desalinhamento**: Qualquer inconsistência entre contrato OpenAPI gerado, tipos TypeScript derivados ou artefatos de build pode quebrar a CI
- **Dependência entre backend e frontend**: Mudanças no OpenAPI do Django que não sejam refletidas em regeneração de tipos causarão rejeição no step `git diff --exit-code`

**Documentação**
- Atualiza `docs/design-acesso-rapido/frontend-arquitetura-piloto.md` com detalhe explícito da Fase 1 (tipos, lint, build) e escopo da Fase 2 (E2E com Playwright, governado por #43)

**Validação manual**
- Abrir o PR e confirmar execução da job `frontend` no histórico de CI
- Verificar se os três passos aparecem: `make frontend-gen-api`, `make frontend-lint`, `make frontend-build` (o git diff é etapa separada)
- Confirmar que sem alterações no contrato, `git diff --exit-code` passa silenciosamente

<!-- end of auto-generated comment: release notes by coderabbit.ai -->