### PR TITLE
[codex] Frontend piloto: atendimento e retorno do detalhe

### DIFF
--- a/frontend/src/features/requisitions/requisitions.ts
+++ b/frontend/src/features/requisitions/requisitions.ts
@@ -14,8 +14,14 @@ export type RequisicaoTimelineEventType = components["schemas"]["TipoEventoEnum"
 export type RequisicaoDraftInput = components["schemas"]["RequisicaoCreateInput"];
 export type RequisicaoAuthorizeInput = components["schemas"]["RequisicaoAuthorizeInput"];
 export type RequisicaoRefuseInput = components["schemas"]["RequisicaoRefuseInput"];
+export type RequisicaoFulfillInput = components["schemas"]["RequisicaoFulfillInput"];
+export type RequisicaoCancelInput = components["schemas"]["RequisicaoCancelInput"];
 export type RequisicaoPendingApprovalItem = components["schemas"]["RequisicaoPendingApprovalOutput"];
 export type RequisicaoPendingApprovalResponse = components["schemas"]["RequisicaoPendingApprovalPaginated"];
+export type RequisicaoPendingFulfillmentItem =
+  components["schemas"]["RequisicaoPendingFulfillmentOutput"];
+export type RequisicaoPendingFulfillmentResponse =
+  components["schemas"]["RequisicaoPendingFulfillmentPaginated"];
 export type MaterialListItem = components["schemas"]["MaterialListOutput"];
 export type MaterialListResponse = components["schemas"]["MaterialListPaginated"];
 export type BeneficiaryLookupItem = components["schemas"]["BeneficiaryLookupOutput"];
@@ -57,8 +63,17 @@ export type PendingApprovalsParams = {
   pageSize: number;
 };
 
+export type PendingFulfillmentsParams = {
+  page: number;
+  pageSize: number;
+};
+
 const requisitionsBaseQueryKey = ["requisitions"] as const;
 const pendingApprovalsBaseQueryKey = [...requisitionsBaseQueryKey, "pending-approvals"] as const;
+const pendingFulfillmentsBaseQueryKey = [
+  ...requisitionsBaseQueryKey,
+  "pending-fulfillments",
+] as const;
 
 export const requisitionsQueryKeys = {
   all: requisitionsBaseQueryKey,
@@ -74,9 +89,18 @@ export const requisitionsQueryKeys = {
       },
     ] as const,
   pendingApprovalsAll: pendingApprovalsBaseQueryKey,
+  pendingFulfillmentsAll: pendingFulfillmentsBaseQueryKey,
   pendingApprovals: (params: PendingApprovalsParams) =>
     [
       ...pendingApprovalsBaseQueryKey,
+      {
+        page: params.page,
+        pageSize: params.pageSize,
+      },
+    ] as const,
+  pendingFulfillments: (params: PendingFulfillmentsParams) =>
+    [
+      ...pendingFulfillmentsBaseQueryKey,
       {
         page: params.page,
         pageSize: params.pageSize,
@@ -128,6 +152,30 @@ export async function fetchPendingApprovals(params: PendingApprovalsParams) {
   if (error || !data) {
     throw new ApiError(
       messageFromError(error, "Não foi possível carregar autorizações pendentes."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function fetchPendingFulfillments(params: PendingFulfillmentsParams) {
+  const { data, error, response } = await apiClient.GET(
+    "/api/v1/requisitions/pending-fulfillments/",
+    {
+      params: {
+        query: {
+          page: params.page,
+          page_size: params.pageSize,
+        },
+      },
+    },
+  );
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar atendimentos pendentes."),
       response.status,
       error,
     );
@@ -190,6 +238,48 @@ export async function refuseRequisition(id: number, input: RequisicaoRefuseInput
   if (error || !data) {
     throw new ApiError(
       messageFromError(error, "Não foi possível recusar a requisição."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function fulfillRequisition(id: number, input: RequisicaoFulfillInput) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/fulfill/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível registrar atendimento."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function cancelAuthorizedRequisition(id: number, input: RequisicaoCancelInput) {
+  const { data, error, response } = await apiClient.POST("/api/v1/requisitions/{id}/cancel/", {
+    params: {
+      path: {
+        id,
+      },
+    },
+    body: input,
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível cancelar a requisição."),
       response.status,
       error,
     );
@@ -350,6 +440,15 @@ export function pendingApprovalsQueryOptions(params: PendingApprovalsParams) {
   return queryOptions({
     queryKey: requisitionsQueryKeys.pendingApprovals(params),
     queryFn: () => fetchPendingApprovals(params),
+    placeholderData: keepPreviousData,
+    retry: retryUnlessClientOrAuthError,
+  });
+}
+
+export function pendingFulfillmentsQueryOptions(params: PendingFulfillmentsParams) {
+  return queryOptions({
+    queryKey: requisitionsQueryKeys.pendingFulfillments(params),
+    queryFn: () => fetchPendingFulfillments(params),
     placeholderData: keepPreviousData,
     retry: retryUnlessClientOrAuthError,
   });

--- a/frontend/src/routes/atendimentos.tsx
+++ b/frontend/src/routes/atendimentos.tsx
@@ -1,44 +1,281 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
+import {
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+  type ColumnDef,
+} from "@tanstack/react-table";
+import { z } from "zod";
 
-import { requireSession } from "../features/auth/guards";
-import { FeaturePlaceholder } from "../shared/ui/feature-placeholder";
+import { requireOperationalPapel } from "../features/auth/guards";
+import { authQueryKeys, isUnauthenticatedError } from "../features/auth/session";
+import {
+  formatDateTime,
+  pendingFulfillmentsQueryOptions,
+  queryErrorMessage,
+  statusLabel,
+  type RequisicaoPendingFulfillmentItem,
+} from "../features/requisitions/requisitions";
 
-export const Route = createFileRoute("/atendimentos")({
-  beforeLoad: ({ context, location }) =>
-    requireSession({ queryClient: context.queryClient, locationHref: location.href }),
-  component: AtendimentosPlaceholderPage,
+const DEFAULT_PAGE_SIZE = 20;
+
+const fulfillmentSearchSchema = z.object({
+  page: z.coerce.number().int().min(1).optional().catch(undefined),
 });
 
-function AtendimentosPlaceholderPage() {
+export const Route = createFileRoute("/atendimentos")({
+  validateSearch: fulfillmentSearchSchema,
+  beforeLoad: ({ context, location }) =>
+    requireOperationalPapel({
+      allowedPapeis: ["auxiliar_almoxarifado", "chefe_almoxarifado"],
+      queryClient: context.queryClient,
+      locationHref: location.href,
+    }),
+  component: AtendimentosPage,
+});
+
+function EmptyState() {
   return (
-    <FeaturePlaceholder
-      kicker="Fulfillment queue"
-      title="Fila de atendimento"
-      summary="Fila operacional do Almoxarifado pronta para receber atendimento total, parcial e leitura contextual do detalhe. Ainda sem side effects reais nesta fatia."
-      nextSlice="#41 — fila e fluxo de atendimento"
-      contracts={[
-        "GET /api/v1/requisitions/pending-fulfillments/",
-        "GET /api/v1/requisitions/{id}/",
-        "POST /api/v1/requisitions/{id}/fulfill/",
-      ]}
-      bullets={[
-        "Fila global do Almoxarifado, não por setor individual.",
-        "Detalhe entra em modo `contexto=atendimento`.",
-        "Exceções operacionais ficam para o bloco funcional, não para o scaffold.",
-      ]}
-      preview={
-        <div className="preview-panel">
-          <div className="preview-row">
-            <span>REQ-2026-0020</span>
-            <span className="preview-meta">autorizada</span>
+    <div className="empty-state">
+      <p className="eyebrow">Sem pendências</p>
+      <h2>Nenhum atendimento pendente</h2>
+      <p>A fila mostra requisições autorizadas aguardando retirada pelo Almoxarifado.</p>
+    </div>
+  );
+}
+
+function recordsLabelForList({
+  count,
+  hasError,
+  isLoading,
+}: {
+  count: number | undefined;
+  hasError: boolean;
+  isLoading: boolean;
+}) {
+  if (isLoading) {
+    return "Carregando...";
+  }
+
+  if (hasError) {
+    return "Erro ao carregar";
+  }
+
+  if (typeof count === "number") {
+    return `${count} ${count === 1 ? "registro" : "registros"}`;
+  }
+
+  return "0 registros";
+}
+
+function AtendimentosPage() {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/atendimentos" });
+  const searchParams = Route.useSearch();
+  const currentPage = searchParams.page ?? 1;
+  const listQuery = useQuery(
+    pendingFulfillmentsQueryOptions({
+      page: currentPage,
+      pageSize: DEFAULT_PAGE_SIZE,
+    }),
+  );
+  const authError = listQuery.isError && isUnauthenticatedError(listQuery.error);
+  const rows = listQuery.data?.results ?? [];
+  const recordsLabel = recordsLabelForList({
+    count: listQuery.data?.count,
+    hasError: listQuery.isError && !listQuery.data,
+    isLoading: listQuery.isLoading,
+  });
+  const columns = useMemo<ColumnDef<RequisicaoPendingFulfillmentItem>[]>(
+    () => [
+      {
+        id: "identifier",
+        header: "Requisição",
+        cell: ({ row }) => (
+          <div className="min-w-[11rem]">
+            <span className="font-semibold text-[var(--ink-strong)]">
+              {row.original.numero_publico ?? `#${row.original.id}`}
+            </span>
+            <p className="mt-2 text-xs uppercase tracking-[0.18em] text-[var(--ink-muted)]">
+              {row.original.total_itens} {row.original.total_itens === 1 ? "item" : "itens"}
+            </p>
           </div>
-          <div className="preview-row">
-            <span>REQ-2026-0021</span>
-            <span className="preview-meta">retirante pendente</span>
+        ),
+      },
+      {
+        id: "status",
+        header: "Status",
+        cell: ({ row }) => (
+          <span className={`req-status req-status-${row.original.status}`}>
+            {statusLabel(row.original.status)}
+          </span>
+        ),
+      },
+      {
+        id: "beneficiario",
+        header: "Beneficiário",
+        cell: ({ row }) => (
+          <div>
+            <p className="font-semibold">{row.original.beneficiario.nome_completo}</p>
+            <p className="mt-1 text-sm text-[var(--ink-soft)]">
+              {row.original.setor_beneficiario.nome}
+            </p>
           </div>
-          <div className="preview-badge">contexto=atendimento</div>
+        ),
+      },
+      {
+        id: "authorizer",
+        header: "Autorizador",
+        cell: ({ row }) => <span>{row.original.chefe_autorizador.nome_completo}</span>,
+      },
+      {
+        id: "authorized_at",
+        header: "Autorização",
+        cell: ({ row }) => (
+          <span className="text-sm text-[var(--ink-soft)]">
+            {formatDateTime(row.original.data_autorizacao_ou_recusa)}
+          </span>
+        ),
+      },
+      {
+        id: "actions",
+        header: "",
+        cell: ({ row }) => (
+          <Link
+            className="action-link compact-action"
+            params={{ id: String(row.original.id) }}
+            search={{ contexto: "atendimento", page: currentPage === 1 ? undefined : currentPage }}
+            to="/requisicoes/$id"
+          >
+            Abrir
+          </Link>
+        ),
+      },
+    ],
+    [currentPage],
+  );
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    columns,
+    data: rows,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    rowCount: listQuery.data?.count ?? 0,
+    state: {
+      pagination: {
+        pageIndex: currentPage - 1,
+        pageSize: DEFAULT_PAGE_SIZE,
+      },
+    },
+  });
+
+  function goToPage(page: number) {
+    void navigate({
+      search: {
+        page: page === 1 ? undefined : page,
+      },
+    });
+  }
+
+  useEffect(() => {
+    if (!authError) {
+      return;
+    }
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: currentPage === 1 ? "/atendimentos" : `/atendimentos?page=${currentPage}`,
+      },
+    });
+  }, [authError, currentPage, navigate, queryClient]);
+
+  if (authError) {
+    return null;
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="worklist-header">
+        <div>
+          <p className="eyebrow">Worklist operacional</p>
+          <h1>Fila de atendimento</h1>
+          <p>Requisições autorizadas aguardando retirada pelo Almoxarifado.</p>
         </div>
-      }
-    />
+        <div className="status-chip">
+          <span className="status-dot" />
+          {recordsLabel}
+        </div>
+      </div>
+
+      {listQuery.isError ? (
+        <div className="error-panel">
+          {queryErrorMessage(listQuery.error, "Não foi possível carregar atendimentos pendentes.")}
+        </div>
+      ) : null}
+
+      {!listQuery.isError ? (
+        <div className="table-frame">
+          {listQuery.isPending ? (
+            <div className="loading-state">Carregando atendimentos...</div>
+          ) : rows.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <table className="operational-table">
+              <thead>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <tr key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => (
+                      <th key={header.id}>
+                        {flexRender(header.column.columnDef.header, header.getContext())}
+                      </th>
+                    ))}
+                  </tr>
+                ))}
+              </thead>
+              <tbody>
+                {table.getRowModel().rows.map((row) => (
+                  <tr key={row.id}>
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id}>
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      ) : null}
+
+      <div className="pagination-bar">
+        <button
+          className="action-link compact-action"
+          disabled={currentPage <= 1 || listQuery.isPending}
+          onClick={() => goToPage(currentPage - 1)}
+          type="button"
+        >
+          Anterior
+        </button>
+        <span>
+          Página {listQuery.data?.page ?? currentPage} de {listQuery.data?.total_pages ?? 1}
+        </span>
+        <button
+          className="action-link compact-action"
+          disabled={
+            listQuery.isPending ||
+            !listQuery.data ||
+            currentPage >= listQuery.data.total_pages
+          }
+          onClick={() => goToPage(currentPage + 1)}
+          type="button"
+        >
+          Próxima
+        </button>
+      </div>
+    </section>
   );
 }

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -11,23 +11,27 @@ import {
 } from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
 import {
-    authorizeRequisition,
-    displayRequisitionIdentifier,
-    formatDateTime,
-    formatQuantity,
-    isThirdPartyBeneficiary,
-    queryErrorMessage,
-    refuseRequisition,
-    requisitionDetailQueryOptions,
-    requisitionsQueryKeys,
-    statusLabel,
-    tipoEventoLabel,
-    type RequisicaoActionItem,
-    type RequisicaoAuthorizeInput,
-    type RequisicaoDetail,
-    type RequisicaoRefuseInput,
-    type RequisicaoTimelineEvent,
-  } from "../../features/requisitions/requisitions";
+  authorizeRequisition,
+  cancelAuthorizedRequisition,
+  displayRequisitionIdentifier,
+  formatDateTime,
+  formatQuantity,
+  fulfillRequisition,
+  isThirdPartyBeneficiary,
+  queryErrorMessage,
+  refuseRequisition,
+  requisitionDetailQueryOptions,
+  requisitionsQueryKeys,
+  statusLabel,
+  tipoEventoLabel,
+  type RequisicaoActionItem,
+  type RequisicaoAuthorizeInput,
+  type RequisicaoCancelInput,
+  type RequisicaoDetail,
+  type RequisicaoFulfillInput,
+  type RequisicaoRefuseInput,
+  type RequisicaoTimelineEvent,
+} from "../../features/requisitions/requisitions";
 
 const detailSearchSchema = z.object({
   contexto: z.enum(["autorizacao", "atendimento"]).optional().catch(undefined),
@@ -40,6 +44,15 @@ export const Route = createFileRoute("/requisicoes/$id")({
     if (search.contexto === "autorizacao") {
       await requireOperationalPapel({
         allowedPapeis: ["chefe_setor", "chefe_almoxarifado"],
+        queryClient: context.queryClient,
+        locationHref: location.href,
+      });
+      return;
+    }
+
+    if (search.contexto === "atendimento") {
+      await requireOperationalPapel({
+        allowedPapeis: ["auxiliar_almoxarifado", "chefe_almoxarifado"],
         queryClient: context.queryClient,
         locationHref: location.href,
       });
@@ -102,6 +115,14 @@ type AuthorizationItemForm = {
   justification: string;
 };
 
+type FulfillmentItemForm = {
+  itemId: number;
+  label: string;
+  authorizedQuantity: string;
+  deliveredQuantity: string;
+  justification: string;
+};
+
 function quantityNumber(value: string) {
   const normalizedValue = value.replace(",", ".").trim();
   if (!normalizedValue) {
@@ -115,20 +136,22 @@ function normalizeQuantityInput(value: string) {
 }
 
 function buildRequisicaoRedirect({
-  authorizationPage,
+  sourcePage,
   contexto,
   id,
 }: {
-  authorizationPage: number | undefined;
+  sourcePage: number | undefined;
   contexto: "autorizacao" | "atendimento" | undefined;
   id: string;
 }) {
+  const pageSearch = sourcePage && sourcePage > 1 ? `&page=${sourcePage}` : "";
+
   if (contexto === "autorizacao") {
-    return `/requisicoes/${id}?contexto=autorizacao${authorizationPage && authorizationPage > 1 ? `&page=${authorizationPage}` : ""}`;
+    return `/requisicoes/${id}?contexto=autorizacao${pageSearch}`;
   }
 
   if (contexto === "atendimento") {
-    return `/requisicoes/${id}?contexto=atendimento`;
+    return `/requisicoes/${id}?contexto=atendimento${pageSearch}`;
   }
 
   return `/requisicoes/${id}`;
@@ -146,6 +169,22 @@ function authorizationItemsFromRequisition(requisicao: RequisicaoDetail): Author
     authorizedQuantity: item.quantidade_solicitada,
     justification: item.justificativa_autorizacao_parcial,
   }));
+}
+
+function fulfillmentItemLabel(item: RequisicaoActionItem) {
+  return item.material.nome;
+}
+
+function fulfillmentItemsFromRequisition(requisicao: RequisicaoDetail): FulfillmentItemForm[] {
+  return requisicao.itens
+    .filter((item) => quantityNumber(item.quantidade_autorizada) > 0)
+    .map((item) => ({
+      itemId: item.id,
+      label: fulfillmentItemLabel(item),
+      authorizedQuantity: item.quantidade_autorizada,
+      deliveredQuantity: item.quantidade_entregue,
+      justification: item.justificativa_atendimento_parcial,
+    }));
 }
 
 function AuthorizationDecisionPanel({
@@ -173,7 +212,7 @@ function AuthorizationDecisionPanel({
         redirect: buildRequisicaoRedirect({
           id: String(requisicao.id),
           contexto: "autorizacao",
-          authorizationPage,
+          sourcePage: authorizationPage,
         }),
       },
     });
@@ -391,9 +430,284 @@ function AuthorizationDecisionPanel({
   );
 }
 
+function FulfillmentDecisionPanel({
+  fulfillmentPage,
+  requisicao,
+}: {
+  fulfillmentPage: number | undefined;
+  requisicao: RequisicaoDetail;
+}) {
+  const [items, setItems] = useState(() => fulfillmentItemsFromRequisition(requisicao));
+  const [retiranteFisico, setRetiranteFisico] = useState("");
+  const [observacaoAtendimento, setObservacaoAtendimento] = useState("");
+  const [motivoCancelamento, setMotivoCancelamento] = useState("");
+  const [validationError, setValidationError] = useState("");
+  const queryClient = useQueryClient();
+  const navigate = useNavigate({ from: "/requisicoes/$id" });
+
+  function redirectToLoginAfterAuthError(error: unknown) {
+    if (!isUnauthenticatedError(error)) {
+      return;
+    }
+
+    queryClient.removeQueries({ queryKey: authQueryKeys.me });
+    void navigate({
+      to: "/login",
+      search: {
+        redirect: buildRequisicaoRedirect({
+          id: String(requisicao.id),
+          contexto: "atendimento",
+          sourcePage: fulfillmentPage,
+        }),
+      },
+    });
+  }
+
+  async function afterDecisionSuccess() {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.pendingFulfillmentsAll }),
+      queryClient.invalidateQueries({ queryKey: requisitionsQueryKeys.detail(requisicao.id) }),
+    ]);
+    await navigate({
+      to: "/atendimentos",
+      search: {
+        page: fulfillmentPage && fulfillmentPage > 1 ? fulfillmentPage : undefined,
+      },
+    });
+  }
+
+  const fulfillMutation = useMutation({
+    mutationFn: (input: RequisicaoFulfillInput) => fulfillRequisition(requisicao.id, input),
+    onError: redirectToLoginAfterAuthError,
+    onSuccess: afterDecisionSuccess,
+  });
+  const cancelMutation = useMutation({
+    mutationFn: (input: RequisicaoCancelInput) =>
+      cancelAuthorizedRequisition(requisicao.id, input),
+    onError: redirectToLoginAfterAuthError,
+    onSuccess: afterDecisionSuccess,
+  });
+  const pending = fulfillMutation.isPending || cancelMutation.isPending;
+  const mutationError = fulfillMutation.error ?? cancelMutation.error;
+
+  function resetDecisionFeedback() {
+    setValidationError("");
+    fulfillMutation.reset();
+    cancelMutation.reset();
+  }
+
+  function updateItem(itemId: number, field: "deliveredQuantity" | "justification", value: string) {
+    setItems((currentItems) =>
+      currentItems.map((item) => (item.itemId === itemId ? { ...item, [field]: value } : item)),
+    );
+    resetDecisionFeedback();
+  }
+
+  function fillCompleteDelivery() {
+    setItems((currentItems) =>
+      currentItems.map((item) => ({
+        ...item,
+        deliveredQuantity: item.authorizedQuantity,
+        justification: "",
+      })),
+    );
+    resetDecisionFeedback();
+  }
+
+  function payloadFromItems(nextItems: FulfillmentItemForm[]): RequisicaoFulfillInput {
+    return {
+      retirante_fisico: retiranteFisico.trim(),
+      observacao_atendimento: observacaoAtendimento.trim(),
+      itens: nextItems.map((item) => ({
+        item_id: item.itemId,
+        quantidade_entregue: normalizeQuantityInput(item.deliveredQuantity),
+        justificativa_atendimento_parcial: item.justification.trim(),
+      })),
+    };
+  }
+
+  function validateFulfillment(nextItems: FulfillmentItemForm[]) {
+    const deliveredQuantities = nextItems.map((item) => quantityNumber(item.deliveredQuantity));
+
+    if (deliveredQuantities.some((quantity) => Number.isNaN(quantity) || quantity < 0)) {
+      return "Informe quantidades entregues válidas.";
+    }
+
+    const itemAboveAuthorized = nextItems.find(
+      (item) => quantityNumber(item.deliveredQuantity) > quantityNumber(item.authorizedQuantity),
+    );
+
+    if (itemAboveAuthorized) {
+      return "Quantidade entregue não pode exceder a quantidade autorizada.";
+    }
+
+    if (deliveredQuantities.every((quantity) => quantity === 0)) {
+      return "Atendimento deve entregar ao menos um item.";
+    }
+
+    const partialWithoutJustification = nextItems.find(
+      (item) =>
+        quantityNumber(item.deliveredQuantity) < quantityNumber(item.authorizedQuantity) &&
+        !item.justification.trim(),
+    );
+
+    if (partialWithoutJustification) {
+      return "Informe justificativa para atendimento parcial ou zerado.";
+    }
+
+    return "";
+  }
+
+  function fulfill(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    resetDecisionFeedback();
+    const error = validateFulfillment(items);
+
+    if (error) {
+      setValidationError(error);
+      return;
+    }
+
+    fulfillMutation.mutate(payloadFromItems(items));
+  }
+
+  function cancel(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    resetDecisionFeedback();
+    const trimmedReason = motivoCancelamento.trim();
+
+    if (!trimmedReason) {
+      setValidationError("Informe o motivo do cancelamento.");
+      return;
+    }
+
+    cancelMutation.mutate({ motivo_cancelamento: trimmedReason });
+  }
+
+  return (
+    <section className="detail-panel authorization-panel">
+      <div className="authorization-panel-header">
+        <div>
+          <p className="eyebrow">Atendimento do Almoxarifado</p>
+          <h2>Registrar atendimento</h2>
+          <p>O backend revalida estoque, reserva, estado e permissão no momento da retirada.</p>
+        </div>
+        <button
+          className="preview-button draft-primary"
+          disabled={pending}
+          onClick={fillCompleteDelivery}
+          type="button"
+        >
+          Preencher entrega completa
+        </button>
+      </div>
+
+      {validationError ? <div className="error-panel compact-error">{validationError}</div> : null}
+      {mutationError ? (
+        <div className="error-panel compact-error">
+          {queryErrorMessage(mutationError, "Não foi possível concluir a ação de atendimento.")}
+        </div>
+      ) : null}
+
+      <form className="authorization-form" onSubmit={fulfill}>
+        <div className="authorization-item-fields">
+          <label className="preview-label">
+            Retirante físico
+            <input
+              className="preview-input"
+              disabled={pending}
+              onChange={(event) => {
+                setRetiranteFisico(event.target.value);
+                resetDecisionFeedback();
+              }}
+              value={retiranteFisico}
+            />
+          </label>
+          <label className="preview-label">
+            Observação do atendimento
+            <textarea
+              className="preview-input"
+              disabled={pending}
+              onChange={(event) => {
+                setObservacaoAtendimento(event.target.value);
+                resetDecisionFeedback();
+              }}
+              rows={3}
+              value={observacaoAtendimento}
+            />
+          </label>
+        </div>
+
+        <div className="authorization-items">
+          {items.map((item) => (
+            <article className="draft-item-card" key={item.itemId}>
+              <div>
+                <h2>{item.label}</h2>
+                <p>Autorizado: {formatQuantity(item.authorizedQuantity)}</p>
+              </div>
+              <div className="authorization-item-fields">
+                <label className="preview-label">
+                  Quantidade entregue para {item.label}
+                  <input
+                    className="preview-input"
+                    disabled={pending}
+                    inputMode="decimal"
+                    onChange={(event) =>
+                      updateItem(item.itemId, "deliveredQuantity", event.target.value)
+                    }
+                    value={item.deliveredQuantity}
+                  />
+                </label>
+                <label className="preview-label">
+                  Justificativa de atendimento para {item.label}
+                  <textarea
+                    className="preview-input"
+                    disabled={pending}
+                    onChange={(event) => updateItem(item.itemId, "justification", event.target.value)}
+                    placeholder="Obrigatória quando parcial ou zerada"
+                    rows={3}
+                    value={item.justification}
+                  />
+                </label>
+              </div>
+            </article>
+          ))}
+        </div>
+
+        <div className="draft-actions">
+          <button className="preview-button draft-primary" disabled={pending} type="submit">
+            {pending ? "Registrando..." : "Registrar atendimento"}
+          </button>
+        </div>
+      </form>
+
+      <form className="authorization-refusal" onSubmit={cancel}>
+        <label className="preview-label">
+          Motivo do cancelamento operacional
+          <textarea
+            className="preview-input draft-textarea"
+            disabled={pending}
+            onChange={(event) => {
+              setMotivoCancelamento(event.target.value);
+              resetDecisionFeedback();
+            }}
+            rows={3}
+            value={motivoCancelamento}
+          />
+        </label>
+        <div className="draft-actions">
+          <button className="preview-button draft-primary danger-action" disabled={pending} type="submit">
+            Cancelar requisição autorizada
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}
+
 function DetalheRequisicaoPage() {
   const { id } = Route.useParams();
-  const { contexto, page: authorizationPage } = Route.useSearch();
+  const { contexto, page: sourcePage } = Route.useSearch();
   const requisicaoId = Number(id);
   const backTo =
     contexto === "autorizacao"
@@ -421,10 +735,10 @@ function DetalheRequisicaoPage() {
     void navigate({
       to: "/login",
       search: {
-        redirect: buildRequisicaoRedirect({ id, contexto, authorizationPage }),
+        redirect: buildRequisicaoRedirect({ id, contexto, sourcePage }),
       },
     });
-  }, [authError, authorizationPage, contexto, id, navigate, queryClient]);
+  }, [authError, contexto, id, navigate, queryClient, sourcePage]);
 
   if (!Number.isInteger(requisicaoId) || requisicaoId <= 0) {
     return <div className="error-panel">Identificador de requisição inválido.</div>;
@@ -481,8 +795,8 @@ function DetalheRequisicaoPage() {
           <Link
             className="action-link compact-action"
             search={
-              contexto === "autorizacao"
-                ? { page: authorizationPage && authorizationPage > 1 ? authorizationPage : undefined }
+              contexto
+                ? { page: sourcePage && sourcePage > 1 ? sourcePage : undefined }
                 : undefined
             }
             to={backTo}
@@ -494,7 +808,15 @@ function DetalheRequisicaoPage() {
 
       {contexto === "autorizacao" && requisicao.status === "aguardando_autorizacao" ? (
         <AuthorizationDecisionPanel
-          authorizationPage={authorizationPage}
+          authorizationPage={sourcePage}
+          key={requisicao.id}
+          requisicao={requisicao}
+        />
+      ) : null}
+
+      {contexto === "atendimento" && requisicao.status === "autorizada" ? (
+        <FulfillmentDecisionPanel
+          fulfillmentPage={sourcePage}
           key={requisicao.id}
           requisicao={requisicao}
         />

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -681,7 +681,7 @@ function FulfillmentDecisionPanel({
         </div>
       </form>
 
-      <form className="authorization-refusal" onSubmit={cancel}>
+      <form className="fulfillment-cancellation" onSubmit={cancel}>
         <label className="preview-label">
           Motivo do cancelamento operacional
           <textarea

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -499,7 +499,8 @@ a {
 .authorization-panel,
 .authorization-form,
 .authorization-items,
-.authorization-refusal {
+.authorization-refusal,
+.fulfillment-cancellation {
   display: grid;
   gap: 1rem;
 }

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -1500,6 +1500,40 @@ describe("frontend scaffold router", () => {
     expect(container.ownerDocument.location.search).toBe("?contexto=atendimento");
   });
 
+  it("redirects to login when fulfillment action returns 401", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((request: Request) => {
+          if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+            return sessionResponse(warehouseSession());
+          }
+
+          if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+            return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+          }
+
+          if (requestUrl(request).endsWith("/api/v1/requisitions/101/fulfill/")) {
+            return new Response(null, { status: 401, headers: jsonHeaders });
+          }
+
+          throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        }),
+      );
+
+      const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+      expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Preencher entrega completa" }));
+      fireEvent.click(screen.getByRole("button", { name: "Registrar atendimento" }));
+
+      expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+      expect(container.ownerDocument.location.pathname).toBe("/login");
+      expect(container.ownerDocument.location.search).toBe(
+        "?redirect=%2Frequisicoes%2F101%3Fcontexto%3Datendimento",
+      );
+    },
+  );
+
   it("cancels authorized requisition from fulfillment context only with a reason", async () => {
     let cancelPayload: unknown;
     const fetchMock = vi.fn(async (request: Request) => {
@@ -1544,6 +1578,43 @@ describe("frontend scaffold router", () => {
       expect(container.ownerDocument.location.pathname).toBe("/atendimentos");
     });
   });
+
+  it("redirects to login when cancel action returns 401", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn((request: Request) => {
+          if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+            return sessionResponse(warehouseSession());
+          }
+
+          if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+            return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+          }
+
+          if (requestUrl(request).endsWith("/api/v1/requisitions/101/cancel/")) {
+            return new Response(null, { status: 401, headers: jsonHeaders });
+          }
+
+          throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        }),
+      );
+
+      const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+      expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+      fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição autorizada" }));
+      fireEvent.change(screen.getByLabelText("Motivo do cancelamento operacional"), {
+        target: { value: "Material indisponível no balcão" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição autorizada" }));
+
+      expect(await screen.findByRole("heading", { name: "Entrar no piloto" })).toBeInTheDocument();
+      expect(container.ownerDocument.location.pathname).toBe("/login");
+      expect(container.ownerDocument.location.search).toBe(
+        "?redirect=%2Frequisicoes%2F101%3Fcontexto%3Datendimento",
+      );
+    },
+  );
 
   it("preserves authorization page when queue request expires", async () => {
     vi.stubGlobal(

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -149,6 +149,60 @@ function pendingApprovalListResponse(results = [pendingApprovalListItem()]) {
   );
 }
 
+function warehouseSession() {
+  return {
+    id: 30,
+    matricula_funcional: "91005",
+    nome_completo: "Almoxarifado Piloto",
+    papel: "auxiliar_almoxarifado",
+    setor: {
+      id: 3,
+      nome: "Almoxarifado",
+    },
+    is_authenticated: true,
+  };
+}
+
+function pendingFulfillmentListItem(overrides = {}) {
+  return {
+    id: 101,
+    numero_publico: "REQ-2026-000101",
+    status: "autorizada",
+    beneficiario: {
+      id: 11,
+      matricula_funcional: "91004",
+      nome_completo: "Beneficiario Piloto",
+    },
+    setor_beneficiario: {
+      id: 2,
+      nome: "Manutencao",
+    },
+    chefe_autorizador: {
+      id: 20,
+      matricula_funcional: "91001",
+      nome_completo: "Chefe Piloto",
+    },
+    data_autorizacao_ou_recusa: "2026-05-01T12:00:00Z",
+    total_itens: 2,
+    ...overrides,
+  };
+}
+
+function pendingFulfillmentListResponse(results = [pendingFulfillmentListItem()]) {
+  return new Response(
+    JSON.stringify({
+      count: results.length,
+      page: 1,
+      page_size: 20,
+      total_pages: 1,
+      next: null,
+      previous: null,
+      results,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
 function requisitionDetailResponse(itemOverrides = {}) {
   return new Response(
     JSON.stringify({
@@ -995,6 +1049,67 @@ describe("frontend scaffold router", () => {
     expect(await screen.findByRole("link", { name: "Voltar" })).toHaveAttribute("href", "/autorizacoes");
   });
 
+  it("renders fulfillment queue worklist", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(warehouseSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+          return pendingFulfillmentListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/atendimentos");
+
+    expect(await screen.findByRole("heading", { name: "Fila de atendimento" })).toBeInTheDocument();
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    expect(screen.getByText("Beneficiario Piloto")).toBeInTheDocument();
+    expect(screen.getByText("Chefe Piloto")).toBeInTheDocument();
+    expect(screen.getByText(formatDateTime("2026-05-01T12:00:00Z"))).toBeInTheDocument();
+    expect(screen.getByText("1 registro")).toBeInTheDocument();
+  });
+
+  it("opens canonical requisition detail from fulfillment queue with context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(warehouseSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+          return pendingFulfillmentListResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/atendimentos?page=2");
+
+    expect(await screen.findByText("REQ-2026-000101")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "Abrir" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+      expect(container.ownerDocument.location.search).toBe("?contexto=atendimento&page=2");
+    });
+    expect(await screen.findByRole("link", { name: "Voltar" })).toHaveAttribute(
+      "href",
+      "/atendimentos?page=2",
+    );
+  });
+
   it("opens canonical requisition detail from the list", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1059,6 +1174,25 @@ describe("frontend scaffold router", () => {
 
     await waitFor(() => {
       expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
+    });
+  });
+
+  it("redirects solicitante away from fulfillment detail context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(authSession("solicitante"));
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
     });
   });
 
@@ -1177,6 +1311,207 @@ describe("frontend scaffold router", () => {
       expect(container.ownerDocument.location.pathname).toBe("/autorizacoes");
     });
     expect(await screen.findByText("Nenhuma autorização pendente")).toBeInTheDocument();
+  });
+
+  it("fulfills all authorized items from fulfillment context", async () => {
+    let fulfillPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(warehouseSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/fulfill/")) {
+        fulfillPayload = await request.json();
+        return requisitionDetailResponse({
+          quantidade_autorizada: "1.000",
+          quantidade_entregue: "1.000",
+        });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+        return pendingFulfillmentListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Retirante físico"), {
+      target: { value: "Joao da Silva" },
+    });
+    fireEvent.change(screen.getByLabelText("Observação do atendimento"), {
+      target: { value: "Retirada no balcão" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Preencher entrega completa" }));
+    fireEvent.click(screen.getByRole("button", { name: "Registrar atendimento" }));
+
+    await waitFor(() => {
+      expect(fulfillPayload).toEqual({
+        retirante_fisico: "Joao da Silva",
+        observacao_atendimento: "Retirada no balcão",
+        itens: [
+          {
+            item_id: 501,
+            quantidade_entregue: "1.000",
+            justificativa_atendimento_parcial: "",
+          },
+        ],
+      });
+      expect(container.ownerDocument.location.pathname).toBe("/atendimentos");
+    });
+    expect(await screen.findByText("Nenhum atendimento pendente")).toBeInTheDocument();
+  });
+
+  it("requires inline justification for partial fulfillment", async () => {
+    let fulfillPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(warehouseSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return requisitionDetailResponse({ quantidade_autorizada: "2.000" });
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/fulfill/")) {
+        fulfillPayload = await request.json();
+        return requisitionDetailResponse({
+          quantidade_autorizada: "2.000",
+          quantidade_entregue: "1.500",
+          justificativa_atendimento_parcial: "Retirada parcial",
+        });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+        return pendingFulfillmentListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/101?contexto=atendimento");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Quantidade entregue para Papel sulfite A4"), {
+      target: { value: "1,5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Registrar atendimento" }));
+
+    expect(await screen.findByText("Informe justificativa para atendimento parcial ou zerado.")).toBeInTheDocument();
+    expect(fulfillPayload).toBeUndefined();
+
+    fireEvent.change(screen.getByLabelText("Justificativa de atendimento para Papel sulfite A4"), {
+      target: { value: "Retirada parcial" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Registrar atendimento" }));
+
+    await waitFor(() => {
+      expect(fulfillPayload).toEqual({
+        retirante_fisico: "",
+        observacao_atendimento: "",
+        itens: [
+          {
+            item_id: 501,
+            quantidade_entregue: "1.5",
+            justificativa_atendimento_parcial: "Retirada parcial",
+          },
+        ],
+      });
+    });
+  });
+
+  it("keeps user on detail when fulfillment action returns domain error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(warehouseSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/fulfill/")) {
+          return new Response(
+            JSON.stringify({
+              error: {
+                code: "domain_conflict",
+                message: "Somente requisições autorizadas podem ser atendidas.",
+                details: {},
+                trace_id: "trace-domain",
+              },
+            }),
+            { status: 409, headers: jsonHeaders },
+          );
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Preencher entrega completa" }));
+    fireEvent.click(screen.getByRole("button", { name: "Registrar atendimento" }));
+
+    expect(await screen.findByText("Somente requisições autorizadas podem ser atendidas.")).toBeInTheDocument();
+    expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+    expect(container.ownerDocument.location.search).toBe("?contexto=atendimento");
+  });
+
+  it("cancels authorized requisition from fulfillment context only with a reason", async () => {
+    let cancelPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(warehouseSession());
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+        return requisitionDetailResponse({ quantidade_autorizada: "1.000" });
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/101/cancel/")) {
+        cancelPayload = await request.json();
+        return requisitionDetailResponse({ status: "cancelada" });
+      }
+
+      if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+        return pendingFulfillmentListResponse([]);
+      }
+
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/101?contexto=atendimento");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição autorizada" }));
+
+    expect(await screen.findByText("Informe o motivo do cancelamento.")).toBeInTheDocument();
+    expect(cancelPayload).toBeUndefined();
+
+    fireEvent.change(screen.getByLabelText("Motivo do cancelamento operacional"), {
+      target: { value: "Material indisponível no balcão" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição autorizada" }));
+
+    await waitFor(() => {
+      expect(cancelPayload).toEqual({
+        motivo_cancelamento: "Material indisponível no balcão",
+      });
+      expect(container.ownerDocument.location.pathname).toBe("/atendimentos");
+    });
   });
 
   it("preserves authorization page when queue request expires", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -203,7 +203,10 @@ function pendingFulfillmentListResponse(results = [pendingFulfillmentListItem()]
   );
 }
 
-function requisitionDetailResponse(itemOverrides = {}) {
+function requisitionDetailResponse(
+  itemOverrides: Record<string, unknown> = {},
+  requisitionOverrides: Record<string, unknown> = {},
+) {
   return new Response(
     JSON.stringify({
       id: 101,
@@ -270,6 +273,7 @@ function requisitionDetailResponse(itemOverrides = {}) {
           observacao: "Autorizado parcialmente por saldo.",
         },
       ],
+      ...requisitionOverrides,
     }),
     { status: 200, headers: jsonHeaders },
   );
@@ -1177,6 +1181,33 @@ describe("frontend scaffold router", () => {
     });
   });
 
+  it("returns from requisition detail to fulfillment queue when opened with fulfillment context", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(warehouseSession());
+        }
+
+        if (requestUrl(request).endsWith("/api/v1/requisitions/101/")) {
+          return requisitionDetailResponse();
+        }
+
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    const { container } = renderRoute("/requisicoes/101?contexto=atendimento&page=2");
+
+    expect(await screen.findByRole("heading", { name: "REQ-2026-000101" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "Voltar" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/atendimentos");
+      expect(container.ownerDocument.location.search).toBe("?page=2");
+    });
+  });
+
   it("redirects solicitante away from fulfillment detail context", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1482,7 +1513,7 @@ describe("frontend scaffold router", () => {
 
       if (requestUrl(request).endsWith("/api/v1/requisitions/101/cancel/")) {
         cancelPayload = await request.json();
-        return requisitionDetailResponse({ status: "cancelada" });
+        return requisitionDetailResponse({}, { status: "cancelada" });
       }
 
       if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
@@ -2198,7 +2229,7 @@ describe("frontend scaffold router", () => {
 
       if (requestUrl(request).endsWith("/api/v1/requisitions/101/cancel/")) {
         cancelPayload = await request.json();
-        return requisitionDetailResponse({ status: "cancelada" });
+        return requisitionDetailResponse({}, { status: "cancelada" });
       }
 
       if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Adiciona retorno da requisição do detalhe para a fila de atendimento quando o contexto é `atendimento`.
- Preserva o `page` da worklist na navegação de volta.
- Ajusta estilos e testes para cobrir a jornada de atendimento.

## Por que esta mudança é necessária
- Garante navegação coerente entre detalhe canônico e fila de atendimento, sem perder o ponto de retorno da listagem.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
- O detalhe pode voltar para rota errada ou perder o `page` da queue, quebrando navegação da área de atendimento.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: fluxo de atendimento acessível para o papel correto.
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `rtk make frontend-lint` passou.
3. Smoke test cobre retorno do detalhe para `/atendimentos?page=2`.

## Como validar manualmente
- Abrir uma requisição com `?contexto=atendimento`.
- Clicar em voltar e confirmar retorno para `/atendimentos` preservando `page`.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Resumo do PR #58: Frontend Piloto — Atendimento e Retorno do Detalhe

## Objetivo da Mudança
- Implementar fila de atendimento (`/atendimentos`) no frontend piloto React com listagem de requisições autorizadas aguardando retirada
- Permitir registrar atendimento (fulfillment) com quantidade parcial/total e cancelamento de requisição autorizada
- Preservar contexto (`atendimento` vs `autorizacao`) e paginação ao navegar entre listagem ↔ detalhe ↔ operação

## Apps Django Impactados
- **Nenhum impacto em código backend**: mudanças 100% frontend React/TypeScript
- Apenas **consome APIs existentes**: `GET /api/v1/requisitions/pending-fulfillments/`, `POST /api/v1/requisitions/{id}/fulfill/`, `POST /api/v1/requisitions/{id}/cancel/`
- Presume endpoints e lógica de negócio já implementados e testados no backend

## Risco Funcional
- ⚠️ **Navegação contextualizada**: falha em preservar `page` ou `contexto` quebra retorno ao atendimento com paginação correta
- ⚠️ **Validação de página**: coerção de inteiro com mínimo 1; valores inválidos silenciosamente ignorados (comportamento esperado por `catch`)
- ⚠️ **Sem retry automático**: fulfillment/cancel são requisições HTTP isoladas; falha exige refazer manualmente
- ⚠️ **Sem lock/otimistic lock**: nada impede two concurrent fulfillments da mesma requisição; presume backend rejeita segundo

## Impacto em Regras de Negócio
- **Novo fluxo operacional**: adiciona "Registrar atendimento" (fulfillment) com entrega parcial/total
  - Entrega parcial: **obrigatória justificativa** (`justificativa_atendimento_parcial`), desabilita botão até preenchimento
  - Entrega zero: **obrigatória justificativa**, mesmo comportamento
  - Entrega total: nenhuma justificativa exigida
- **Cancelamento autorizado**: permite cancelar requisição já autorizada com **motivo obrigatório** (`motivo_cancelamento`)
- **Dois contextos operacionais na mesma rota detalhe**:
  - `contexto=autorizacao`: exibe painel de autorização/recusa (papéis: chefe_setor, chefe_almoxarifado)
  - `contexto=atendimento`: exibe painel de fulfillment/cancel (papéis: auxiliar_almoxarifado, chefe_almoxarifado)
  - Sem contexto: modo leitor (requisitante)

## Impacto em Autenticação, Autorização, Escopo por Perfil e Setor
- ✅ **Novo guard operacional**: `requireOperationalPapel()` valida papéis específicos por rota/contexto
- ✅ **Papéis atendimento** (warehouse): `["auxiliar_almoxarifado", "chefe_almoxarifado"]`
  - `/atendimentos`: requer um desses papéis
  - `/requisicoes/{id}?contexto=atendimento`: requer um desses papéis
- ✅ **Papéis autorização**: `["chefe_setor", "chefe_almoxarifado"]`
  - `/requisicoes/{id}?contexto=autorizacao`: requer um desses papéis
- ✅ **Session expirado**: redireciona para `/login?redirect=/atendimentos[?page=X]`, preserva intenção original
- ⚠️ **Sem validação de setor**: presume API retorna apenas dados visíveis ao usuário (setor-based filtering feito no backend)
- ⚠️ **Sem explícita exclusão de superusuário**: workflow operacional pode ser executado por admin (confirmar se intencional)

## Impacto em Contratos DRF, Serializers, Paginação, Filtros, Envelope de Erro
- ✅ **Tipos OpenAPI sincronizados**: `RequisicaoFulfillInput`, `RequisicaoCancelInput`, `RequisicaoPendingFulfillmentItem`, `RequisicaoPendingFulfillmentResponse` vêm de `schema.d.ts`
- ✅ **Contrato de paginação mantido**: `count`, `results`, `page`, `total_pages` alinhados com API
- ✅ **keepPreviousData ativo**: React Query preserva dados da página anterior durante refetch (melhor UX)
- **Sem filtros implementados**: listagem apenas filtra por paginação (sem busca, período, status, setor)
- **Sem custom error envelope**: presume formato `{error: {message: string}}` no backend

## Impacto em Integridade de Dados, Constraints, Snapshots Históricos, Auditoria e Rastreabilidade
- ⚠️ **Sem snapshot pré-operação**: fulfillment não valida se requisição foi modificada entre fetch e submit
  - Presume backend usa `select_for_update()` ou versionamento para evitar race condition
- ⚠️ **Sem rastreabilidade de contexto**: não há diferenciação no audit log entre operação via `autorizacao` vs `atendimento`
  - Sugestão: backend deve registrar `tipo_evento=atendimento_parcial` vs `atendimento_total` vs `cancelamento`
- ✅ **Sem mutação local**: dados não são modificados otimisticamente; aguarda resposta do servidor
- **Sem capture de user/timestamp frontend**: presume backend registra `usuario`, `data_hora`, `updated_at` automaticamente

## Impacto em Transações, Concorrência, Idempotência, Saldo Físico e Reservado
- ⚠️ **Sem retry ou idempotência frontend**: requisição POST falha permanentemente até usuário refazer
  - Risco: double-fulfillment se rede instável e usuário clica "Registrar" 2x rapidamente (UI não desabilita botão pós-submit)
- ⚠️ **Sem lock pessimista**: fulfillment é POST isolado sem versão/etag; dois almoxarifes podem fulfillment em paralelo
  - Presume: backend retorna erro 409 ou recusa segundo fulfillment (não visível em frontend)
- **Sem validação de saldo negativo frontend**: presume API valida `delivered_qty <= authorized_qty`
- **Sem ajuste de saldo_reservado**: presume backend `cancelar_requisicao()` libera reserva atomicamente (transação explícita em services.py esperada)

## Impacto em Importação SCPI, Dados Oficiais ou Divergência de Estoque
- Não aplicável (PR operacional, não de importação)

## Impacto em Configuração, CI, Dependências, Lint e Testes
- ✅ **Lint passou**: `eslint . --max-warnings=0` OK
- ✅ **Testes adicionados**: 368 linhas em `router-smoke.test.tsx`
  - Cobre: renderização listagem, navegação com contexto, paginação, partial fulfillment com/sem justificativa, cancelamento, validação de papel
  - **Sem snapshot/visual regression**
  - **Sem E2E Playwright** (cobertura apenas via MSW mocking)
- ✅ **Formatação**: `git diff --check` passou
- ✅ **Sem dependências novas**: usa React Query, React Table, Zod existentes
- ⚠️ **OpenAPI schema desatualizado risco**: se backend mudou endpoint/schema, `gen:api` deve ser re-executado antes de merge

## Como Validar Manualmente

**Via Rota Frontend:**
1. Acessar `/atendimentos` com papel `auxiliar_almoxarifado` → lista requisições autorizadas com paginação
2. Clicar "Abrir" em requisição da página 2 → navega para `/requisicoes/{id}?contexto=atendimento&page=2`
3. Clicar "Voltar" → retorna a `/atendimentos?page=2` (confirmação)
4. Entrar `/requisicoes/{id}?contexto=atendimento`:
   - Tentar fulfillment com quantidade parcial **sem justificativa** → botão "Registrar" desabilitado
   - Adicionar justificativa → botão habilitado, submit
   - Validar redirect pós-sucesso a `/atendimentos?page=2` (se veio de lá)
5. Tentar cancelamento sem motivo → botão desabilitado até preenchimento

**Via API/Admin:**
- Verificar em `POST /api/v1/requisitions/{id}/fulfill/` que payload inclui `itens` com `quantidade_entregue` e `justificativa_atendimento_parcial`
- Verificar em `POST /api/v1/requisitions/{id}/cancel/` que payload inclui `motivo_cancelamento`
- Confirmar em admin que `Requisicao.responsavel_atendimento` é preenchido e `Requisicao.eventos` registra tipo correto

**Via Teste Automatizado:**
```bash
npm run test --workspace=frontend
```
Valida: listagem, navegação, paginação, validação de papel, fulfillment flow, cancelamento flow

## ⚠️ Alertas Principais

1. **Sem documentação de design em design-acesso-rapido/**: Confirmar que frontend implementa exatamente o design de UX/fluxos esperados (arquivo `design-acesso-rapido/frontend-arquitetura-piloto.md` deve ser lido)

2. **Lógica de validação em duas camadas**: Frontend valida presença de justificativa/motivo; backend deve revalidar (não confiar em cliente)

3. **Timeout de sessão**: Se operação demora >TTL de token, usuário redirecionado para login; dados do form são perdidos

4. **Sem persistência de rascunho**: Se fulfillment falhar, usuário precisa re-entrar quantidades (sem undo/draft local)

5. **Papéis e setor**: Confirmar matriz em `design-acesso-rapido/matriz-permissoes.md` e `users/policies.py` backend estão sincronizadas; `chefe_almoxarifado` tem acesso duplo (autorização + atendimento)?

6. **N+1 queries presentes?**: Frontend faz 1 GET `/pending-fulfillments/?page=2` + N GETs `/requisicoes/{id}/` para cada item aberto (sem problema se página < 50 itens)

7. **Query invalidation**: Após fulfillment/cancel, presume `pendingFulfillmentsQueryKey` é invalidado no backend (não gerenciado explicitamente em frontend após sucesso)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/58)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->