### PR TITLE
feat(frontend): Playwright real com backend + CI fase 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,8 @@ jobs:
           enable-cache: true
       - name: Install backend dependencies
         run: uv sync --locked
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Install frontend dependencies
         run: make frontend-deps
       - name: Generate frontend API types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
           enable-cache: true
       - name: Install backend dependencies
         run: uv sync --locked
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Install frontend dependencies
         run: make frontend-deps
       - name: Install Playwright Chromium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,65 @@ jobs:
             echo "Run 'make frontend-gen-api' locally and commit the updated files."
             exit 1
           }
+
+  frontend-e2e:
+    runs-on: ubuntu-latest
+    needs: frontend
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: saep
+          POSTGRES_PASSWORD: saep
+          POSTGRES_DB: test_wms_saep
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      SECRET_KEY: test-secret-key-for-ci
+      DATABASE_URL: postgres://saep:saep@localhost:5432/test_wms_saep
+      DJANGO_SETTINGS_MODULE: config.settings.test
+      TEST_SETTINGS_MODULE: config.settings.test
+      PNPM: pnpm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - uses: actions/setup-python@v6
+        with:
+          python-version-file: ".python-version"
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install backend dependencies
+        run: uv sync --locked
+      - name: Install frontend dependencies
+        run: make frontend-deps
+      - name: Install Playwright Chromium
+        run: cd frontend && ./node_modules/.bin/playwright install --with-deps chromium
+      - name: Rebuild ephemeral schema/migrations
+        run: make setup DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
+      - name: Seed pilot baseline
+        run: make seed-pilot-minimo DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
+      - name: Run frontend real E2E
+        run: make frontend-e2e DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
+      - name: Upload Playwright artifacts
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            frontend/playwright-report/
+            frontend/test-results/
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,11 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y postgresql-client
       - name: Install frontend dependencies
         run: make frontend-deps
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
       - name: Install Playwright Chromium
         run: cd frontend && ./node_modules/.bin/playwright install --with-deps chromium
       - name: Rebuild ephemeral schema/migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,6 @@ jobs:
         run: cd frontend && ./node_modules/.bin/playwright install --with-deps chromium
       - name: Rebuild ephemeral schema/migrations
         run: make setup DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
-      - name: Seed pilot baseline
-        run: make seed-pilot-minimo DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
       - name: Run frontend real E2E
         run: make frontend-e2e DATABASE_URL="$DATABASE_URL" DJANGO_SETTINGS_MODULE="$DJANGO_SETTINGS_MODULE" TEST_SETTINGS_MODULE="$TEST_SETTINGS_MODULE" SECRET_KEY="$SECRET_KEY"
       - name: Upload Playwright artifacts

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ frontend-lint: frontend-gen-api ## Rodar lint e typecheck do frontend
 frontend-test: frontend-gen-api ## Rodar smoke tests unitários/integration do frontend
 	cd $(FRONTEND_DIR) && ./node_modules/.bin/vitest run
 
-frontend-e2e: frontend-gen-api ## Rodar smoke E2E do frontend com Playwright
+frontend-e2e: frontend-gen-api seed-pilot-minimo ## Rodar E2E real do frontend com Playwright + backend seedado
 	cd $(FRONTEND_DIR) && ./node_modules/.bin/playwright test
 
 .PHONY: help prepare init setup clean cleanall veryclean test seed-pilot-minimo run resetdb resetpostgres frontend-deps frontend-init frontend-gen-api frontend-dev frontend-build frontend-lint frontend-test frontend-e2e

--- a/apps/requisitions/seed_pilot_minimo.py
+++ b/apps/requisitions/seed_pilot_minimo.py
@@ -150,6 +150,9 @@ def _upsert_material(
         estoque.saldo_fisico != saldo_inicial
         and not Requisicao.objects.filter(itens__material=material).exists()
     ):
+        # SEED ONLY: this direct stock reset is restricted to ephemeral bootstrap
+        # inside carregar_seed_pilot_minimo() transaction; do not copy this path
+        # to runtime/business flows (use stock services with lock semantics there).
         estoque.saldo_fisico = saldo_inicial
         estoque.saldo_reservado = Decimal("0")
         estoque.save(update_fields=["saldo_fisico", "saldo_reservado", "updated_at"])

--- a/docs/backlog/backlog-tecnico-piloto.md
+++ b/docs/backlog/backlog-tecnico-piloto.md
@@ -1243,10 +1243,10 @@ Status do enablement do frontend: bloco 0 do backend concluído em código/contr
 
 Débito técnico residual do scaffold frontend:
 
-- O repositório ainda não tem a primeira fatia de CI do frontend. Ela deve validar artefatos gerados (`frontend/src/routeTree.gen.ts` e OpenAPI/types), lint, typecheck, smoke tests e Playwright.
+- A fase 1 de CI do frontend está ativa no workflow `CI`, job `frontend`, validando geração OpenAPI/types, lint e build.
 - A árvore `src/features/` começou a receber comportamento real por `features/auth`, mas as próximas fatias ainda devem evitar crescimento permanente de placeholders em `routes/`/`shared/`.
 - `frontend-gen-api`/`frontend-test` ainda depende de `frontend-init` via `npx pnpm@10.15.1`; em ambiente sem rede, use os binários locais em `frontend/node_modules/.bin` ou conclua a instalação oficial antes dos checks completos.
-- O E2E atual da SPA é smoke mockado para login/logout. Próximo degrau: E2E real com backend e seed mínima quando a infra estiver estável.
+- A fase 2 de CI do frontend está ativa no workflow `CI`, job `frontend-e2e`, com backend real + seed mínima + Playwright (Chromium, traces em retry).
 - `/unknown-role` é fallback defensivo para papel não mapeado, não fluxo de negócio. Se aparecer em uso real, tratar como desalinhamento de contrato/cadastro/OpenAPI.
 
 Próxima fatia recomendada:

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -273,7 +273,7 @@ Significado operacional:
 - `make frontend-build`: executa `frontend-gen-api` e gera o build;
 - `make frontend-lint`: executa `frontend-gen-api`, lint e typecheck;
 - `make frontend-test`: executa `frontend-gen-api` e smoke tests com Vitest;
-- `make frontend-e2e`: executa `frontend-gen-api` e smoke E2E com Playwright.
+- `make frontend-e2e`: executa `frontend-gen-api`, aplica `seed-pilot-minimo` e roda E2E real com Playwright contra backend Django + SPA Vite, sem mocks HTTP.
 
 ## 13. OpenAPI
 
@@ -333,6 +333,8 @@ Implementada no workflow `CI`, job `frontend`:
 
 Escopo da issue #43:
 
-- subir backend com bloco 0 estável
+- job separado no workflow `CI` (`frontend-e2e`)
+- subir Postgres + backend Django + SPA Vite
 - carregar `seed_pilot_minimo`
-- rodar Playwright
+- rodar Playwright real serializado (`workers: 1`, Chromium, `trace: on-first-retry`)
+- publicar `frontend/playwright-report/` e traces quando falhar/cancelar

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,10 +2,10 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  fullyParallel: true,
+  fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
   reporter: "html",
   use: {
     baseURL: "http://127.0.0.1:4173",
@@ -19,12 +19,25 @@ export default defineConfig({
       },
     },
   ],
-  webServer: {
-    command: "./node_modules/.bin/vite --host 127.0.0.1 --port 4173",
-    url: "http://127.0.0.1:4173",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    stdout: "ignore",
-    stderr: "pipe",
-  },
+  webServer: [
+    {
+      name: "backend",
+      command: "uv run python manage.py runserver 127.0.0.1:8000 --noreload",
+      cwd: "..",
+      url: "http://127.0.0.1:8000/api/v1/auth/csrf/",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: "ignore",
+      stderr: "pipe",
+    },
+    {
+      name: "frontend",
+      command: "./node_modules/.bin/vite --host 127.0.0.1 --port 4173",
+      url: "http://127.0.0.1:4173",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: "ignore",
+      stderr: "pipe",
+    },
+  ],
 });

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: 1,
+  workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
     baseURL: "http://127.0.0.1:4173",

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -11,6 +11,26 @@ async function loginAs(page: Page, matricula: string, expectedPath: RegExp) {
   await expect(page).toHaveURL(expectedPath);
 }
 
+function expectDetailContextUrl(
+  rawUrl: string,
+  contexto: "autorizacao" | "atendimento",
+  allowPageParam = true,
+) {
+  const url = new URL(rawUrl);
+
+  expect(url.pathname).toMatch(/^\/requisicoes\/\d+$/);
+  expect(url.searchParams.get("contexto")).toBe(contexto);
+
+  const pageParam = url.searchParams.get("page");
+  if (!allowPageParam) {
+    expect(pageParam).toBeNull();
+    return;
+  }
+  if (pageParam !== null) {
+    expect(pageParam).toMatch(/^\d+$/);
+  }
+}
+
 test("logs in and logs out through real backend", async ({ page }) => {
   await loginAs(page, "chefe-setor", /\/autorizacoes(?:\?.*)?$/);
   await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
@@ -66,7 +86,8 @@ test("authorizes pending requisition from worklist", async ({ page }) => {
   await expect(approvalRow).toBeVisible();
   await approvalRow.getByRole("link", { name: "Abrir" }).click();
 
-  await expect(page).toHaveURL(/\/requisicoes\/\d+\?contexto=autorizacao(?:&page=\d+)?$/);
+  await expect(page).toHaveURL(/\/requisicoes\/\d+\?/);
+  expectDetailContextUrl(page.url(), "autorizacao");
   await page.getByRole("button", { name: "Autorizar tudo como solicitado" }).click();
   await expect(page).toHaveURL(/\/autorizacoes(?:\?.*)?$/);
   await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
@@ -80,7 +101,8 @@ test("fulfills authorized requisition from worklist", async ({ page }) => {
   await expect(fulfillmentRow).toBeVisible();
   await fulfillmentRow.getByRole("link", { name: "Abrir" }).click();
 
-  await expect(page).toHaveURL(/\/requisicoes\/\d+\?contexto=atendimento(?:&page=\d+)?$/);
+  await expect(page).toHaveURL(/\/requisicoes\/\d+\?/);
+  expectDetailContextUrl(page.url(), "atendimento");
   await page.getByRole("button", { name: "Preencher entrega completa" }).click();
   await page.getByLabel("Retirante físico").fill("Servidor piloto E2E");
   await page.getByRole("button", { name: "Registrar atendimento" }).click();

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 // Keep aligned with apps/requisitions/seed_pilot_minimo.py (SEED_PASSWORD).
-const SEED_PASSWORD = process.env.PLAYWRIGHT_SEED_PASSWORD ?? "piloto-minimo";
+const SEED_PASSWORD = "piloto-minimo";
 
 async function loginAs(page: Page, matricula: string, expectedPath: RegExp) {
   await page.goto("/login");

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -1,210 +1,88 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
-test("logs in and logs out through pilot shell", async ({ page }) => {
-  let authenticated = false;
+const SEED_PASSWORD = "piloto-minimo";
 
-  await page.route("**/api/v1/auth/me/", async (route) => {
-    if (!authenticated) {
-      await route.fulfill({
-        status: 401,
-        contentType: "application/json",
-        body: JSON.stringify({
-          error: {
-            code: "not_authenticated",
-            message: "Autenticação necessária.",
-            details: {},
-            trace_id: null,
-          },
-        }),
-      });
-      return;
-    }
-
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: 20,
-        matricula_funcional: "91003",
-        nome_completo: "Chefe Piloto",
-        papel: "chefe_setor",
-        setor: {
-          id: 2,
-          nome: "Manutencao",
-        },
-        is_authenticated: true,
-      }),
-    });
-  });
-  await page.route("**/api/v1/auth/csrf/", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ csrf_token: "csrf-token" }),
-    });
-  });
-  await page.route("**/api/v1/auth/login/", async (route) => {
-    authenticated = true;
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: 20,
-        matricula_funcional: "91003",
-        nome_completo: "Chefe Piloto",
-        papel: "chefe_setor",
-        setor: {
-          id: 2,
-          nome: "Manutencao",
-        },
-        is_authenticated: true,
-      }),
-    });
-  });
-  await page.route("**/api/v1/auth/logout/", async (route) => {
-    authenticated = false;
-    await route.fulfill({ status: 204 });
-  });
-
+async function loginAs(page: Page, matricula: string, expectedPath: RegExp) {
   await page.goto("/login");
-
-  await page.getByLabel("Matrícula funcional").fill("91003");
-  await page.getByLabel("Senha").fill("senha-segura-123");
+  await page.getByLabel("Matrícula funcional").fill(matricula);
+  await page.getByLabel("Senha").fill(SEED_PASSWORD);
   await page.getByRole("button", { name: "Entrar" }).click();
+  await expect(page).toHaveURL(expectedPath);
+}
 
-  await expect(page).toHaveURL(/\/autorizacoes$/);
-  await expect(page.getByText("Chefe Piloto")).toBeVisible();
+test("logs in and logs out through real backend", async ({ page }) => {
+  await loginAs(page, "chefe-setor", /\/autorizacoes(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
+  await expect(page.getByText("Wagner Fonseca")).toBeVisible();
 
   await page.getByRole("button", { name: "Sair" }).click();
-
-  await expect(page).toHaveURL(/\/login$/);
+  await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
   await expect(page.getByRole("heading", { name: "Entrar no piloto" })).toBeVisible();
 });
 
-test("opens minhas requisicoes and canonical detail", async ({ page }) => {
-  await page.route("**/api/v1/auth/me/", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: 10,
-        matricula_funcional: "91003",
-        nome_completo: "Usuario Piloto",
-        papel: "solicitante",
-        setor: {
-          id: 1,
-          nome: "Operacao",
-        },
-        is_authenticated: true,
-      }),
-    });
-  });
-  await page.route("**/api/v1/requisitions/mine/?**", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        count: 1,
-        page: 1,
-        page_size: 20,
-        total_pages: 1,
-        next: null,
-        previous: null,
-        results: [
-          {
-            id: 101,
-            numero_publico: "REQ-2026-000101",
-            status: "aguardando_autorizacao",
-            criador: {
-              id: 10,
-              matricula_funcional: "91003",
-              nome_completo: "Usuario Piloto",
-            },
-            beneficiario: {
-              id: 11,
-              matricula_funcional: "91004",
-              nome_completo: "Beneficiario Terceiro",
-            },
-            setor_beneficiario: {
-              id: 1,
-              nome: "Operacao",
-            },
-            data_criacao: "2026-05-01T10:00:00Z",
-            data_envio_autorizacao: "2026-05-01T11:00:00Z",
-            data_autorizacao_ou_recusa: null,
-            data_finalizacao: null,
-            updated_at: "2026-05-01T11:00:00Z",
-            total_itens: 1,
-          },
-        ],
-      }),
-    });
-  });
-  await page.route("**/api/v1/requisitions/101/", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: 101,
-        numero_publico: "REQ-2026-000101",
-        status: "autorizada",
-        criador: {
-          id: 10,
-          matricula_funcional: "91003",
-          nome_completo: "Usuario Piloto",
-        },
-        beneficiario: {
-          id: 11,
-          matricula_funcional: "91004",
-          nome_completo: "Beneficiario Terceiro",
-        },
-        setor_beneficiario: {
-          id: 1,
-          nome: "Operacao",
-        },
-        chefe_autorizador: null,
-        responsavel_atendimento: null,
-        data_criacao: "2026-05-01T10:00:00Z",
-        data_envio_autorizacao: "2026-05-01T11:00:00Z",
-        data_autorizacao_ou_recusa: "2026-05-01T12:00:00Z",
-        motivo_recusa: "",
-        motivo_cancelamento: "",
-        data_finalizacao: null,
-        retirante_fisico: "",
-        observacao: "",
-        observacao_atendimento: "",
-        itens: [
-          {
-            id: 501,
-            material: {
-              id: 301,
-              codigo_completo: "010.001.001",
-              nome: "Papel sulfite A4",
-              unidade_medida: "UN",
-            },
-            unidade_medida: "UN",
-            quantidade_solicitada: "2.000",
-            quantidade_autorizada: "1.000",
-            quantidade_entregue: "0.000",
-            justificativa_autorizacao_parcial: "Saldo parcial",
-            justificativa_atendimento_parcial: "",
-            observacao: "",
-          },
-        ],
-        eventos: [],
-      }),
-    });
-  });
-
-  await page.goto("/minhas-requisicoes?search=REQ");
+test("opens minhas requisicoes and canonical detail with real data", async ({ page }) => {
+  await loginAs(page, "solicitante1", /\/minhas-requisicoes(?:\?.*)?$/);
 
   await expect(page.getByRole("heading", { name: "Minhas requisições" })).toBeVisible();
-  await expect(page.getByText("REQ-2026-000101")).toBeVisible();
-  await expect(page.getByText("Beneficiário terceiro")).toBeVisible();
+  const formalRow = page.locator("tbody tr").filter({ hasText: /REQ-\d{4}-\d+/ }).first();
+  await expect(formalRow).toBeVisible();
+  await formalRow.getByRole("link", { name: "Abrir" }).click();
 
-  await page.getByRole("link", { name: "Abrir" }).click();
+  await expect(page).toHaveURL(/\/requisicoes\/\d+$/);
+  await expect(page.locator(".detail-hero h1")).toContainText(/REQ-\d{4}-\d+/);
+});
 
-  await expect(page).toHaveURL(/\/requisicoes\/101$/);
-  await expect(page.getByRole("heading", { name: "REQ-2026-000101" })).toBeVisible();
-  await expect(page.getByText("Papel sulfite A4")).toBeVisible();
+test("creates draft and submits to authorization using seed scenario", async ({ page }) => {
+  await loginAs(page, "91002", /\/minhas-requisicoes(?:\?.*)?$/);
+
+  await page.goto("/requisicoes/nova");
+  await expect(page.getByRole("heading", { name: "Nova requisição" })).toBeVisible();
+
+  await page.getByLabel("Para terceiro").click();
+  await page.getByLabel("Buscar beneficiário").fill("Ped");
+  await page.getByRole("button", { name: /Pedro Nunes/i }).click();
+
+  await page.getByLabel("Buscar material").fill("Papel sulfite");
+  await page.getByRole("button", { name: /Adicionar Papel sulfite A4/i }).click();
+  await page.getByLabel("Quantidade solicitada").fill("2");
+
+  await page.getByRole("button", { name: "Salvar rascunho" }).click();
+  await expect(page).toHaveURL(/\/requisicoes\/\d+$/);
+  await expect(page.getByRole("heading", { name: "Editar rascunho" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Enviar para autorização" }).click();
+  await page.getByRole("button", { name: "Confirmar envio" }).click();
+
+  await expect(page.locator(".detail-hero h1")).toContainText(/REQ-\d{4}-\d+/);
+  await expect(page.getByText("Aguardando autorização")).toBeVisible();
+});
+
+test("authorizes pending requisition from worklist", async ({ page }) => {
+  await loginAs(page, "chefe-setor", /\/autorizacoes(?:\?.*)?$/);
+
+  await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
+  const approvalRow = page.locator("tbody tr").first();
+  await expect(approvalRow).toBeVisible();
+  await approvalRow.getByRole("link", { name: "Abrir" }).click();
+
+  await expect(page).toHaveURL(/\/requisicoes\/\d+\?contexto=autorizacao(?:&page=\d+)?$/);
+  await page.getByRole("button", { name: "Autorizar tudo como solicitado" }).click();
+  await expect(page).toHaveURL(/\/autorizacoes(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
+});
+
+test("fulfills authorized requisition from worklist", async ({ page }) => {
+  await loginAs(page, "auxiliar-almox", /\/atendimentos(?:\?.*)?$/);
+
+  await expect(page.getByRole("heading", { name: "Fila de atendimento" })).toBeVisible();
+  const fulfillmentRow = page.locator("tbody tr").first();
+  await expect(fulfillmentRow).toBeVisible();
+  await fulfillmentRow.getByRole("link", { name: "Abrir" }).click();
+
+  await expect(page).toHaveURL(/\/requisicoes\/\d+\?contexto=atendimento(?:&page=\d+)?$/);
+  await page.getByRole("button", { name: "Preencher entrega completa" }).click();
+  await page.getByLabel("Retirante físico").fill("Servidor piloto E2E");
+  await page.getByRole("button", { name: "Registrar atendimento" }).click();
+  await expect(page).toHaveURL(/\/atendimentos(?:\?.*)?$/);
+  await expect(page.getByRole("heading", { name: "Fila de atendimento" })).toBeVisible();
 });

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -82,7 +82,9 @@ test("authorizes pending requisition from worklist", async ({ page }) => {
   await loginAs(page, "chefe-setor", /\/autorizacoes(?:\?.*)?$/);
 
   await expect(page.getByRole("heading", { name: "Fila de autorizações" })).toBeVisible();
-  const approvalRow = page.locator("tbody tr").first();
+  const approvalRows = page.locator("tbody tr");
+  await expect(approvalRows).not.toHaveCount(0);
+  const approvalRow = approvalRows.first();
   await expect(approvalRow).toBeVisible();
   await approvalRow.getByRole("link", { name: "Abrir" }).click();
 
@@ -97,7 +99,9 @@ test("fulfills authorized requisition from worklist", async ({ page }) => {
   await loginAs(page, "auxiliar-almox", /\/atendimentos(?:\?.*)?$/);
 
   await expect(page.getByRole("heading", { name: "Fila de atendimento" })).toBeVisible();
-  const fulfillmentRow = page.locator("tbody tr").first();
+  const fulfillmentRows = page.locator("tbody tr");
+  await expect(fulfillmentRows).not.toHaveCount(0);
+  const fulfillmentRow = fulfillmentRows.first();
   await expect(fulfillmentRow).toBeVisible();
   await fulfillmentRow.getByRole("link", { name: "Abrir" }).click();
 

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const SEED_PASSWORD = "piloto-minimo";
+// Keep aligned with apps/requisitions/seed_pilot_minimo.py (SEED_PASSWORD).
+const SEED_PASSWORD = process.env.PLAYWRIGHT_SEED_PASSWORD ?? "piloto-minimo";
 
 async function loginAs(page: Page, matricula: string, expectedPath: RegExp) {
   await page.goto("/login");
@@ -29,7 +30,7 @@ test("opens minhas requisicoes and canonical detail with real data", async ({ pa
   await formalRow.getByRole("link", { name: "Abrir" }).click();
 
   await expect(page).toHaveURL(/\/requisicoes\/\d+$/);
-  await expect(page.locator(".detail-hero h1")).toContainText(/REQ-\d{4}-\d+/);
+  await expect(page.getByRole("heading", { name: /REQ-\d{4}-\d+/ })).toBeVisible();
 });
 
 test("creates draft and submits to authorization using seed scenario", async ({ page }) => {
@@ -53,7 +54,7 @@ test("creates draft and submits to authorization using seed scenario", async ({ 
   await page.getByRole("button", { name: "Enviar para autorização" }).click();
   await page.getByRole("button", { name: "Confirmar envio" }).click();
 
-  await expect(page.locator(".detail-hero h1")).toContainText(/REQ-\d{4}-\d+/);
+  await expect(page.getByRole("heading", { name: /REQ-\d{4}-\d+/ })).toBeVisible();
   await expect(page.getByText("Aguardando autorização")).toBeVisible();
 });
 


### PR DESCRIPTION
# Contexto

## O que este PR faz
- troca o E2E Playwright mockado por fluxo real contra Django + Vite
- configura `frontend/playwright.config.ts` com `webServer` múltiplo (backend + frontend), Chromium e execução serial
- adiciona job `frontend-e2e` no workflow `CI` com Postgres, `make setup`, `make seed-pilot-minimo` e execução Playwright
- ajusta `Makefile` para `frontend-e2e` depender de `frontend-gen-api` e seed oficial
- atualiza docs rápidas e backlog residual para refletir fase 1/fase 2 de CI

## Por que esta mudança é necessária
A issue #43 pede E2E real do piloto para validar contrato real backend/frontend e manter CI fase 1 rápida, com fase 2 separada para Playwright.

---

# Checklist de impacto

- [ ] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [x] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Instabilidade de E2E por ambiente/infra (subida de serviços e sincronização).

## Impactos adicionais (somente se houver)

- permissões / perfil / setor:
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências: novo job `frontend-e2e` e execução Playwright real

---

# Testes e validação

## Cenários validados

1. login/logout real e redirecionamento por papel
2. worklist `Minhas requisições` + detalhe canônico
3. criação de rascunho + envio para autorização
4. autorização pela fila operacional
5. atendimento pela fila operacional

## Como validar manualmente
1. `rtk make setup`
2. `rtk make seed-pilot-minimo`
3. `rtk make frontend-e2e`

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

Closes #43

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR #59

**Objetivo**: Substituir testes E2E Playwright mockados por execução real contra backend Django + frontend Vite, usando a seed mínima oficial do piloto e integrar isso na CI (fase 2).

---

### Mudanças por escopo

- Apps Django impactados:
  - apps/requisitions: seed_pilot_minimo.py usado como dependência obrigatória de make frontend-e2e; testes exercem fluxo completo (criar rascunho → enviar → autorizar → atender).
  - apps/users: login/logout via backend real testados.
  - apps/stock: seed manipula saldos; comentário adicionado indicando que reset direto de EstoqueMaterial é exclusivo do bootstrap efêmero.
  - apps/materials: dados de seed carregados antes de testes.

- Risco funcional:
  - Instabilidade por timing/startup de serviços (backend/frontend/Postgres) e flakiness de sincronização entre seed e testes.
  - Dependência de estado compartilhado pela seed (sem isolamento entre testes) → falhas na seed impactam toda a suíte.
  - Possível race condition se seed ainda não completou quando Playwright começa a interagir.

- Impacto em regras de negócio:
  - Nenhuma mudança nas regras de negócio implementadas; testes apenas exercem fluxos existentes.
  - Atenção a side effects: testes executam fluxos reais (criação, autorização, atendimento) que alteram estado persistente do DB de teste.

- Impacto em autenticação/ autorização/escopo por perfil/setor:
  - Testes cobrem autenticação real (senha da seed) e redirecionamentos por papel:
    - "chefe-setor" → fila de autorizações
    - "auxiliar-almox" → fila de atendimento
    - solicitantes → minhas requisições
  - Não há mudanças no backend de autorização, mas existe risco de falhas de autorização refletadas como flakiness se seed/perfis divergir.

- Impacto em contratos DRF / serializers / paginação / filtros / envelope de erro / OpenAPI:
  - Não há alterações nos endpoints ou serializers.
  - make frontend-e2e depende de frontend-gen-api (regenera types a partir de OpenAPI) — garante congruência dos tipos TS com OpenAPI.
  - E2E roda via UI; não altera contratos, apenas os valida implicitamente.

- Impacto em integridade de dados / constraints / snapshots históricos / auditoria / rastreabilidade:
  - Seed usa upserts dentro de transaction.atomic(); novo comentário impede uso do reset direto de EstoqueMaterial fora do bootstrap.
  - Testes alteram dados persistentes no ambiente efêmero; não há mudança que quebre auditoria ou snapshots, porém testes podem deixar estado residual entre execuções se não houver limpeza explícita.

- Impacto em transações / concorrência / idempotência / saldo físico / saldo reservado / saldo disponível:
  - Sem mudanças de lógica transacional em runtime; seed registra saldos iniciais.
  - Risco operacional: reexecuções ou retries em CI podem reprocessar fluxos se não forem idempotentes ao nível da seed/testes, potencialmente mascarando problemas de concorrência.

- Impacto em importação SCPI / dados oficiais de materiais / divergência de estoque:
  - Seed carrega materiais oficiais do piloto; divergências entre seed e dados de produção podem existir, mas não há alteração no processo de importação SCPI.

- Impacto em configuração / CI / dependências / lint / testes / ambiente efêmero:
  - Novo job frontend-e2e em .github/workflows/ci.yml:
    - Provisiona Postgres, executa make setup, make seed-pilot-minimo e make frontend-e2e.
    - Instala cliente Postgres; instala Chromium; publica relatórios/traces em falha.
  - Makefile: frontend-e2e agora depende de frontend-gen-api e seed-pilot-minimo.
  - frontend/playwright.config.ts: fullyParallel → false; webServer agora é array (Django + Vite); workers: 1 em CI; trace on-first-retry; reuseExistingServer controlado por CI.
  - Ajustes tornam a pipeline mais integrada, mas aumentam superfície de falha (infra + seed).

- Como validar manualmente:
  - Local:
    - rtk make setup
    - rtk make seed-pilot-minimo
    - rtk make frontend-e2e
  - CI:
    - Push/PR para acionar workflow CI e observar job frontend-e2e (artifacts e traces em falha).
  - Verificações específicas:
    - Login/logout para perfis da seed; navegação para /minhas-requisicoes, /autorizacoes, /atendimentos.
    - Criar rascunho, enviar, autorizar e atender uma requisição via UI reproduzida pelo Playwright.
    - Conferir que seed upsertou usuários/materials/setores e saldos iniciais via admin ou DB (psql).

---

### Testes E2E e cenários validados

- Arquivo frontend/tests/e2e/shell.spec.ts reescrito: remove page.route mocks e executa fluxos reais.
- Cenários cobertos:
  1. Login/logout e redirecionamento por papel.
  2. Listagem e abertura de "Minhas requisições".
  3. Criação de requisição (rascunho) e envio para autorização.
  4. Autorização pela fila operacional.
  5. Atendimento pela fila operacional.
- Asserções via URL/contexto (?contexto=...) e conteúdo DOM.

---

### Pontos de atenção / riscos principais

- Falha ou lentidão na execução de make seed-pilot-minimo pode deixar o DB em estado inesperado → testar robustez da seed e idempotência dos upserts.
- Seed contém senha hardcoded ("piloto-minimo") — aceitável para ambiente efêmero, documentado; não usar em produção.
- Sincronização entre subida dos servidores e disponibilidade dos dados da seed pode causar flakiness; recomenda-se garantir que a seed finalize antes de Playwright começar (ou adicionar checagem específica).
- Não há mudanças na lógica de autorização ou em modelos de negócio, mas testes que exercem fluxos reais exigem cuidado para não mascarar problemas de concorrência, consistência de saldo ou auditoria.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/59)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->