### PR TITLE
[codex] Frontend piloto: fila de autorizações e detalhe canônico

### DIFF
--- a/frontend/src/features/auth/guards.ts
+++ b/frontend/src/features/auth/guards.ts
@@ -1,7 +1,14 @@
 import type { QueryClient } from "@tanstack/react-query";
 import { redirect } from "@tanstack/react-router";
 
-import { authQueryKeys, isAuthError, meQueryOptions } from "./session";
+import {
+  authQueryKeys,
+  homePathForPapel,
+  isAuthError,
+  isPapelOperacional,
+  meQueryOptions,
+  type PapelOperacional,
+} from "./session";
 
 export async function requireSession({
   queryClient,
@@ -26,4 +33,23 @@ export async function requireSession({
 
     throw error;
   }
+}
+
+export async function requireOperationalPapel({
+  allowedPapeis,
+  locationHref,
+  queryClient,
+}: {
+  allowedPapeis: PapelOperacional[];
+  locationHref: string;
+  queryClient: QueryClient;
+}) {
+  const session = await requireSession({ queryClient, locationHref });
+
+  if (isPapelOperacional(session.papel) && allowedPapeis.includes(session.papel)) {
+    return session;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/only-throw-error
+  throw redirect({ to: homePathForPapel(session.papel) });
 }

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -7,12 +7,15 @@ export type AuthSession = components["schemas"]["AuthSessionOutput"];
 export type AuthLoginInput = components["schemas"]["AuthLoginInput"];
 export type ErrorResponse = components["schemas"]["ErrorResponse"];
 
-export type PapelOperacional =
-  | "solicitante"
-  | "auxiliar_setor"
-  | "chefe_setor"
-  | "auxiliar_almoxarifado"
-  | "chefe_almoxarifado";
+export const PAPEL_OPERACIONAL_VALUES = [
+  "solicitante",
+  "auxiliar_setor",
+  "chefe_setor",
+  "auxiliar_almoxarifado",
+  "chefe_almoxarifado",
+] as const;
+
+export type PapelOperacional = (typeof PAPEL_OPERACIONAL_VALUES)[number];
 
 export const UNKNOWN_ROLE_PATH = "/unknown-role";
 
@@ -110,13 +113,7 @@ export const meQueryOptions = queryOptions({
 });
 
 export function isPapelOperacional(value: string): value is PapelOperacional {
-  return (
-    value === "solicitante" ||
-    value === "auxiliar_setor" ||
-    value === "chefe_setor" ||
-    value === "auxiliar_almoxarifado" ||
-    value === "chefe_almoxarifado"
-  );
+  return PAPEL_OPERACIONAL_VALUES.includes(value as PapelOperacional);
 }
 
 export function homePathForPapel(papel: string) {

--- a/frontend/src/features/auth/session.ts
+++ b/frontend/src/features/auth/session.ts
@@ -39,6 +39,18 @@ export function isAuthError(error: unknown) {
   return error instanceof ApiError && (error.status === 401 || error.status === 403);
 }
 
+export function isUnauthenticatedError(error: unknown) {
+  if (!(error instanceof ApiError)) {
+    return false;
+  }
+
+  if (error.status === 401) {
+    return true;
+  }
+
+  return error.status === 403 && error.payload?.error?.code === "not_authenticated";
+}
+
 export async function ensureCsrfCookie() {
   const result = await apiClient.GET("/api/v1/auth/csrf/");
   const error = result.error as ErrorResponse | undefined;
@@ -96,6 +108,16 @@ export const meQueryOptions = queryOptions({
   queryFn: fetchCurrentSession,
   retry: false,
 });
+
+export function isPapelOperacional(value: string): value is PapelOperacional {
+  return (
+    value === "solicitante" ||
+    value === "auxiliar_setor" ||
+    value === "chefe_setor" ||
+    value === "auxiliar_almoxarifado" ||
+    value === "chefe_almoxarifado"
+  );
+}
 
 export function homePathForPapel(papel: string) {
   switch (papel as PapelOperacional) {

--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -12,6 +12,10 @@ export type RequisicaoTimelineEvent = components["schemas"]["RequisicaoTimelineE
 export type RequisicaoActionItem = components["schemas"]["RequisicaoActionOutput"];
 export type RequisicaoTimelineEventType = components["schemas"]["TipoEventoEnum"];
 export type RequisicaoDraftInput = components["schemas"]["RequisicaoCreateInput"];
+export type RequisicaoAuthorizeInput = components["schemas"]["RequisicaoAuthorizeInput"];
+export type RequisicaoRefuseInput = components["schemas"]["RequisicaoRefuseInput"];
+export type RequisicaoPendingApprovalItem = components["schemas"]["RequisicaoPendingApprovalOutput"];
+export type RequisicaoPendingApprovalResponse = components["schemas"]["RequisicaoPendingApprovalPaginated"];
 export type MaterialListItem = components["schemas"]["MaterialListOutput"];
 export type MaterialListResponse = components["schemas"]["MaterialListPaginated"];
 export type BeneficiaryLookupItem = components["schemas"]["BeneficiaryLookupOutput"];
@@ -48,11 +52,19 @@ export type RequisicoesListParams = {
   status?: RequisicaoStatus;
 };
 
+export type PendingApprovalsParams = {
+  page: number;
+  pageSize: number;
+};
+
+const requisitionsBaseQueryKey = ["requisitions"] as const;
+const pendingApprovalsBaseQueryKey = [...requisitionsBaseQueryKey, "pending-approvals"] as const;
+
 export const requisitionsQueryKeys = {
-  all: ["requisitions"] as const,
+  all: requisitionsBaseQueryKey,
   mine: (params: RequisicoesListParams) =>
     [
-      ...requisitionsQueryKeys.all,
+      ...requisitionsBaseQueryKey,
       "mine",
       {
         page: params.page,
@@ -61,10 +73,19 @@ export const requisitionsQueryKeys = {
         status: params.status ?? "",
       },
     ] as const,
-  detail: (id: number) => [...requisitionsQueryKeys.all, "detail", id] as const,
-  materials: (search: string) => [...requisitionsQueryKeys.all, "materials", search] as const,
+  pendingApprovalsAll: pendingApprovalsBaseQueryKey,
+  pendingApprovals: (params: PendingApprovalsParams) =>
+    [
+      ...pendingApprovalsBaseQueryKey,
+      {
+        page: params.page,
+        pageSize: params.pageSize,
+      },
+    ] as const,
+  detail: (id: number) => [...requisitionsBaseQueryKey, "detail", id] as const,
+  materials: (search: string) => [...requisitionsBaseQueryKey, "materials", search] as const,
   beneficiaries: (search: string) =>
-    [...requisitionsQueryKeys.all, "beneficiaries", search] as const,
+    [...requisitionsBaseQueryKey, "beneficiaries", search] as const,
 };
 
 function messageFromError(error: ErrorResponse | undefined, fallback: string) {
@@ -94,6 +115,27 @@ export async function fetchMyRequisitions(params: RequisicoesListParams) {
   return data;
 }
 
+export async function fetchPendingApprovals(params: PendingApprovalsParams) {
+  const { data, error, response } = await apiClient.GET("/api/v1/requisitions/pending-approvals/", {
+    params: {
+      query: {
+        page: params.page,
+        page_size: params.pageSize,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar autorizações pendentes."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
 export async function fetchRequisitionDetail(id: number) {
   const { data, error, response } = await apiClient.GET("/api/v1/requisitions/{id}/", {
     params: {
@@ -106,6 +148,48 @@ export async function fetchRequisitionDetail(id: number) {
   if (error || !data) {
     throw new ApiError(
       messageFromError(error, "Não foi possível carregar a requisição."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function authorizeRequisition(id: number, input: RequisicaoAuthorizeInput) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/authorize/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível autorizar a requisição."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function refuseRequisition(id: number, input: RequisicaoRefuseInput) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/refuse/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível recusar a requisição."),
       response.status,
       error,
     );
@@ -257,6 +341,15 @@ export function myRequisitionsQueryOptions(params: RequisicoesListParams) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.mine(params),
     queryFn: () => fetchMyRequisitions(params),
+    placeholderData: keepPreviousData,
+    retry: retryUnlessClientOrAuthError,
+  });
+}
+
+export function pendingApprovalsQueryOptions(params: PendingApprovalsParams) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.pendingApprovals(params),
+    queryFn: () => fetchPendingApprovals(params),
     placeholderData: keepPreviousData,
     retry: retryUnlessClientOrAuthError,
   });

--- a/frontend/src/routes/autorizacoes.tsx
+++ b/frontend/src/routes/autorizacoes.tsx
@@ -9,8 +9,8 @@ import {
 } from "@tanstack/react-table";
 import { z } from "zod";
 
-import { requireSession } from "../features/auth/guards";
-import { authQueryKeys, isAuthError } from "../features/auth/session";
+import { requireOperationalPapel } from "../features/auth/guards";
+import { authQueryKeys, isUnauthenticatedError } from "../features/auth/session";
 import {
   formatDateTime,
   pendingApprovalsQueryOptions,
@@ -28,7 +28,11 @@ const authorizationSearchSchema = z.object({
 export const Route = createFileRoute("/autorizacoes")({
   validateSearch: authorizationSearchSchema,
   beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
+    requireOperationalPapel({
+      allowedPapeis: ["chefe_setor", "chefe_almoxarifado"],
+      queryClient: context.queryClient,
+      locationHref: location.href,
+    }),
   component: AutorizacoesPage,
 });
 
@@ -42,6 +46,30 @@ function EmptyState() {
   );
 }
 
+function recordsLabelForList({
+  count,
+  hasError,
+  isLoading,
+}: {
+  count: number | undefined;
+  hasError: boolean;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return "Carregando...";
+  }
+
+  if (hasError) {
+    return "Erro ao carregar";
+  }
+
+  if (typeof count === "number") {
+    return `${count} ${count === 1 ? "registro" : "registros"}`;
+  }
+
+  return "0 registros";
+}
+
 function AutorizacoesPage() {
   const queryClient = useQueryClient();
   const navigate = useNavigate({ from: "/autorizacoes" });
@@ -53,15 +81,13 @@ function AutorizacoesPage() {
       pageSize: DEFAULT_PAGE_SIZE,
     }),
   );
-  const authError = listQuery.isError && isAuthError(listQuery.error);
+  const authError = listQuery.isError && isUnauthenticatedError(listQuery.error);
   const rows = listQuery.data?.results ?? [];
-  const recordsLabel = listQuery.isLoading
-    ? "Carregando..."
-    : listQuery.isError && !listQuery.data
-      ? "Erro ao carregar"
-      : listQuery.data
-        ? `${listQuery.data.count} ${listQuery.data.count === 1 ? "registro" : "registros"}`
-        : "0 registros";
+  const recordsLabel = recordsLabelForList({
+    count: listQuery.data?.count,
+    hasError: listQuery.isError && !listQuery.data,
+    isLoading: listQuery.isLoading,
+  });
   const columns = useMemo<ColumnDef<RequisicaoPendingApprovalItem>[]>(
     () => [
       {
@@ -145,8 +171,8 @@ function AutorizacoesPage() {
     },
   });
 
-  async function goToPage(page: number) {
-    await navigate({
+  function goToPage(page: number) {
+    void navigate({
       search: {
         page: page === 1 ? undefined : page,
       },
@@ -161,10 +187,10 @@ function AutorizacoesPage() {
     void navigate({
       to: "/login",
       search: {
-        redirect: "/autorizacoes",
+        redirect: currentPage === 1 ? "/autorizacoes" : `/autorizacoes?page=${currentPage}`,
       },
     });
-  }, [authError, navigate, queryClient]);
+  }, [authError, currentPage, navigate, queryClient]);
 
   return (
     <section className="space-y-6">
@@ -225,7 +251,7 @@ function AutorizacoesPage() {
         <button
           className="action-link compact-action"
           disabled={currentPage <= 1 || listQuery.isPending}
-          onClick={() => void goToPage(currentPage - 1)}
+          onClick={() => goToPage(currentPage - 1)}
           type="button"
         >
           Anterior
@@ -240,7 +266,7 @@ function AutorizacoesPage() {
             !listQuery.data ||
             currentPage >= listQuery.data.total_pages
           }
-          onClick={() => void goToPage(currentPage + 1)}
+          onClick={() => goToPage(currentPage + 1)}
           type="button"
         >
           Próxima

--- a/frontend/src/routes/autorizacoes.tsx
+++ b/frontend/src/routes/autorizacoes.tsx
@@ -1,43 +1,251 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import { z } from "zod";
 
 import { requireSession } from "../features/auth/guards";
-import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
+import { authQueryKeys, isAuthError } from "../features/auth/session";
+import {
+  formatDateTime,
+  pendingApprovalsQueryOptions,
+  queryErrorMessage,
+  statusLabel,
+  type RequisicaoPendingApprovalItem,
+} from "../features/requisitions/requisitions";
 
-export const Route = createFileRoute("/autorizacoes")({
-  beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
-  component: AutorizacoesPlaceholderPage,
+const DEFAULT_PAGE_SIZE = 20;
+
+const authorizationSearchSchema = z.object({
+  page: z.coerce.number().int().min(1).optional().catch(undefined),
 });
 
-function AutorizacoesPlaceholderPage() {
+export const Route = createFileRoute("/autorizacoes")({
+  validateSearch: authorizationSearchSchema,
+  beforeLoad: ({ context, location }) =>
+    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
+  component: AutorizacoesPage,
+});
+
+function EmptyState() {
   return (
-    <FeaturePlaceholder
-      kicker="Authorization queue"
-      title="Fila de autorizações"
-      summary="Fila especializada para chefia de setor. O scaffold já reserva densidade operacional maior e ligação direta com o detalhe em `?contexto=autorizacao`."
-      nextSlice="#40 — fila e decisões de autorização"
-      contracts={[
-        "GET /api/v1/requisitions/pending-approvals/",
-        "GET /api/v1/requisitions/{id}/",
-      ]}
-      bullets={[
-        "Ordenação por pendências mais antigas primeiro.",
-        "Ação rápida só depois da leitura do detalhe canônico.",
-        "Nada de capability inventada para auxiliar de setor.",
-      ]}
-      preview={
-        <div className="preview-panel">
-          <div className="preview-row">
-            <span>REQ-2026-0011</span>
-            <span className="preview-meta">setor manutenção</span>
+    <div className="empty-state">
+      <p className="eyebrow">Sem pendências</p>
+      <h2>Nenhuma autorização pendente</h2>
+      <p>A fila mostra requisições aguardando decisão do chefe do setor responsável.</p>
+    </div>
+  );
+}
+
+function AutorizacoesPage() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/autorizacoes" });
+  const searchParams = Route.useSearch();
+  const currentPage = searchParams.page ?? 1;
+  const listQuery = useQuery(
+    pendingApprovalsQueryOptions({
+      page: currentPage,
+      pageSize: DEFAULT_PAGE_SIZE,
+    }),
+  );
+  const authError = listQuery.isError && isAuthError(listQuery.error);
+  const rows = listQuery.data?.results ?? [];
+  const recordsLabel = listQuery.isLoading
+    ? "Carregando..."
+    : listQuery.isError && !listQuery.data
+      ? "Erro ao carregar"
+      : listQuery.data
+        ? `${listQuery.data.count} ${listQuery.data.count === 1 ? "registro" : "registros"}`
+        : "0 registros";
+  const columns = useMemo<ColumnDef<RequisicaoPendingApprovalItem>[]>(
+    () => [
+      {
+        id: "identifier",
+        header: "Requisição",
+        cell: ({ row }) => (
+          <div className="min-w-[11rem]">
+            <span className="font-semibold text-[var(--ink-strong)]">
+              {row.original.numero_publico ?? `#${row.original.id}`}
+            </span>
+            <p className="mt-2 text-xs uppercase tracking-[0.18em] text-[var(--ink-muted)]">
+              {row.original.total_itens} {row.original.total_itens === 1 ? "item" : "itens"}
+            </p>
           </div>
-          <div className="preview-row">
-            <span>REQ-2026-0013</span>
-            <span className="preview-meta">2 itens pendentes</span>
+        ),
+      },
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row }) => (
+          <span className={`req-status req-status-${row.original.status}`}>
+            {statusLabel(row.original.status)}
+          </span>
+        ),
+      },
+      {
+        id: "beneficiario",
+        header: "Beneficiário",
+        cell: ({ row }) => (
+          <div>
+            <p className="font-semibold">{row.original.beneficiario.nome_completo}</p>
+            <p className="mt-1 text-sm text-[var(--ink-soft)]">
+              {row.original.setor_beneficiario.nome}
+            </p>
           </div>
-          <div className="preview-badge">contexto=autorizacao</div>
+        ),
+      },
+      {
+        id: "criador",
+        header: "Criador",
+        cell: ({ row }) => <span>{row.original.criador.nome_completo}</span>,
+      },
+      {
+        id: "sent_at",
+        header: "Envio",
+        cell: ({ row }) => (
+          <span className="text-sm text-[var(--ink-soft)]">
+            {formatDateTime(row.original.data_envio_autorizacao)}
+          </span>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => (
+          <Link
+            className="action-link compact-action"
+            params={{ id: String(row.original.id) }}
+            search={{ contexto: "autorizacao", page: currentPage === 1 ? undefined : currentPage }}
+            to="/requisicoes/$id"
+          >
+            Abrir
+          </Link>
+        ),
+      },
+    ],
+    [currentPage],
+  );
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    columns,
+    data: rows,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    rowCount: listQuery.data?.count ?? 0,
+    state: {
+      pagination: {
+        pageIndex: currentPage - 1,
+        pageSize: DEFAULT_PAGE_SIZE,
+      },
+    },
+  });
+
+  async function goToPage(page: number) {
+    await navigate({
+      search: {
+        page: page === 1 ? undefined : page,
+      },
+    });
+  }
+
+  useEffect(() => {
+    if (!authError) {
+      return;
+    }
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: "/autorizacoes",
+      },
+    });
+  }, [authError, navigate, queryClient]);
+
+  return (
+    <section className="space-y-6">
+      <div className="worklist-header">
+        <div>
+          <p className="eyebrow">Worklist operacional</p>
+          <h1>Fila de autorizações</h1>
+          <p>Requisições aguardando decisão da chefia do setor responsável.</p>
         </div>
-      }
-    />
+        <div className="status-chip">
+          <span className="status-dot" />
+          {recordsLabel}
+        </div>
+      </div>
+
+      {listQuery.isError && !authError ? (
+        <div className="error-panel">
+          {queryErrorMessage(listQuery.error, "Não foi possível carregar autorizações pendentes.")}
+        </div>
+      ) : null}
+
+      {!listQuery.isError || authError ? (
+        <div className="table-frame">
+          {listQuery.isPending ? (
+            <div className="loading-state">Carregando autorizações...</div>
+          ) : rows.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <table className="operational-table">
+              <thead>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th key={header.id}>
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody>
+                {table.getRowModel().rows.map((row) => (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      ) : null}
+
+      <div className="pagination-bar">
+        <button
+          className="action-link compact-action"
+          disabled={currentPage <= 1 || listQuery.isPending}
+          onClick={() => void goToPage(currentPage - 1)}
+          type="button"
+        >
+          Anterior
+        </button>
+        <span>
+          Página {listQuery.data?.page ?? currentPage} de {listQuery.data?.total_pages ?? 1}
+        </span>
+        <button
+          className="action-link compact-action"
+          disabled={
+            listQuery.isPending ||
+            !listQuery.data ||
+            currentPage >= listQuery.data.total_pages
+          }
+          onClick={() => void goToPage(currentPage + 1)}
+          type="button"
+        >
+          Próxima
+        </button>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/routes/autorizacoes.tsx
+++ b/frontend/src/routes/autorizacoes.tsx
@@ -192,6 +192,10 @@ function AutorizacoesPage() {
     });
   }, [authError, currentPage, navigate, queryClient]);
 
+  if (authError) {
+    return null;
+  }
+
   return (
     <section className="space-y-6">
       <div className="worklist-header">
@@ -206,13 +210,13 @@ function AutorizacoesPage() {
         </div>
       </div>
 
-      {listQuery.isError && !authError ? (
+      {listQuery.isError ? (
         <div className="error-panel">
           {queryErrorMessage(listQuery.error, "Não foi possível carregar autorizações pendentes.")}
         </div>
       ) : null}
 
-      {!listQuery.isError || authError ? (
+      {!listQuery.isError ? (
         <div className="table-frame">
           {listQuery.isPending ? (
             <div className="loading-state">Carregando autorizações...</div>

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState, type FormEvent } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
@@ -7,20 +7,26 @@ import { requireSession } from "../../features/auth/guards";
 import { authQueryKeys, isAuthError, meQueryOptions } from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 import {
+    authorizeRequisition,
     displayRequisitionIdentifier,
     formatDateTime,
     formatQuantity,
     isThirdPartyBeneficiary,
     queryErrorMessage,
+    refuseRequisition,
     requisitionDetailQueryOptions,
+    requisitionsQueryKeys,
     statusLabel,
     tipoEventoLabel,
     type RequisicaoActionItem,
+    type RequisicaoAuthorizeInput,
+    type RequisicaoDetail,
     type RequisicaoTimelineEvent,
   } from "../../features/requisitions/requisitions";
 
 const detailSearchSchema = z.object({
   contexto: z.enum(["autorizacao", "atendimento"]).optional().catch(undefined),
+  page: z.coerce.number().int().min(1).optional().catch(undefined),
 });
 
 export const Route = createFileRoute("/requisicoes/$id")({
@@ -73,9 +79,255 @@ function TimelineEvent({ event }: { event: RequisicaoTimelineEvent }) {
   );
 }
 
+type AuthorizationItemForm = {
+  itemId: number;
+  label: string;
+  requestedQuantity: string;
+  authorizedQuantity: string;
+  justification: string;
+};
+
+function quantityNumber(value: string) {
+  const normalizedValue = value.replace(",", ".").trim();
+  if (!normalizedValue) {
+    return Number.NaN;
+  }
+  return Number(normalizedValue);
+}
+
+function authorizationItemLabel(item: RequisicaoActionItem) {
+  return item.material.nome;
+}
+
+function authorizationItemsFromRequisition(requisicao: RequisicaoDetail): AuthorizationItemForm[] {
+  return requisicao.itens.map((item) => ({
+    itemId: item.id,
+    label: authorizationItemLabel(item),
+    requestedQuantity: item.quantidade_solicitada,
+    authorizedQuantity: item.quantidade_solicitada,
+    justification: item.justificativa_autorizacao_parcial,
+  }));
+}
+
+function AuthorizationDecisionPanel({
+  authorizationPage,
+  requisicao,
+}: {
+  authorizationPage: number | undefined;
+  requisicao: RequisicaoDetail;
+}) {
+  const [items, setItems] = useState(() => authorizationItemsFromRequisition(requisicao));
+  const [refusalReason, setRefusalReason] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/requisicoes/$id" });
+
+  async function afterDecisionSuccess(updatedRequisition: RequisicaoDetail) {
+    queryClient.setQueryData(requisitionsQueryKeys.detail(requisicao.id), updatedRequisition);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.pendingApprovalsAll }),
+      queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.detail(requisicao.id) }),
+    ]);
+    await navigate({
+      to: "/autorizacoes",
+      search: {
+        page: authorizationPage && authorizationPage > 1 ? authorizationPage : undefined,
+      },
+    });
+  }
+
+  const authorizeMutation = useMutation({
+    mutationFn: (input: RequisicaoAuthorizeInput) => authorizeRequisition(requisicao.id, input),
+    onSuccess: afterDecisionSuccess,
+  });
+  const refuseMutation = useMutation({
+    mutationFn: (input: { motivo_recusa: string }) => refuseRequisition(requisicao.id, input),
+    onSuccess: afterDecisionSuccess,
+  });
+  const pending = authorizeMutation.isPending || refuseMutation.isPending;
+  const mutationError = authorizeMutation.error ?? refuseMutation.error;
+
+  function updateItem(itemId: number, field: "authorizedQuantity" | "justification", value: string) {
+    setItems((currentItems) =>
+      currentItems.map((item) => (item.itemId === itemId ? { ...item, [field]: value } : item)),
+    );
+    setValidationError("");
+  }
+
+  function payloadFromItems(nextItems: AuthorizationItemForm[]) {
+    return {
+      itens: nextItems.map((item) => ({
+        item_id: item.itemId,
+        quantidade_autorizada: item.authorizedQuantity.trim(),
+        justificativa_autorizacao_parcial: item.justification.trim(),
+      })),
+    };
+  }
+
+  function validateAuthorization(nextItems: AuthorizationItemForm[]) {
+    const authorizedQuantities = nextItems.map((item) => quantityNumber(item.authorizedQuantity));
+
+    if (authorizedQuantities.some((quantity) => Number.isNaN(quantity) || quantity < 0)) {
+      return "Informe quantidades autorizadas válidas.";
+    }
+
+    const itemAboveRequested = nextItems.find(
+      (item) => quantityNumber(item.authorizedQuantity) > quantityNumber(item.requestedQuantity),
+    );
+
+    if (itemAboveRequested) {
+      return "Quantidade autorizada não pode exceder a quantidade solicitada.";
+    }
+
+    if (authorizedQuantities.every((quantity) => quantity === 0)) {
+      return "Para negar todos os itens, use Recusar requisição.";
+    }
+
+    const partialWithoutJustification = nextItems.find(
+      (item) =>
+        quantityNumber(item.authorizedQuantity) < quantityNumber(item.requestedQuantity) &&
+        !item.justification.trim(),
+    );
+
+    if (partialWithoutJustification) {
+      return "Informe justificativa para autorização parcial ou zerada.";
+    }
+
+    return "";
+  }
+
+  function authorizeAll() {
+    const nextItems = requisicao.itens.map((item) => ({
+      itemId: item.id,
+      label: authorizationItemLabel(item),
+      requestedQuantity: item.quantidade_solicitada,
+      authorizedQuantity: item.quantidade_solicitada,
+      justification: "",
+    }));
+    setItems(nextItems);
+    setValidationError("");
+    authorizeMutation.mutate(payloadFromItems(nextItems));
+  }
+
+  function authorizeAdjusted(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const error = validateAuthorization(items);
+
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+
+    setValidationError("");
+    authorizeMutation.mutate(payloadFromItems(items));
+  }
+
+  function refuse(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmedReason = refusalReason.trim();
+
+    if (!trimmedReason) {
+      setValidationError("Informe o motivo da recusa.");
+      return;
+    }
+
+    setValidationError("");
+    refuseMutation.mutate({ motivo_recusa: trimmedReason });
+  }
+
+  return (
+    <section className="detail-panel authorization-panel">
+      <div className="authorization-panel-header">
+        <div>
+          <p className="eyebrow">Decisão da chefia</p>
+          <h2>Autorizar ou recusar requisição</h2>
+          <p>O backend revalida saldo, setor, estado e permissão no momento da decisão.</p>
+        </div>
+        <button
+          className="preview-button draft-primary"
+          disabled={pending}
+          onClick={authorizeAll}
+          type="button"
+        >
+          {authorizeMutation.isPending ? "Autorizando..." : "Autorizar tudo como solicitado"}
+        </button>
+      </div>
+
+      {validationError ? <div className="error-panel compact-error">{validationError}</div> : null}
+      {mutationError ? (
+        <div className="error-panel compact-error">
+          {queryErrorMessage(mutationError, "Não foi possível concluir a decisão.")}
+        </div>
+      ) : null}
+
+      <form className="authorization-form" onSubmit={authorizeAdjusted}>
+        <div className="authorization-items">
+          {items.map((item) => (
+            <article className="draft-item-card" key={item.itemId}>
+              <div>
+                <h2>{item.label}</h2>
+                <p>Solicitado: {formatQuantity(item.requestedQuantity)}</p>
+              </div>
+              <div className="authorization-item-fields">
+                <label className="preview-label">
+                  Quantidade autorizada para {item.label}
+                  <input
+                    className="preview-input"
+                    disabled={pending}
+                    onChange={(event) =>
+                      updateItem(item.itemId, "authorizedQuantity", event.target.value)
+                    }
+                    value={item.authorizedQuantity}
+                  />
+                </label>
+                <label className="preview-label">
+                  Justificativa para {item.label}
+                  <input
+                    className="preview-input"
+                    disabled={pending}
+                    onChange={(event) => updateItem(item.itemId, "justification", event.target.value)}
+                    placeholder="Obrigatória quando parcial ou zerada"
+                    value={item.justification}
+                  />
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+        <div className="draft-actions">
+          <button className="preview-button draft-primary" disabled={pending} type="submit">
+            Autorizar conforme ajustes
+          </button>
+        </div>
+      </form>
+
+      <form className="authorization-refusal" onSubmit={refuse}>
+        <label className="preview-label">
+          Motivo da recusa
+          <textarea
+            className="preview-input draft-textarea"
+            disabled={pending}
+            onChange={(event) => {
+              setRefusalReason(event.target.value);
+              setValidationError("");
+            }}
+            rows={3}
+            value={refusalReason}
+          />
+        </label>
+        <div className="draft-actions">
+          <button className="preview-button draft-primary danger-action" disabled={pending} type="submit">
+            Recusar requisição
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
 function DetalheRequisicaoPage() {
   const { id } = Route.useParams();
-  const { contexto } = Route.useSearch();
+  const { contexto, page: authorizationPage } = Route.useSearch();
   const requisicaoId = Number(id);
   const backTo =
     contexto === "autorizacao"
@@ -157,11 +409,27 @@ function DetalheRequisicaoPage() {
         </div>
         <div className="detail-actions">
           {contexto ? <span className="context-chip">Contexto: {contexto}</span> : null}
-          <Link className="action-link compact-action" to={backTo}>
+          <Link
+            className="action-link compact-action"
+            search={
+              contexto === "autorizacao"
+                ? { page: authorizationPage && authorizationPage > 1 ? authorizationPage : undefined }
+                : undefined
+            }
+            to={backTo}
+          >
             Voltar
           </Link>
         </div>
       </div>
+
+      {contexto === "autorizacao" && requisicao.status === "aguardando_autorizacao" ? (
+        <AuthorizationDecisionPanel
+          authorizationPage={authorizationPage}
+          key={requisicao.id}
+          requisicao={requisicao}
+        />
+      ) : null}
 
       <div className="detail-grid">
         <section className="detail-panel">

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
-import { requireSession } from "../../features/auth/guards";
+import { requireOperationalPapel, requireSession } from "../../features/auth/guards";
 import { authQueryKeys, isAuthError, meQueryOptions } from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 import {
@@ -21,6 +21,7 @@ import {
     type RequisicaoActionItem,
     type RequisicaoAuthorizeInput,
     type RequisicaoDetail,
+    type RequisicaoRefuseInput,
     type RequisicaoTimelineEvent,
   } from "../../features/requisitions/requisitions";
 
@@ -31,8 +32,18 @@ const detailSearchSchema = z.object({
 
 export const Route = createFileRoute("/requisicoes/$id")({
   validateSearch: detailSearchSchema,
-  beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
+  beforeLoad: async ({ context, location, search }) => {
+    if (search.contexto === "autorizacao") {
+      await requireOperationalPapel({
+        allowedPapeis: ["chefe_setor", "chefe_almoxarifado"],
+        queryClient: context.queryClient,
+        locationHref: location.href,
+      });
+      return;
+    }
+
+    await requireSession({ queryClient: context.queryClient, locationHref: location.href });
+  },
   component: DetalheRequisicaoPage,
 });
 
@@ -95,6 +106,10 @@ function quantityNumber(value: string) {
   return Number(normalizedValue);
 }
 
+function normalizeQuantityInput(value: string) {
+  return value.replace(",", ".").trim();
+}
+
 function authorizationItemLabel(item: RequisicaoActionItem) {
   return item.material.nome;
 }
@@ -122,8 +137,7 @@ function AuthorizationDecisionPanel({
   const queryClient = useQueryClient();
   const navigate = useNavigate({ from: "/requisicoes/$id" });
 
-  async function afterDecisionSuccess(updatedRequisition: RequisicaoDetail) {
-    queryClient.setQueryData(requisitionsQueryKeys.detail(requisicao.id), updatedRequisition);
+  async function afterDecisionSuccess() {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.pendingApprovalsAll }),
       queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.detail(requisicao.id) }),
@@ -141,24 +155,30 @@ function AuthorizationDecisionPanel({
     onSuccess: afterDecisionSuccess,
   });
   const refuseMutation = useMutation({
-    mutationFn: (input: { motivo_recusa: string }) => refuseRequisition(requisicao.id, input),
+    mutationFn: (input: RequisicaoRefuseInput) => refuseRequisition(requisicao.id, input),
     onSuccess: afterDecisionSuccess,
   });
   const pending = authorizeMutation.isPending || refuseMutation.isPending;
   const mutationError = authorizeMutation.error ?? refuseMutation.error;
 
+  function resetDecisionFeedback() {
+    setValidationError("");
+    authorizeMutation.reset();
+    refuseMutation.reset();
+  }
+
   function updateItem(itemId: number, field: "authorizedQuantity" | "justification", value: string) {
     setItems((currentItems) =>
       currentItems.map((item) => (item.itemId === itemId ? { ...item, [field]: value } : item)),
     );
-    setValidationError("");
+    resetDecisionFeedback();
   }
 
   function payloadFromItems(nextItems: AuthorizationItemForm[]) {
     return {
       itens: nextItems.map((item) => ({
         item_id: item.itemId,
-        quantidade_autorizada: item.authorizedQuantity.trim(),
+        quantidade_autorizada: normalizeQuantityInput(item.authorizedQuantity),
         justificativa_autorizacao_parcial: item.justification.trim(),
       })),
     };
@@ -205,12 +225,13 @@ function AuthorizationDecisionPanel({
       justification: "",
     }));
     setItems(nextItems);
-    setValidationError("");
+    resetDecisionFeedback();
     authorizeMutation.mutate(payloadFromItems(nextItems));
   }
 
   function authorizeAdjusted(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    resetDecisionFeedback();
     const error = validateAuthorization(items);
 
     if (error) {
@@ -218,12 +239,12 @@ function AuthorizationDecisionPanel({
       return;
     }
 
-    setValidationError("");
     authorizeMutation.mutate(payloadFromItems(items));
   }
 
   function refuse(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    resetDecisionFeedback();
     const trimmedReason = refusalReason.trim();
 
     if (!trimmedReason) {
@@ -231,7 +252,6 @@ function AuthorizationDecisionPanel({
       return;
     }
 
-    setValidationError("");
     refuseMutation.mutate({ motivo_recusa: trimmedReason });
   }
 
@@ -309,7 +329,7 @@ function AuthorizationDecisionPanel({
             disabled={pending}
             onChange={(event) => {
               setRefusalReason(event.target.value);
-              setValidationError("");
+              resetDecisionFeedback();
             }}
             rows={3}
             value={refusalReason}
@@ -341,7 +361,10 @@ function DetalheRequisicaoPage() {
     ...requisitionDetailQueryOptions(requisicaoId),
     enabled: Number.isInteger(requisicaoId) && requisicaoId > 0,
   });
-  const sessionQuery = useQuery(meQueryOptions);
+  const sessionQuery = useQuery({
+    ...meQueryOptions,
+    enabled: detailQuery.data?.status === "rascunho",
+  });
   const authError = detailQuery.isError && isAuthError(detailQuery.error);
 
   useEffect(() => {
@@ -352,10 +375,15 @@ function DetalheRequisicaoPage() {
     void navigate({
       to: "/login",
       search: {
-        redirect: `/requisicoes/${id}`,
+        redirect:
+          contexto === "autorizacao"
+            ? `/requisicoes/${id}?contexto=autorizacao${authorizationPage && authorizationPage > 1 ? `&page=${authorizationPage}` : ""}`
+            : contexto === "atendimento"
+              ? `/requisicoes/${id}?contexto=atendimento`
+              : `/requisicoes/${id}`,
       },
     });
-  }, [authError, id, navigate, queryClient]);
+  }, [authError, authorizationPage, contexto, id, navigate, queryClient]);
 
   if (!Number.isInteger(requisicaoId) || requisicaoId <= 0) {
     return <div className="error-panel">Identificador de requisição inválido.</div>;

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -339,6 +339,7 @@ function AuthorizationDecisionPanel({
                   <input
                     className="preview-input"
                     disabled={pending}
+                    inputMode="decimal"
                     onChange={(event) =>
                       updateItem(item.itemId, "authorizedQuantity", event.target.value)
                     }
@@ -347,11 +348,12 @@ function AuthorizationDecisionPanel({
                 </label>
                 <label className="preview-label">
                   Justificativa para {item.label}
-                  <input
+                  <textarea
                     className="preview-input"
                     disabled={pending}
                     onChange={(event) => updateItem(item.itemId, "justification", event.target.value)}
                     placeholder="Obrigatória quando parcial ou zerada"
+                    rows={3}
                     value={item.justification}
                   />
                 </label>

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -6,7 +6,6 @@ import { z } from "zod";
 import { requireOperationalPapel, requireSession } from "../../features/auth/guards";
 import {
   authQueryKeys,
-  isAuthError,
   isUnauthenticatedError,
   meQueryOptions,
 } from "../../features/auth/session";
@@ -412,7 +411,7 @@ function DetalheRequisicaoPage() {
     ...meQueryOptions,
     enabled: detailQuery.data?.status === "rascunho",
   });
-  const authError = detailQuery.isError && isAuthError(detailQuery.error);
+  const authError = detailQuery.isError && isUnauthenticatedError(detailQuery.error);
 
   useEffect(() => {
     if (!authError) {

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -4,7 +4,12 @@ import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { z } from "zod";
 
 import { requireOperationalPapel, requireSession } from "../../features/auth/guards";
-import { authQueryKeys, isAuthError, meQueryOptions } from "../../features/auth/session";
+import {
+  authQueryKeys,
+  isAuthError,
+  isUnauthenticatedError,
+  meQueryOptions,
+} from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 import {
     authorizeRequisition,
@@ -110,6 +115,26 @@ function normalizeQuantityInput(value: string) {
   return value.replace(",", ".").trim();
 }
 
+function buildRequisicaoRedirect({
+  authorizationPage,
+  contexto,
+  id,
+}: {
+  authorizationPage: number | undefined;
+  contexto: "autorizacao" | "atendimento" | undefined;
+  id: string;
+}) {
+  if (contexto === "autorizacao") {
+    return `/requisicoes/${id}?contexto=autorizacao${authorizationPage && authorizationPage > 1 ? `&page=${authorizationPage}` : ""}`;
+  }
+
+  if (contexto === "atendimento") {
+    return `/requisicoes/${id}?contexto=atendimento`;
+  }
+
+  return `/requisicoes/${id}`;
+}
+
 function authorizationItemLabel(item: RequisicaoActionItem) {
   return item.material.nome;
 }
@@ -137,6 +162,24 @@ function AuthorizationDecisionPanel({
   const queryClient = useQueryClient();
   const navigate = useNavigate({ from: "/requisicoes/$id" });
 
+  function redirectToLoginAfterAuthError(error: unknown) {
+    if (!isUnauthenticatedError(error)) {
+      return;
+    }
+
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: buildRequisicaoRedirect({
+          id: String(requisicao.id),
+          contexto: "autorizacao",
+          authorizationPage,
+        }),
+      },
+    });
+  }
+
   async function afterDecisionSuccess() {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.pendingApprovalsAll }),
@@ -152,10 +195,12 @@ function AuthorizationDecisionPanel({
 
   const authorizeMutation = useMutation({
     mutationFn: (input: RequisicaoAuthorizeInput) => authorizeRequisition(requisicao.id, input),
+    onError: redirectToLoginAfterAuthError,
     onSuccess: afterDecisionSuccess,
   });
   const refuseMutation = useMutation({
     mutationFn: (input: RequisicaoRefuseInput) => refuseRequisition(requisicao.id, input),
+    onError: redirectToLoginAfterAuthError,
     onSuccess: afterDecisionSuccess,
   });
   const pending = authorizeMutation.isPending || refuseMutation.isPending;
@@ -375,12 +420,7 @@ function DetalheRequisicaoPage() {
     void navigate({
       to: "/login",
       search: {
-        redirect:
-          contexto === "autorizacao"
-            ? `/requisicoes/${id}?contexto=autorizacao${authorizationPage && authorizationPage > 1 ? `&page=${authorizationPage}` : ""}`
-            : contexto === "atendimento"
-              ? `/requisicoes/${id}?contexto=atendimento`
-              : `/requisicoes/${id}`,
+        redirect: buildRequisicaoRedirect({ id, contexto, authorizationPage }),
       },
     });
   }, [authError, authorizationPage, contexto, id, navigate, queryClient]);

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -496,6 +496,42 @@ a {
   font-size: 0.9rem;
 }
 
+.authorization-panel,
+.authorization-form,
+.authorization-items,
+.authorization-refusal {
+  display: grid;
+  gap: 1rem;
+}
+
+.authorization-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.authorization-panel-header h2 {
+  margin-top: 0.55rem;
+  font-size: 1.35rem;
+  color: var(--ink-strong);
+}
+
+.authorization-panel-header p {
+  margin-top: 0.4rem;
+  color: var(--ink-soft);
+}
+
+.authorization-item-fields {
+  display: grid;
+  grid-template-columns: minmax(10rem, 14rem) minmax(14rem, 1fr);
+  gap: 1rem;
+}
+
+.compact-error {
+  padding: 1rem;
+}
+
 .timeline-list {
   list-style: none;
   padding: 0;
@@ -648,8 +684,13 @@ a {
   .filters-bar,
   .detail-grid,
   .quantity-grid,
+  .authorization-item-fields,
   .draft-item-fields {
     grid-template-columns: 1fr;
+  }
+
+  .authorization-panel-header {
+    flex-direction: column;
   }
 
   .table-frame {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -1062,6 +1062,28 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("keeps permission denied detail errors inline instead of redirecting to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return forbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByText("Permissão negada.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+  });
+
   it("does not render authorization panel outside pending authorization status", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { AppProviders } from "../app/providers";
 import { createAppQueryClient } from "../app/query-client";
 import { buildRouter } from "../app/router";
+import { formatDateTime } from "../features/requisitions/requisitions";
 
 function renderRoute(pathname: string) {
   window.history.replaceState({}, "", pathname);
@@ -403,6 +404,20 @@ function unauthenticatedResponse() {
       },
     }),
     { status: 401, headers: jsonHeaders },
+  );
+}
+
+function unauthenticatedForbiddenResponse() {
+  return new Response(
+    JSON.stringify({
+      error: {
+        code: "not_authenticated",
+        message: "Autenticação necessária.",
+        details: {},
+        trace_id: null,
+      },
+    }),
+    { status: 403, headers: jsonHeaders },
   );
 }
 
@@ -878,6 +893,47 @@ describe("frontend scaffold router", () => {
     expect(screen.getByText("1 registro")).toBeInTheDocument();
   });
 
+  it("redirects solicitante away from authorization queue", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(authSession("solicitante"));
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/autorizacoes");
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
+    });
+  });
+
+  it("renders formatted envio timestamp in authorization queue", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return pendingApprovalListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/autorizacoes");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.getByText(formatDateTime("2026-05-01T11:00:00Z"))).toBeInTheDocument();
+  });
+
   it("sends authorization queue pagination from the URL to backend", async () => {
     const requestedUrls: string[] = [];
     vi.stubGlobal(
@@ -936,7 +992,7 @@ describe("frontend scaffold router", () => {
       expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
       expect(container.ownerDocument.location.search).toBe("?contexto=autorizacao");
     });
-    expect(await screen.findByText("Contexto: autorizacao")).toBeInTheDocument();
+    expect(await screen.findByRole("link", { name: "Voltar" })).toHaveAttribute("href", "/autorizacoes");
   });
 
   it("opens canonical requisition detail from the list", async () => {
@@ -1004,6 +1060,29 @@ describe("frontend scaffold router", () => {
     await waitFor(() => {
       expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
     });
+  });
+
+  it("does not render authorization panel outside pending authorization status", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Autorizar ou recusar requisição" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Autorizar tudo como solicitado" })).not.toBeInTheDocument();
   });
 
   it("formats requisition quantities with pt-BR decimal rendering", async () => {
@@ -1075,6 +1154,52 @@ describe("frontend scaffold router", () => {
       });
       expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
     });
+    expect(await screen.findByText("Nenhuma autorização pendente")).toBeInTheDocument();
+  });
+
+  it("preserves authorization page when queue request expires", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return unauthenticatedForbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/autorizacoes?page=2");
+
+    expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/login");
+    expect(container.ownerDocument.location.search).toBe("?redirect=%2Fautorizacoes%3Fpage%3D2");
+  });
+
+  it("keeps permission denied queue errors inside the page", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return forbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/autorizacoes");
+
+    expect(await screen.findByText("Permissão negada.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
   });
 
   it("requires inline justification for partial authorization", async () => {
@@ -1123,6 +1248,54 @@ describe("frontend scaffold router", () => {
           {
             item_id: 501,
             quantidade_autorizada: "1",
+            justificativa_autorizacao_parcial: "Saldo parcial",
+          },
+        ],
+      });
+    });
+  });
+
+  it("normalizes comma decimal separator before sending authorization payload", async () => {
+    let authorizePayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(chefeSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return pendingApprovalDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/authorize/")) {
+        authorizePayload = await request.json();
+        return requisitionDetailResponse({ quantidade_autorizada: "1.500" });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+        return pendingApprovalListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Quantidade autorizada para Papel sulfite A4"), {
+      target: { value: "1,5" },
+    });
+    fireEvent.change(screen.getByLabelText("Justificativa para Papel sulfite A4"), {
+      target: { value: "Saldo parcial" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar conforme ajustes" }));
+
+    await waitFor(() => {
+      expect(authorizePayload).toEqual({
+        itens: [
+          {
+            item_id: 501,
+            quantidade_autorizada: "1.5",
             justificativa_autorizacao_parcial: "Saldo parcial",
           },
         ],

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -108,6 +108,46 @@ function requisitionListResponse(results = [requisitionListItem()]) {
   );
 }
 
+function pendingApprovalListItem(overrides = {}) {
+  return {
+    id: 101,
+    numero_publico: "REQ-2026-000101",
+    status: "aguardando_autorizacao",
+    data_envio_autorizacao: "2026-05-01T11:00:00Z",
+    criador: {
+      id: 10,
+      matricula_funcional: "91003",
+      nome_completo: "Usuario Piloto",
+    },
+    beneficiario: {
+      id: 11,
+      matricula_funcional: "91004",
+      nome_completo: "Beneficiario Piloto",
+    },
+    setor_beneficiario: {
+      id: 2,
+      nome: "Manutencao",
+    },
+    total_itens: 2,
+    ...overrides,
+  };
+}
+
+function pendingApprovalListResponse(results = [pendingApprovalListItem()]) {
+  return new Response(
+    JSON.stringify({
+      count: results.length,
+      page: 1,
+      page_size: 20,
+      total_pages: 1,
+      next: null,
+      previous: null,
+      results,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
 function requisitionDetailResponse(itemOverrides = {}) {
   return new Response(
     JSON.stringify({
@@ -173,6 +213,74 @@ function requisitionDetailResponse(itemOverrides = {}) {
           },
           data_hora: "2026-05-01T12:00:00Z",
           observacao: "Autorizado parcialmente por saldo.",
+        },
+      ],
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function pendingApprovalDetailResponse(itemOverrides = {}) {
+  return new Response(
+    JSON.stringify({
+      id: 101,
+      numero_publico: "REQ-2026-000101",
+      status: "aguardando_autorizacao",
+      criador: {
+        id: 10,
+        matricula_funcional: "91003",
+        nome_completo: "Usuario Piloto",
+      },
+      beneficiario: {
+        id: 11,
+        matricula_funcional: "91004",
+        nome_completo: "Beneficiario Piloto",
+      },
+      setor_beneficiario: {
+        id: 2,
+        nome: "Manutencao",
+      },
+      chefe_autorizador: null,
+      responsavel_atendimento: null,
+      data_criacao: "2026-05-01T10:00:00Z",
+      data_envio_autorizacao: "2026-05-01T11:00:00Z",
+      data_autorizacao_ou_recusa: null,
+      motivo_recusa: "",
+      motivo_cancelamento: "",
+      data_finalizacao: null,
+      retirante_fisico: "",
+      observacao: "Observacao operacional",
+      observacao_atendimento: "",
+      itens: [
+        {
+          id: 501,
+          material: {
+            id: 301,
+            codigo_completo: "010.001.001",
+            nome: "Papel sulfite A4",
+            unidade_medida: "UN",
+          },
+          unidade_medida: "UN",
+          quantidade_solicitada: "2.000",
+          quantidade_autorizada: "0.000",
+          quantidade_entregue: "0.000",
+          justificativa_autorizacao_parcial: "",
+          justificativa_atendimento_parcial: "",
+          observacao: "Urgente",
+          ...itemOverrides,
+        },
+      ],
+      eventos: [
+        {
+          id: 701,
+          tipo_evento: "envio_autorizacao",
+          usuario: {
+            id: 10,
+            matricula_funcional: "91003",
+            nome_completo: "Usuario Piloto",
+          },
+          data_hora: "2026-05-01T11:00:00Z",
+          observacao: "Enviada para avaliação.",
         },
       ],
     }),
@@ -746,6 +854,91 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("renders authorization queue worklist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return pendingApprovalListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/autorizacoes");
+
+    expect(await screen.findByRole("heading", { name: "Fila de autorizações" })).toBeInTheDocument();
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.getByText("Beneficiario Piloto")).toBeInTheDocument();
+    expect(screen.getByText("1 registro")).toBeInTheDocument();
+  });
+
+  it("sends authorization queue pagination from the URL to backend", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        requestedUrls.push(requestUrl(request));
+
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return pendingApprovalListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/autorizacoes?page=2");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    const listUrl = new URL(
+      requestedUrls.find((url) => url.includes("/api/v1/requisitions/pending-approvals/"))!,
+    );
+    expect(listUrl.searchParams.get("page")).toBe("2");
+    expect(listUrl.searchParams.get("page_size")).toBe("20");
+  });
+
+  it("opens canonical requisition detail from authorization queue with context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return pendingApprovalDetailResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return pendingApprovalListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/autorizacoes");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "Abrir" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+      expect(container.ownerDocument.location.search).toBe("?contexto=autorizacao");
+    });
+    expect(await screen.findByText("Contexto: autorizacao")).toBeInTheDocument();
+  });
+
   it("opens canonical requisition detail from the list", async () => {
     vi.stubGlobal(
       "fetch",
@@ -839,6 +1032,186 @@ describe("frontend scaffold router", () => {
     expect(screen.getByText("2,5 UN")).toBeInTheDocument();
     expect(screen.getByText("1,25 UN")).toBeInTheDocument();
     expect(screen.getByText("0,125 UN")).toBeInTheDocument();
+  });
+
+  it("authorizes all requested items from authorization context", async () => {
+    let authorizePayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(chefeSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return pendingApprovalDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/authorize/")) {
+        authorizePayload = await request.json();
+        return requisitionDetailResponse({ quantidade_autorizada: "2.000" });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+        return pendingApprovalListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar tudo como solicitado" }));
+
+    await waitFor(() => {
+      expect(authorizePayload).toEqual({
+        itens: [
+          {
+            item_id: 501,
+            quantidade_autorizada: "2.000",
+            justificativa_autorizacao_parcial: "",
+          },
+        ],
+      });
+      expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
+  });
+
+  it("requires inline justification for partial authorization", async () => {
+    let authorizePayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(chefeSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return pendingApprovalDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/authorize/")) {
+        authorizePayload = await request.json();
+        return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+        return pendingApprovalListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Quantidade autorizada para Papel sulfite A4"), {
+      target: { value: "1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar conforme ajustes" }));
+
+    expect(await screen.findByText("Informe justificativa para autorização parcial ou zerada.")).toBeInTheDocument();
+    expect(authorizePayload).toBeUndefined();
+
+    fireEvent.change(screen.getByLabelText("Justificativa para Papel sulfite A4"), {
+      target: { value: "Saldo parcial" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar conforme ajustes" }));
+
+    await waitFor(() => {
+      expect(authorizePayload).toEqual({
+        itens: [
+          {
+            item_id: 501,
+            quantidade_autorizada: "1",
+            justificativa_autorizacao_parcial: "Saldo parcial",
+          },
+        ],
+      });
+    });
+  });
+
+  it("refuses a requisition only with a reason", async () => {
+    let refusePayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(chefeSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return pendingApprovalDetailResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/refuse/")) {
+        refusePayload = await request.json();
+        return requisitionDetailResponse();
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+        return pendingApprovalListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Recusar requisição" }));
+
+    expect(await screen.findByText("Informe o motivo da recusa.")).toBeInTheDocument();
+    expect(refusePayload).toBeUndefined();
+
+    fireEvent.change(screen.getByLabelText("Motivo da recusa"), {
+      target: { value: "Pedido fora do escopo do setor" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Recusar requisição" }));
+
+    await waitFor(() => {
+      expect(refusePayload).toEqual({
+        motivo_recusa: "Pedido fora do escopo do setor",
+      });
+      expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
+  });
+
+  it("keeps user on detail when authorization action returns domain error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return pendingApprovalDetailResponse();
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/authorize/")) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "domain_conflict",
+                message: "Saldo atual insuficiente.",
+                details: {},
+                trace_id: "trace-domain",
+              },
+            }),
+            { status: 409, headers: jsonHeaders },
+          );
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar tudo como solicitado" }));
+
+    expect(await screen.findByText("Saldo atual insuficiente.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
   });
 
   it("creates draft requisition for the current user", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -1180,6 +1180,28 @@ describe("frontend scaffold router", () => {
     expect(container.ownerDocument.location.search).toBe("?redirect=%2Fautorizacoes%3Fpage%3D2");
   });
 
+  it("does not render empty state while redirecting authorization queue auth error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return unauthenticatedForbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/autorizacoes");
+
+    expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+    expect(screen.queryByText("Nenhuma autorização pendente")).not.toBeInTheDocument();
+  });
+
   it("keeps permission denied queue errors inside the page", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1385,6 +1407,73 @@ describe("frontend scaffold router", () => {
 
     expect(await screen.findByText("Saldo atual insuficiente.")).toBeInTheDocument();
     expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+  });
+
+  it("redirects to login when authorize returns unauthenticated error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return pendingApprovalDetailResponse();
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/authorize/")) {
+          return unauthenticatedResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao&page=2");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Autorizar tudo como solicitado" }));
+
+    expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/login");
+    expect(container.ownerDocument.location.search).toBe(
+      "?redirect=%2Frequisicoes%2F101%3Fcontexto%3Dautorizacao%26page%3D2",
+    );
+  });
+
+  it("redirects to login when refuse returns unauthenticated error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return pendingApprovalDetailResponse();
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/refuse/")) {
+          return unauthenticatedForbiddenResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=autorizacao&page=2");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Motivo da recusa"), {
+      target: { value: "Sessão expirou antes da decisão" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Recusar requisição" }));
+
+    expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/login");
+    expect(container.ownerDocument.location.search).toBe(
+      "?redirect=%2Frequisicoes%2F101%3Fcontexto%3Dautorizacao%26page%3D2",
+    );
   });
 
   it("creates draft requisition for the current user", async () => {


### PR DESCRIPTION
@coderabbitai ignore

<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Implementa a fila de autorizações na SPA do piloto com paginação, tabela operacional e acesso ao detalhe canônico.
- Adiciona ações de autorizar e recusar a requisição no contexto de autorização.
- Atualiza estilos e smoke tests para cobrir a jornada de lista, detalhe e ações.

## Por que esta mudança é necessária
- Entrega a primeira worklist operacional da SPA, necessária para a chefia de setor decidir requisições pendentes sem depender do admin ou de fluxos incompletos.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
- Acesso indevido ou fluxo incorreto na fila de autorizações se o guard de sessão, o contexto do detalhe ou os retornos de erro não estiverem alinhados ao backend.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: `autorizacoes` e detalhe em `?contexto=autorizacao`.
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas: ação de autorizar/recusar no detalhe canônico.
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `rtk make frontend-lint` passou.
3. Smoke tests cobrem fila, detalhe e ações de autorização.

## Como validar manualmente
- Abrir `/autorizacoes` com sessão de chefe de setor.
- Abrir uma requisição em `?contexto=autorizacao` e validar autorizar/recusar.
- Confirmar redirect previsível para `/login` quando a sessão expirar.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Objetivo da mudança
  - Entregar na SPA a primeira worklist operacional de autorizações (/autorizacoes) com paginação, tabela, navegação para detalhe canônico em contexto ?contexto=autorizacao e painel de decisão para autorizar/recusar com chamadas API correspondentes.

- Apps Django impactados
  - apps.requisitions — novos contratos/handlers esperados: pending-approvals (GET paginado), authorize (POST), refuse (POST); novos serializers/outputs paginados.
  - apps.users / auth — validação de papéis operacionais por setor (chefe_setor, chefe_almoxarifado) deve existir no backend.

- Risco funcional
  - MÉDIO/ALTO em pontos críticos: exposição indevida entre setores, falha de autorização contextual, fluxo de autorização sem revalidação no backend e condições de corrida ao reservar saldos. Frontend aplica guards, mas backend deve ser fonte da verdade.

- Impacto em regras de negócio
  - Introduz jornada AGUARDANDO_AUTORIZACAO → AUTORIZADA (com reserva) ou RECUSADA; regras: autorização parcial/zero requer justificativa, recusa exige motivo, “autorizar tudo” envia quantidades autorizadas por item.
  - Side-effect crítico: autorização aciona lógica de reserva/alteração de saldos.

- Impacto em autenticação/autorizações/escopo por perfil e setor
  - Novo contexto URL ?contexto=autorizacao; acesso à fila e ao painel restrito a papeis operacionais (chefe_setor, chefe_almoxarifado).
  - Frontend impede superusuário operar a fila operacional — backend deve também aplicar restrição por papel e setor.
  - Tratamento de 401/403 no frontend limpa sessão e redireciona para /login mantendo redirect com ?contexto e page quando aplicável.

- Impacto em contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Novos endpoints consumidores esperados:
    - GET /api/.../pending-approvals/?page=&page_size= → resposta paginada compatível com RequisicaoPendingApprovalPaginated.
    - POST /api/.../requisitions/{id}/authorize/ com payload itens (item_id, quantidade_autorizada como string decimal normalizada, justificativa_parcial).
    - POST /api/.../requisitions/{id}/refuse/ com motivo_recusa.
  - Frontend depende de envelope de erro com códigos/status para distinguir 401/403/409 e mensagem de domínio (ex.: 409 mantém usuário na página).
  - Validar OpenAPI/serializers para tipos (quantidades como string decimal) e esquema de paginação esperado.

- Impacto em integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Cada decisão deve gerar evento/timeline auditável (usuário, timestamp, justificativas) e registrar movimentos/reservas de forma imutável para preservar histórico.
  - Risco de quebra de rastreabilidade se reservas/alterações não criarem snapshots ou registros auditáveis.

- Impacto em transações, concorrência, idempotência, saldos (físico/reservado/disponível)
  - Autorização precisa de transação atômica e locks (select_for_update()/transaction.atomic()) ao criar reservas para evitar over-reservation; reentrância/retries devem ser idempotentes ou detectar conflitos (409).
  - Possível necessidade de controle para evitar deadlocks e garantir ordem de locks quando múltiplas autorizações ocorrem concurrentemente.

- Impacto em importação SCPI, dados oficiais de materiais ou divergência de estoque
  - Sem alteração explícita em importações SCPI, mas reservas provenientes da autorização podem afetar disponibilidade usada por integrações — checar efeitos sobre processos que consomem saldo reservado.

- Impacto em configuração, CI, dependências, lint, testes ou ambiente efêmero
  - Frontend: sem novas dependências de runtime; lint e checks passaram; smoke tests frontend adicionados e ampliam cobertura de lista→detalhe→ações.
  - Testes backend de concorrência/autorizações foram mencionados (sinal de preocupação), revisar que CI os execute.

- Como validar manualmente (API, admin, comando ou teste automatizado)
  - API:
    - GET pending-approvals como chefe de setor → apenas requisições AGUARDANDO_AUTORIZACAO do setor, com paginação.
    - POST authorize com payload de itens (quantidade como "12.34") → 200 e status AUTORIZADA; confirmar reservas criadas; 409 em conflito de domínio.
    - POST refuse com motivo → 200 e status RECUSADA; sem reserva.
    - Verificar 401/403 redirecionando e preservando redirect ?contexto=autorizacao&page.
  - Frontend:
    - Acesse /autorizacoes como chefe: validar paginação, colunas, “Abrir” envia ?contexto=autorizacao e page quando aplicável.
    - No detalhe com contexto: AuthorizationDecisionPanel aparece somente se status == aguardando_autorizacao; testar autorizar tudo, autorização parcial (requer justificativa), recusar (requer motivo), vírgula→ponto na normalização de quantidades.
    - Forçar 409 e confirmar UI mostra erro e não navega embora.
  - Testes:
    - Executar smoke tests adicionados e testes backend de concorrência/autorizações.

- Pontos prioritários a revisar antes de aprovar (backend)
  - Garantir revalidação de papel e setor no backend para todos os endpoints novos.
  - Assegurar transação/lock atômico ao reservar saldos e que operações sejam idempotentes ou retornem 409 em conflitos.
  - Confirmar criação de eventos/histórico/auditoria para cada decisão e imutabilidade dos registros de movimentação.
  - Validar OpenAPI/serializers (tipos de quantidade como string decimal) e envelope de erro esperado pelo frontend.
  - Verificar que mudanças não introduzem N+1 e que consultas críticas usam select_related/prefetch quando necessário.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/57)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->