### PR TITLE
feat(notifications): notificações contextuais da SPA (issue #44)

### DIFF
--- a/apps/notifications/models.py
+++ b/apps/notifications/models.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.utils import timezone
 
 from apps.users.models import PapelChoices
 
@@ -97,10 +96,3 @@ class Notificacao(models.Model):
     def __str__(self):
         destino = self.destinatario_id or self.papel_destinatario
         return f"{self.tipo} -> {destino}"
-
-    def marcar_como_lida(self):
-        if self.lida:
-            return
-        self.lida = True
-        self.lida_em = timezone.now()
-        self.save(update_fields=["lida", "lida_em"])

--- a/apps/notifications/policies.py
+++ b/apps/notifications/policies.py
@@ -1,0 +1,12 @@
+from django.db.models import Q, QuerySet
+
+from apps.notifications.models import Notificacao
+from apps.users.models import User
+
+
+def queryset_notificacoes_visiveis(usuario: User) -> QuerySet[Notificacao]:
+    return (
+        Notificacao.objects.filter(Q(destinatario=usuario) | Q(papel_destinatario=usuario.papel))
+        .select_related("content_type", "destinatario")
+        .order_by("-created_at", "-id")
+    )

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -3,6 +3,9 @@ from rest_framework import serializers
 
 from apps.notifications.models import Notificacao
 
+REQUISICAO_APP_LABEL = "requisitions"
+REQUISICAO_MODEL = "requisicao"
+
 
 class NotificacaoDestinoOutputSerializer(serializers.Serializer):
     tipo = serializers.ChoiceField(choices=["usuario", "papel"], read_only=True)
@@ -61,7 +64,10 @@ class NotificacaoOutputSerializer(serializers.ModelSerializer):
         if obj.content_type_id is None or obj.object_id is None:
             return None
 
-        if obj.content_type.app_label != "requisitions" or obj.content_type.model != "requisicao":
+        if (
+            obj.content_type.app_label != REQUISICAO_APP_LABEL
+            or obj.content_type.model != REQUISICAO_MODEL
+        ):
             return None
 
         requisicao = obj.objeto_relacionado

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -1,0 +1,93 @@
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from apps.notifications.models import Notificacao
+
+
+class NotificacaoDestinoOutputSerializer(serializers.Serializer):
+    tipo = serializers.ChoiceField(choices=["usuario", "papel"], read_only=True)
+    usuario_id = serializers.IntegerField(required=False, allow_null=True, read_only=True)
+    papel = serializers.CharField(required=False, allow_null=True, read_only=True)
+
+
+class NotificacaoObjetoRelacionadoOutputSerializer(serializers.Serializer):
+    tipo = serializers.CharField(read_only=True)
+    id = serializers.IntegerField(read_only=True)
+    numero_publico = serializers.CharField(required=False, allow_null=True, read_only=True)
+    status = serializers.CharField(required=False, read_only=True)
+
+
+class NotificacaoOutputSerializer(serializers.ModelSerializer):
+    leitura_suportada = serializers.SerializerMethodField()
+    destino = serializers.SerializerMethodField()
+    objeto_relacionado = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Notificacao
+        fields = [
+            "id",
+            "tipo",
+            "titulo",
+            "mensagem",
+            "created_at",
+            "lida",
+            "lida_em",
+            "leitura_suportada",
+            "destino",
+            "objeto_relacionado",
+        ]
+        read_only_fields = fields
+
+    def get_leitura_suportada(self, obj: Notificacao) -> bool:
+        return obj.destinatario_id is not None
+
+    @extend_schema_field(NotificacaoDestinoOutputSerializer)
+    def get_destino(self, obj: Notificacao) -> dict[str, object]:
+        if obj.destinatario_id is not None:
+            return {
+                "tipo": "usuario",
+                "usuario_id": obj.destinatario_id,
+                "papel": None,
+            }
+
+        return {
+            "tipo": "papel",
+            "usuario_id": None,
+            "papel": obj.papel_destinatario,
+        }
+
+    @extend_schema_field(NotificacaoObjetoRelacionadoOutputSerializer(allow_null=True))
+    def get_objeto_relacionado(self, obj: Notificacao) -> dict[str, object] | None:
+        if obj.content_type_id is None or obj.object_id is None:
+            return None
+
+        if obj.content_type.app_label != "requisitions" or obj.content_type.model != "requisicao":
+            return None
+
+        requisicao = obj.objeto_relacionado
+        if requisicao is None:
+            return {
+                "tipo": "requisicao",
+                "id": obj.object_id,
+            }
+
+        return {
+            "tipo": "requisicao",
+            "id": requisicao.id,
+            "numero_publico": requisicao.numero_publico,
+            "status": requisicao.status,
+        }
+
+
+class NotificacaoListPaginatedSerializer(serializers.Serializer):
+    count = serializers.IntegerField(read_only=True)
+    page = serializers.IntegerField(read_only=True)
+    page_size = serializers.IntegerField(read_only=True)
+    total_pages = serializers.IntegerField(read_only=True)
+    next = serializers.URLField(allow_null=True, read_only=True)
+    previous = serializers.URLField(allow_null=True, read_only=True)
+    results = NotificacaoOutputSerializer(many=True, read_only=True)
+
+
+class NotificacaoUnreadCountOutputSerializer(serializers.Serializer):
+    unread_count = serializers.IntegerField(read_only=True)

--- a/apps/notifications/services.py
+++ b/apps/notifications/services.py
@@ -1,6 +1,7 @@
 from collections.abc import Iterable
 
 from django.contrib.contenttypes.models import ContentType
+from django.utils import timezone
 from rest_framework.exceptions import PermissionDenied
 
 from apps.notifications.models import Notificacao, TipoNotificacao
@@ -85,5 +86,12 @@ def marcar_notificacao_como_lida(*, notificacao: Notificacao, usuario: User) -> 
         raise PermissionDenied("Notificações coletivas por papel não possuem leitura individual.")
     if notificacao.destinatario_id != usuario.pk:
         raise PermissionDenied("Usuário não é destinatário desta notificação.")
-    notificacao.marcar_como_lida()
+    if not notificacao.lida:
+        notificacao.lida = True
+        notificacao.lida_em = timezone.now()
+        notificacao.save(update_fields=["lida", "lida_em"])
     return notificacao
+
+
+def contar_notificacoes_individuais_nao_lidas(*, usuario: User) -> int:
+    return Notificacao.objects.filter(destinatario=usuario, lida=False).count()

--- a/apps/notifications/services.py
+++ b/apps/notifications/services.py
@@ -86,10 +86,11 @@ def marcar_notificacao_como_lida(*, notificacao: Notificacao, usuario: User) -> 
         raise PermissionDenied("Notificações coletivas por papel não possuem leitura individual.")
     if notificacao.destinatario_id != usuario.pk:
         raise PermissionDenied("Usuário não é destinatário desta notificação.")
-    if not notificacao.lida:
-        notificacao.lida = True
-        notificacao.lida_em = timezone.now()
-        notificacao.save(update_fields=["lida", "lida_em"])
+    Notificacao.objects.filter(pk=notificacao.pk, lida=False).update(
+        lida=True,
+        lida_em=timezone.now(),
+    )
+    notificacao.refresh_from_db(fields=["lida", "lida_em"])
     return notificacao
 
 

--- a/apps/notifications/urls.py
+++ b/apps/notifications/urls.py
@@ -1,0 +1,8 @@
+from rest_framework.routers import SimpleRouter
+
+from apps.notifications.views import NotificacaoViewSet
+
+router = SimpleRouter()
+router.register("notifications", NotificacaoViewSet, basename="notification")
+
+urlpatterns = router.urls

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -16,7 +16,10 @@ from apps.notifications.serializers import (
     NotificacaoOutputSerializer,
     NotificacaoUnreadCountOutputSerializer,
 )
-from apps.notifications.services import marcar_notificacao_como_lida
+from apps.notifications.services import (
+    contar_notificacoes_individuais_nao_lidas,
+    marcar_notificacao_como_lida,
+)
 
 
 class NotificacaoViewSet(mixins.ListModelMixin, GenericViewSet):
@@ -87,6 +90,10 @@ class NotificacaoViewSet(mixins.ListModelMixin, GenericViewSet):
     @extend_schema(
         operation_id="notifications_unread_count",
         tags=["notifications"],
+        description=(
+            "Retorna o contador de notificações individuais não lidas do usuário autenticado. "
+            "Notificações coletivas por papel não entram nesse contador."
+        ),
         responses={
             200: NotificacaoUnreadCountOutputSerializer(),
             403: ErrorResponseSerializer(),
@@ -94,5 +101,5 @@ class NotificacaoViewSet(mixins.ListModelMixin, GenericViewSet):
     )
     @action(detail=False, methods=["get"], url_path="unread-count")
     def unread_count(self, request):
-        unread_count = request.user.notificacoes.filter(lida=False).count()
+        unread_count = contar_notificacoes_individuais_nao_lidas(usuario=request.user)
         return Response({"unread_count": unread_count})

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -1,0 +1,98 @@
+from django.shortcuts import get_object_or_404
+from drf_spectacular.helpers import forced_singular_serializer
+from drf_spectacular.openapi import OpenApiParameter
+from drf_spectacular.utils import extend_schema
+from rest_framework import mixins
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import GenericViewSet
+
+from apps.core.api.serializers import ErrorResponseSerializer
+from apps.notifications.models import Notificacao
+from apps.notifications.policies import queryset_notificacoes_visiveis
+from apps.notifications.serializers import (
+    NotificacaoListPaginatedSerializer,
+    NotificacaoOutputSerializer,
+    NotificacaoUnreadCountOutputSerializer,
+)
+from apps.notifications.services import marcar_notificacao_como_lida
+
+
+class NotificacaoViewSet(mixins.ListModelMixin, GenericViewSet):
+    permission_classes = [IsAuthenticated]
+    serializer_class = NotificacaoOutputSerializer
+    queryset = Notificacao.objects.none()
+
+    def get_queryset(self):
+        if getattr(self, "swagger_fake_view", False):
+            return self.queryset
+        return queryset_notificacoes_visiveis(self.request.user)
+
+    def get_object(self):
+        queryset = self.get_queryset()
+        obj = get_object_or_404(queryset, pk=self.kwargs["pk"])
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    @extend_schema(
+        operation_id="notifications_list",
+        tags=["notifications"],
+        description=(
+            "Lista paginada das notificações visíveis ao usuário autenticado. "
+            "Inclui notificações individuais do usuário e notificações coletivas do papel atual."
+        ),
+        parameters=[
+            OpenApiParameter(
+                name="page",
+                description="Número da página (padrão: 1)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+            OpenApiParameter(
+                name="page_size",
+                description="Quantidade de resultados por página (padrão: 20, máximo: 100)",
+                required=False,
+                type=int,
+                location=OpenApiParameter.QUERY,
+            ),
+        ],
+        responses={
+            200: forced_singular_serializer(NotificacaoListPaginatedSerializer),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
+
+    @extend_schema(
+        operation_id="notifications_mark_read",
+        tags=["notifications"],
+        request=None,
+        responses={
+            200: NotificacaoOutputSerializer(),
+            403: ErrorResponseSerializer(),
+            404: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=True, methods=["post"], url_path="mark-read")
+    def mark_read(self, request, pk=None):
+        notificacao = marcar_notificacao_como_lida(
+            notificacao=self.get_object(),
+            usuario=request.user,
+        )
+        return Response(NotificacaoOutputSerializer(notificacao).data)
+
+    @extend_schema(
+        operation_id="notifications_unread_count",
+        tags=["notifications"],
+        responses={
+            200: NotificacaoUnreadCountOutputSerializer(),
+            403: ErrorResponseSerializer(),
+        },
+    )
+    @action(detail=False, methods=["get"], url_path="unread-count")
+    def unread_count(self, request):
+        unread_count = request.user.notificacoes.filter(lida=False).count()
+        return Response({"unread_count": unread_count})

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/", include("apps.materials.urls")),
     path("api/v1/", include("apps.requisitions.urls")),
+    path("api/v1/", include("apps.notifications.urls")),
     path(
         "api/v1/schema/",
         SpectacularAPIView.as_view(**schema_view_kwargs),

--- a/frontend/openapi/schema.json
+++ b/frontend/openapi/schema.json
@@ -300,6 +300,151 @@
                 }
             }
         },
+        "/api/v1/notifications/": {
+            "get": {
+                "operationId": "notifications_list",
+                "description": "Lista paginada das notificações visíveis ao usuário autenticado. Inclui notificações individuais do usuário e notificações coletivas do papel atual.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Número da página (padrão: 1)"
+                    },
+                    {
+                        "in": "query",
+                        "name": "page_size",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Quantidade de resultados por página (padrão: 20, máximo: 100)"
+                    }
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotificacaoListPaginated"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/notifications/{id}/mark-read/": {
+            "post": {
+                "operationId": "notifications_mark_read",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "integer"
+                        },
+                        "description": "Um valor inteiro único que identifica este Notificação.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotificacaoOutput"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/notifications/unread-count/": {
+            "get": {
+                "operationId": "notifications_unread_count",
+                "tags": [
+                    "notifications"
+                ],
+                "security": [
+                    {
+                        "cookieAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotificacaoUnreadCountOutput"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1/requisitions/": {
             "get": {
                 "operationId": "requisitions_list",
@@ -1829,6 +1974,216 @@
                     "previous",
                     "results",
                     "total_pages"
+                ]
+            },
+            "NotificacaoDestinoOutput": {
+                "type": "object",
+                "properties": {
+                    "tipo": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/NotificacaoDestinoOutputTipoEnum"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "usuario_id": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "papel": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "papel",
+                    "tipo",
+                    "usuario_id"
+                ]
+            },
+            "NotificacaoDestinoOutputTipoEnum": {
+                "enum": [
+                    "usuario",
+                    "papel"
+                ],
+                "type": "string",
+                "description": "* `usuario` - usuario\n* `papel` - papel"
+            },
+            "NotificacaoListPaginated": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "page": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "page_size": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "total_pages": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "next": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "previous": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/NotificacaoOutput"
+                        },
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "count",
+                    "next",
+                    "page",
+                    "page_size",
+                    "previous",
+                    "results",
+                    "total_pages"
+                ]
+            },
+            "NotificacaoObjetoRelacionadoOutput": {
+                "type": "object",
+                "properties": {
+                    "tipo": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "numero_publico": {
+                        "type": "string",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "status": {
+                        "type": "string",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "id",
+                    "numero_publico",
+                    "status",
+                    "tipo"
+                ]
+            },
+            "NotificacaoOutput": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "tipo": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/NotificacaoOutputTipoEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Tipo de notificação.\n\n* `requisicao_enviada_autorizacao` - Requisição enviada para autorização\n* `requisicao_autorizada` - Requisição autorizada\n* `requisicao_recusada` - Requisição recusada\n* `requisicao_cancelada` - Requisição cancelada\n* `requisicao_atendida` - Requisição atendida"
+                    },
+                    "titulo": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "mensagem": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "lida": {
+                        "type": "boolean",
+                        "readOnly": true
+                    },
+                    "lida_em": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "nullable": true
+                    },
+                    "leitura_suportada": {
+                        "type": "boolean",
+                        "readOnly": true
+                    },
+                    "destino": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/NotificacaoDestinoOutput"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "objeto_relacionado": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/NotificacaoObjetoRelacionadoOutput"
+                            }
+                        ],
+                        "nullable": true,
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "destino",
+                    "id",
+                    "leitura_suportada",
+                    "lida",
+                    "lida_em",
+                    "mensagem",
+                    "objeto_relacionado",
+                    "tipo",
+                    "titulo"
+                ]
+            },
+            "NotificacaoOutputTipoEnum": {
+                "enum": [
+                    "requisicao_enviada_autorizacao",
+                    "requisicao_autorizada",
+                    "requisicao_recusada",
+                    "requisicao_cancelada",
+                    "requisicao_atendida"
+                ],
+                "type": "string",
+                "description": "* `requisicao_enviada_autorizacao` - Requisição enviada para autorização\n* `requisicao_autorizada` - Requisição autorizada\n* `requisicao_recusada` - Requisição recusada\n* `requisicao_cancelada` - Requisição cancelada\n* `requisicao_atendida` - Requisição atendida"
+            },
+            "NotificacaoUnreadCountOutput": {
+                "type": "object",
+                "properties": {
+                    "unread_count": {
+                        "type": "integer",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "unread_count"
                 ]
             },
             "RequisicaoActionOutput": {

--- a/frontend/openapi/schema.json
+++ b/frontend/openapi/schema.json
@@ -413,6 +413,7 @@
         "/api/v1/notifications/unread-count/": {
             "get": {
                 "operationId": "notifications_unread_count",
+                "description": "Retorna o contador de notificações individuais não lidas do usuário autenticado. Notificações coletivas por papel não entram nesse contador.",
                 "tags": [
                     "notifications"
                 ],

--- a/frontend/src/app/layouts/app-shell.tsx
+++ b/frontend/src/app/layouts/app-shell.tsx
@@ -48,6 +48,7 @@ export function AppShell() {
     retry: false,
     onSuccess: async () => {
       queryClient.removeQueries({ queryKey: authQueryKeys.me });
+      queryClient.removeQueries({ queryKey: notificationsQueryKeys.all });
       await navigate({ to: "/login", search: { redirect: undefined } });
     },
   });
@@ -205,7 +206,10 @@ export function AppShell() {
                               <button
                                 className="notification-read-button"
                                 disabled={markReadMutation.isPending}
-                                onClick={() => markReadMutation.mutate(notification.id)}
+                                onClick={() => {
+                                  markReadMutation.reset();
+                                  markReadMutation.mutate(notification.id);
+                                }}
                                 type="button"
                               >
                                 Marcar como lida

--- a/frontend/src/app/layouts/app-shell.tsx
+++ b/frontend/src/app/layouts/app-shell.tsx
@@ -2,6 +2,15 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, Outlet, useLocation, useNavigate } from "@tanstack/react-router";
 
 import { ApiError, authQueryKeys, logoutSession, meQueryOptions } from "../../features/auth/session";
+import {
+  formatNotificationDate,
+  markNotificationRead,
+  notificationListQueryOptions,
+  notificationOperationalContext,
+  notificationOperationalLabel,
+  notificationUnreadCountQueryOptions,
+  notificationsQueryKeys,
+} from "../../features/notifications/notifications";
 import { navigationItems } from "../../shared/config/navigation";
 
 function messageFromLogoutError(error: unknown) {
@@ -14,6 +23,18 @@ function messageFromLogoutError(error: unknown) {
   }
 
   return "Não foi possível sair. Tente novamente.";
+}
+
+function messageFromNotificationError(error: unknown) {
+  if (error instanceof ApiError) {
+    return error.payload?.error.message || error.message;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Não foi possível carregar notificações.";
 }
 
 export function AppShell() {
@@ -30,6 +51,25 @@ export function AppShell() {
       await navigate({ to: "/login", search: { redirect: undefined } });
     },
   });
+  const notificationsQuery = useQuery({
+    ...notificationListQueryOptions({ page: 1, pageSize: 6 }),
+    enabled: Boolean(session),
+  });
+  const unreadCountQuery = useQuery({
+    ...notificationUnreadCountQueryOptions,
+    enabled: Boolean(session),
+  });
+  const markReadMutation = useMutation({
+    mutationFn: markNotificationRead,
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: notificationsQueryKeys.all }),
+        queryClient.invalidateQueries({ queryKey: notificationsQueryKeys.unreadCount }),
+      ]);
+    },
+  });
+  const notifications = notificationsQuery.data?.results ?? [];
+  const unreadCount = unreadCountQuery.data?.unread_count ?? 0;
 
   return (
     <div className="min-h-screen bg-[var(--page-bg)] text-[var(--ink-strong)]">
@@ -88,6 +128,99 @@ export function AppShell() {
                   </p>
                   {session.setor ? (
                     <p className="mt-2 text-sm text-[var(--ink-soft)]">{session.setor.nome}</p>
+                  ) : null}
+                </div>
+                <div className="notifications-panel">
+                  <div className="notifications-header">
+                    <p className="text-xs uppercase tracking-[0.22em] text-[var(--ink-muted)]">
+                      Notificações
+                    </p>
+                    <span className="notifications-count">{unreadCount}</span>
+                  </div>
+
+                  {notificationsQuery.isLoading || unreadCountQuery.isLoading ? (
+                    <p className="notifications-empty">Carregando notificações...</p>
+                  ) : null}
+
+                  {notificationsQuery.isError || unreadCountQuery.isError ? (
+                    <p className="notifications-error">
+                      {messageFromNotificationError(
+                        notificationsQuery.error ?? unreadCountQuery.error,
+                      )}
+                    </p>
+                  ) : null}
+
+                  {!notificationsQuery.isLoading &&
+                  !notificationsQuery.isError &&
+                  !unreadCountQuery.isError &&
+                  notifications.length === 0 ? (
+                    <p className="notifications-empty">Sem notificações no momento.</p>
+                  ) : null}
+
+                  {!notificationsQuery.isLoading &&
+                  !notificationsQuery.isError &&
+                  !unreadCountQuery.isError &&
+                  notifications.length > 0 ? (
+                    <ul className="notifications-list">
+                      {notifications.map((notification) => {
+                        const relatedObject = notification.objeto_relacionado;
+                        const context = notificationOperationalContext(notification.tipo);
+                        const contextLabel = notificationOperationalLabel(notification.tipo);
+
+                        return (
+                          <li className="notification-item" key={notification.id}>
+                            <div className="notification-meta">
+                              <strong>{notification.titulo}</strong>
+                              <span>{formatNotificationDate(notification.created_at)}</span>
+                            </div>
+                            <p className="notification-message">{notification.mensagem}</p>
+
+                            {notification.destino.tipo === "papel" ? (
+                              <span className="notification-badge">Aviso coletivo</span>
+                            ) : null}
+
+                            {relatedObject?.tipo === "requisicao" ? (
+                              <div className="notification-links">
+                                <Link
+                                  className="notification-link"
+                                  params={{ id: String(relatedObject.id) }}
+                                  search={
+                                    context
+                                      ? {
+                                          contexto: context,
+                                        }
+                                      : undefined
+                                  }
+                                  to="/requisicoes/$id"
+                                >
+                                  Abrir requisição
+                                </Link>
+                                {contextLabel ? (
+                                  <span className="notification-context">{contextLabel}</span>
+                                ) : null}
+                              </div>
+                            ) : null}
+
+                            {notification.leitura_suportada && !notification.lida ? (
+                              <button
+                                className="notification-read-button"
+                                disabled={markReadMutation.isPending}
+                                onClick={() => markReadMutation.mutate(notification.id)}
+                                type="button"
+                              >
+                                Marcar como lida
+                              </button>
+                            ) : null}
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  ) : null}
+
+                  {markReadMutation.isError ? (
+                    <p className="notifications-error">
+                      {messageFromNotificationError(markReadMutation.error)}
+                    </p>
                   ) : null}
                 </div>
                 <button

--- a/frontend/src/app/layouts/app-shell.tsx
+++ b/frontend/src/app/layouts/app-shell.tsx
@@ -152,6 +152,7 @@ export function AppShell() {
                   ) : null}
 
                   {!notificationsQuery.isLoading &&
+                  !unreadCountQuery.isLoading &&
                   !notificationsQuery.isError &&
                   !unreadCountQuery.isError &&
                   notifications.length === 0 ? (
@@ -159,6 +160,7 @@ export function AppShell() {
                   ) : null}
 
                   {!notificationsQuery.isLoading &&
+                  !unreadCountQuery.isLoading &&
                   !notificationsQuery.isError &&
                   !unreadCountQuery.isError &&
                   notifications.length > 0 ? (

--- a/frontend/src/features/notifications/notifications.ts
+++ b/frontend/src/features/notifications/notifications.ts
@@ -116,7 +116,7 @@ export function notificationOperationalLabel(tipo: NotificationType) {
   if (tipo === "requisicao_autorizada") {
     return "Fila de atendimentos";
   }
-  return null;
+  return undefined;
 }
 
 export function formatNotificationDate(value: string) {

--- a/frontend/src/features/notifications/notifications.ts
+++ b/frontend/src/features/notifications/notifications.ts
@@ -1,0 +1,127 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { ApiError, type ErrorResponse } from "../auth/session";
+import { apiClient } from "../../shared/api/client";
+import type { components } from "../../shared/api/schema";
+
+export type NotificationItem = components["schemas"]["NotificacaoOutput"];
+export type NotificationListResponse = components["schemas"]["NotificacaoListPaginated"];
+export type NotificationUnreadCountResponse =
+  components["schemas"]["NotificacaoUnreadCountOutput"];
+export type NotificationType = NotificationItem["tipo"];
+
+export type NotificationListParams = {
+  page: number;
+  pageSize: number;
+};
+
+const notificationsBaseQueryKey = ["notifications"] as const;
+const notificationsUnreadCountKey = [...notificationsBaseQueryKey, "unread-count"] as const;
+
+export const notificationsQueryKeys = {
+  all: notificationsBaseQueryKey,
+  list: (params: NotificationListParams) =>
+    [
+      ...notificationsBaseQueryKey,
+      "list",
+      { page: params.page, pageSize: params.pageSize },
+    ] as const,
+  unreadCount: notificationsUnreadCountKey,
+};
+
+function messageFromError(error: ErrorResponse | undefined, fallback: string) {
+  return error?.error?.message || fallback;
+}
+
+export async function fetchNotifications(params: NotificationListParams) {
+  const { data, error, response } = await apiClient.GET("/api/v1/notifications/", {
+    params: {
+      query: {
+        page: params.page,
+        page_size: params.pageSize,
+      },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar notificações."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function fetchNotificationUnreadCount() {
+  const { data, error, response } = await apiClient.GET("/api/v1/notifications/unread-count/");
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível carregar contador de notificações."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export async function markNotificationRead(id: number) {
+  const { data, error, response } = await apiClient.POST("/api/v1/notifications/{id}/mark-read/", {
+    params: {
+      path: { id },
+    },
+  });
+
+  if (error || !data) {
+    throw new ApiError(
+      messageFromError(error, "Não foi possível marcar notificação como lida."),
+      response.status,
+      error,
+    );
+  }
+
+  return data;
+}
+
+export const notificationListQueryOptions = (params: NotificationListParams) =>
+  queryOptions({
+    queryKey: notificationsQueryKeys.list(params),
+    queryFn: () => fetchNotifications(params),
+    retry: false,
+  });
+
+export const notificationUnreadCountQueryOptions = queryOptions({
+  queryKey: notificationsQueryKeys.unreadCount,
+  queryFn: fetchNotificationUnreadCount,
+  retry: false,
+});
+
+export function notificationOperationalContext(tipo: NotificationType) {
+  if (tipo === "requisicao_enviada_autorizacao") {
+    return "autorizacao" as const;
+  }
+  if (tipo === "requisicao_autorizada") {
+    return "atendimento" as const;
+  }
+  return undefined;
+}
+
+export function notificationOperationalLabel(tipo: NotificationType) {
+  if (tipo === "requisicao_enviada_autorizacao") {
+    return "Fila de autorizações";
+  }
+  if (tipo === "requisicao_autorizada") {
+    return "Fila de atendimentos";
+  }
+  return null;
+}
+
+export function formatNotificationDate(value: string) {
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -102,6 +102,55 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/notifications/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Lista paginada das notificações visíveis ao usuário autenticado. Inclui notificações individuais do usuário e notificações coletivas do papel atual. */
+        get: operations["notifications_list"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/notifications/{id}/mark-read/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["notifications_mark_read"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/notifications/unread-count/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["notifications_unread_count"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/requisitions/": {
         parameters: {
             query?: never;
@@ -422,6 +471,69 @@ export interface components {
             /** Format: uri */
             readonly previous: string | null;
             readonly results: components["schemas"]["MaterialListOutput"][];
+        };
+        NotificacaoDestinoOutput: {
+            readonly tipo: components["schemas"]["NotificacaoDestinoOutputTipoEnum"];
+            readonly usuario_id: number | null;
+            readonly papel: string | null;
+        };
+        /**
+         * @description * `usuario` - usuario
+         *     * `papel` - papel
+         * @enum {string}
+         */
+        NotificacaoDestinoOutputTipoEnum: "usuario" | "papel";
+        NotificacaoListPaginated: {
+            readonly count: number;
+            readonly page: number;
+            readonly page_size: number;
+            readonly total_pages: number;
+            /** Format: uri */
+            readonly next: string | null;
+            /** Format: uri */
+            readonly previous: string | null;
+            readonly results: components["schemas"]["NotificacaoOutput"][];
+        };
+        NotificacaoObjetoRelacionadoOutput: {
+            readonly tipo: string;
+            readonly id: number;
+            readonly numero_publico: string | null;
+            readonly status: string;
+        };
+        NotificacaoOutput: {
+            readonly id: number;
+            /**
+             * @description Tipo de notificação.
+             *
+             *     * `requisicao_enviada_autorizacao` - Requisição enviada para autorização
+             *     * `requisicao_autorizada` - Requisição autorizada
+             *     * `requisicao_recusada` - Requisição recusada
+             *     * `requisicao_cancelada` - Requisição cancelada
+             *     * `requisicao_atendida` - Requisição atendida
+             */
+            readonly tipo: components["schemas"]["NotificacaoOutputTipoEnum"];
+            readonly titulo: string;
+            readonly mensagem: string;
+            /** Format: date-time */
+            readonly created_at: string;
+            readonly lida: boolean;
+            /** Format: date-time */
+            readonly lida_em: string | null;
+            readonly leitura_suportada: boolean;
+            readonly destino: components["schemas"]["NotificacaoDestinoOutput"];
+            readonly objeto_relacionado: components["schemas"]["NotificacaoObjetoRelacionadoOutput"] | null;
+        };
+        /**
+         * @description * `requisicao_enviada_autorizacao` - Requisição enviada para autorização
+         *     * `requisicao_autorizada` - Requisição autorizada
+         *     * `requisicao_recusada` - Requisição recusada
+         *     * `requisicao_cancelada` - Requisição cancelada
+         *     * `requisicao_atendida` - Requisição atendida
+         * @enum {string}
+         */
+        NotificacaoOutputTipoEnum: "requisicao_enviada_autorizacao" | "requisicao_autorizada" | "requisicao_recusada" | "requisicao_cancelada" | "requisicao_atendida";
+        NotificacaoUnreadCountOutput: {
+            readonly unread_count: number;
         };
         RequisicaoActionOutput: {
             readonly id: number;
@@ -938,6 +1050,103 @@ export interface operations {
                 };
             };
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    notifications_list: {
+        parameters: {
+            query?: {
+                /** @description Número da página (padrão: 1) */
+                page?: number;
+                /** @description Quantidade de resultados por página (padrão: 20, máximo: 100) */
+                page_size?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificacaoListPaginated"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    notifications_mark_read: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Um valor inteiro único que identifica este Notificação. */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificacaoOutput"];
+                };
+            };
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    notifications_unread_count: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificacaoUnreadCountOutput"];
+                };
+            };
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/shared/api/schema.d.ts
+++ b/frontend/src/shared/api/schema.d.ts
@@ -142,6 +142,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** @description Retorna o contador de notificações individuais não lidas do usuário autenticado. Notificações coletivas por papel não entram nesse contador. */
         get: operations["notifications_unread_count"];
         put?: never;
         post?: never;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -221,6 +221,131 @@ a {
   opacity: 0.82;
 }
 
+.notifications-panel {
+  border-radius: 16px;
+  border: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.66);
+  padding: 0.75rem;
+}
+
+.notifications-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.notifications-count {
+  display: inline-flex;
+  min-width: 1.7rem;
+  justify-content: center;
+  border-radius: 999px;
+  background: var(--accent-soft);
+  padding: 0.1rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.notifications-list {
+  margin: 0.6rem 0 0;
+  display: grid;
+  gap: 0.55rem;
+  list-style: none;
+  padding: 0;
+}
+
+.notification-item {
+  border-radius: 12px;
+  border: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.86);
+  padding: 0.55rem;
+}
+
+.notification-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.notification-meta strong {
+  font-size: 0.82rem;
+  color: var(--ink-strong);
+}
+
+.notification-meta span {
+  font-size: 0.7rem;
+  color: var(--ink-muted);
+}
+
+.notification-message {
+  margin: 0.3rem 0 0;
+  font-size: 0.77rem;
+  color: var(--ink-soft);
+}
+
+.notification-badge {
+  margin-top: 0.4rem;
+  display: inline-flex;
+  border-radius: 999px;
+  border: 1px solid var(--line-soft);
+  background: rgba(255, 248, 232, 0.95);
+  padding: 0.2rem 0.55rem;
+  font-size: 0.67rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8f6020;
+}
+
+.notification-links {
+  margin-top: 0.35rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.notification-link {
+  font-size: 0.74rem;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  color: var(--ink-strong);
+}
+
+.notification-context {
+  font-size: 0.69rem;
+  color: var(--ink-muted);
+}
+
+.notification-read-button {
+  margin-top: 0.45rem;
+  border-radius: 999px;
+  border: 1px solid var(--line-soft);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 0.28rem 0.6rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.notifications-empty {
+  margin: 0.5rem 0 0;
+  font-size: 0.76rem;
+  color: var(--ink-muted);
+}
+
+.notifications-error {
+  margin: 0.5rem 0 0;
+  border-radius: 10px;
+  border: 1px solid #f1caca;
+  background: #fff4f4;
+  padding: 0.45rem 0.55rem;
+  font-size: 0.73rem;
+  color: #902f2f;
+}
+
 .worklist-header,
 .detail-hero {
   display: flex;

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -203,6 +203,91 @@ function pendingFulfillmentListResponse(results = [pendingFulfillmentListItem()]
   );
 }
 
+function notificationListItem(overrides = {}) {
+  return {
+    id: 901,
+    tipo: "requisicao_enviada_autorizacao",
+    titulo: "Requisição aguardando autorização",
+    mensagem: "A requisição REQ-2026-000101 aguarda autorização.",
+    created_at: "2026-05-02T09:30:00Z",
+    lida: false,
+    lida_em: null,
+    leitura_suportada: true,
+    destino: {
+      tipo: "usuario",
+      usuario_id: 10,
+      papel: null,
+    },
+    objeto_relacionado: {
+      tipo: "requisicao",
+      id: 101,
+      numero_publico: "REQ-2026-000101",
+      status: "aguardando_autorizacao",
+    },
+    ...overrides,
+  };
+}
+
+function notificationListResponse(results = [notificationListItem()]) {
+  return new Response(
+    JSON.stringify({
+      count: results.length,
+      page: 1,
+      page_size: 6,
+      total_pages: 1,
+      next: null,
+      previous: null,
+      results,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function notificationUnreadCountResponse(unreadCount = 0) {
+  return new Response(
+    JSON.stringify({
+      unread_count: unreadCount,
+    }),
+    { status: 200, headers: jsonHeaders },
+  );
+}
+
+function maybeNotificationsRequest(request: Request) {
+  if (
+    requestUrl(request).includes("/api/v1/notifications/") &&
+    request.method === "GET" &&
+    requestUrl(request).includes("/api/v1/notifications/unread-count/")
+  ) {
+    return notificationUnreadCountResponse(1);
+  }
+
+  if (
+    requestUrl(request).includes("/api/v1/notifications/") &&
+    request.method === "GET" &&
+    !requestUrl(request).includes("/mark-read/")
+  ) {
+    return notificationListResponse();
+  }
+
+  if (
+    requestUrl(request).includes("/api/v1/notifications/") &&
+    request.method === "POST" &&
+    requestUrl(request).includes("/mark-read/")
+  ) {
+    return new Response(
+      JSON.stringify(
+        notificationListItem({
+          lida: true,
+          lida_em: "2026-05-02T09:35:00Z",
+        }),
+      ),
+      { status: 200, headers: jsonHeaders },
+    );
+  }
+
+  return null;
+}
+
 function requisitionDetailResponse(
   itemOverrides: Record<string, unknown> = {},
   requisitionOverrides: Record<string, unknown> = {},
@@ -501,6 +586,8 @@ function mockCurrentSession(papel = "solicitante") {
         return sessionResponse(authSession(papel));
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     }),
   );
@@ -547,6 +634,8 @@ describe("frontend scaffold router", () => {
         return sessionResponse(session);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -598,7 +687,9 @@ describe("frontend scaffold router", () => {
           );
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -633,6 +724,8 @@ describe("frontend scaffold router", () => {
         return sessionResponse(authSession("solicitante"));
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -669,6 +762,8 @@ describe("frontend scaffold router", () => {
         return sessionResponse(authSession("solicitante"));
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -699,7 +794,9 @@ describe("frontend scaffold router", () => {
           return unauthenticatedResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -718,7 +815,9 @@ describe("frontend scaffold router", () => {
           return forbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -753,7 +852,9 @@ describe("frontend scaffold router", () => {
           ]);
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
     renderRoute("/minhas-requisicoes");
@@ -791,7 +892,9 @@ describe("frontend scaffold router", () => {
           ]);
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -819,7 +922,9 @@ describe("frontend scaffold router", () => {
           ]);
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -854,7 +959,9 @@ describe("frontend scaffold router", () => {
           );
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -881,7 +988,9 @@ describe("frontend scaffold router", () => {
           return requisitionListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -908,7 +1017,9 @@ describe("frontend scaffold router", () => {
           return requisitionListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -939,7 +1050,9 @@ describe("frontend scaffold router", () => {
           return pendingApprovalListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -959,7 +1072,9 @@ describe("frontend scaffold router", () => {
           return sessionResponse(authSession("solicitante"));
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -982,7 +1097,9 @@ describe("frontend scaffold router", () => {
           return pendingApprovalListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1007,7 +1124,9 @@ describe("frontend scaffold router", () => {
           return pendingApprovalListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1037,7 +1156,9 @@ describe("frontend scaffold router", () => {
           return pendingApprovalListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1065,7 +1186,9 @@ describe("frontend scaffold router", () => {
           return pendingFulfillmentListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1095,7 +1218,9 @@ describe("frontend scaffold router", () => {
           return pendingFulfillmentListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1130,7 +1255,9 @@ describe("frontend scaffold router", () => {
           return requisitionListResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1167,7 +1294,9 @@ describe("frontend scaffold router", () => {
           return requisitionDetailResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1193,7 +1322,9 @@ describe("frontend scaffold router", () => {
           return requisitionDetailResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1216,7 +1347,9 @@ describe("frontend scaffold router", () => {
           return sessionResponse(authSession("solicitante"));
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1239,7 +1372,9 @@ describe("frontend scaffold router", () => {
           return forbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1261,7 +1396,9 @@ describe("frontend scaffold router", () => {
           return requisitionDetailResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1288,7 +1425,9 @@ describe("frontend scaffold router", () => {
           });
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1320,6 +1459,8 @@ describe("frontend scaffold router", () => {
         return pendingApprovalListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1367,6 +1508,8 @@ describe("frontend scaffold router", () => {
         return pendingFulfillmentListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1424,6 +1567,8 @@ describe("frontend scaffold router", () => {
         return pendingFulfillmentListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1485,7 +1630,9 @@ describe("frontend scaffold router", () => {
           );
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1516,7 +1663,9 @@ describe("frontend scaffold router", () => {
             return new Response(null, { status: 401, headers: jsonHeaders });
           }
 
-          throw new Error(`Unexpected request: ${requestUrl(request)}`);
+          const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
         }),
       );
 
@@ -1554,6 +1703,8 @@ describe("frontend scaffold router", () => {
         return pendingFulfillmentListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1595,7 +1746,9 @@ describe("frontend scaffold router", () => {
             return new Response(null, { status: 401, headers: jsonHeaders });
           }
 
-          throw new Error(`Unexpected request: ${requestUrl(request)}`);
+          const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
         }),
       );
 
@@ -1628,7 +1781,9 @@ describe("frontend scaffold router", () => {
           return unauthenticatedForbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1651,7 +1806,9 @@ describe("frontend scaffold router", () => {
           return unauthenticatedForbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1673,7 +1830,9 @@ describe("frontend scaffold router", () => {
           return forbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1703,6 +1862,8 @@ describe("frontend scaffold router", () => {
         return pendingApprovalListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1756,6 +1917,8 @@ describe("frontend scaffold router", () => {
         return pendingApprovalListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1804,6 +1967,8 @@ describe("frontend scaffold router", () => {
         return pendingApprovalListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -1855,7 +2020,9 @@ describe("frontend scaffold router", () => {
           );
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1884,7 +2051,9 @@ describe("frontend scaffold router", () => {
           return unauthenticatedResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1916,7 +2085,9 @@ describe("frontend scaffold router", () => {
           return unauthenticatedForbiddenResponse();
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -1973,6 +2144,8 @@ describe("frontend scaffold router", () => {
         });
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2024,6 +2197,8 @@ describe("frontend scaffold router", () => {
         return requisitionDetailResponse();
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2071,6 +2246,8 @@ describe("frontend scaffold router", () => {
         return requisitionDetailResponse();
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2123,6 +2300,8 @@ describe("frontend scaffold router", () => {
         return requisitionDetailResponse();
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2164,6 +2343,8 @@ describe("frontend scaffold router", () => {
         return draftRequisitionDetailResponse({ observacao: "Observacao nova" });
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2220,6 +2401,8 @@ describe("frontend scaffold router", () => {
         return requisitionDetailResponse();
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2270,6 +2453,8 @@ describe("frontend scaffold router", () => {
         return requisitionListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2307,6 +2492,8 @@ describe("frontend scaffold router", () => {
         return requisitionListResponse([]);
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2348,7 +2535,9 @@ describe("frontend scaffold router", () => {
           ]);
         }
 
-        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
       }),
     );
 
@@ -2363,6 +2552,163 @@ describe("frontend scaffold router", () => {
     expect(addButton).toBeDisabled();
     expect(screen.getByText(/saldo 0 UN/i)).toBeInTheDocument();
     expect(screen.getByText("Nenhum material adicionado.")).toBeInTheDocument();
+  });
+
+  it("renders notifications counter and collective badge in app shell", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/notifications/unread-count/")) {
+        return notificationUnreadCountResponse(2);
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/notifications/") &&
+        request.method === "GET" &&
+        !requestUrl(request).includes("/mark-read/")
+      ) {
+        return notificationListResponse([
+          notificationListItem({
+            id: 910,
+            destino: { tipo: "papel", usuario_id: null, papel: "chefe_setor" },
+            leitura_suportada: false,
+            tipo: "requisicao_autorizada",
+            titulo: "Aviso coletivo",
+          }),
+          notificationListItem({
+            id: 911,
+            titulo: "Aviso individual",
+            leitura_suportada: true,
+            destino: { tipo: "usuario", usuario_id: 10, papel: null },
+          }),
+        ]);
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByText("Notificações")).toBeInTheDocument();
+    expect(await screen.findByText("2")).toBeInTheDocument();
+    expect(
+      await screen.findByText("Aviso coletivo", { selector: ".notification-badge" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Marcar como lida" })).toBeInTheDocument();
+  });
+
+  it("marks individual notification as read and refreshes unread counter", async () => {
+    let unreadCount = 1;
+    let notificationsRead = false;
+
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("solicitante"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/notifications/unread-count/")) {
+        return notificationUnreadCountResponse(unreadCount);
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/notifications/") &&
+        request.method === "GET" &&
+        !requestUrl(request).includes("/mark-read/")
+      ) {
+        return notificationListResponse([
+          notificationListItem({
+            id: 920,
+            lida: notificationsRead,
+            lida_em: notificationsRead ? "2026-05-02T09:35:00Z" : null,
+            leitura_suportada: true,
+          }),
+        ]);
+      }
+
+      if (requestUrl(request).includes("/api/v1/notifications/920/mark-read/")) {
+        unreadCount = 0;
+        notificationsRead = true;
+        return new Response(
+          JSON.stringify(
+            notificationListItem({
+              id: 920,
+              lida: true,
+              lida_em: "2026-05-02T09:35:00Z",
+              leitura_suportada: true,
+            }),
+          ),
+          { status: 200, headers: jsonHeaders },
+        );
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/minhas-requisicoes");
+
+    const markReadButton = await screen.findByRole("button", { name: "Marcar como lida" });
+    fireEvent.click(markReadButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("0")).toBeInTheDocument();
+    });
+
+    expect(
+      fetchMock.mock.calls.some(([request]) =>
+        requestUrl(request).includes("/api/v1/notifications/920/mark-read/"),
+      ),
+    ).toBe(true);
+  });
+
+  it("builds requisition link with operational context from notification type", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("chefe_setor"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/notifications/unread-count/")) {
+        return notificationUnreadCountResponse(1);
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/notifications/") &&
+        request.method === "GET" &&
+        !requestUrl(request).includes("/mark-read/")
+      ) {
+        return notificationListResponse([
+          notificationListItem({
+            id: 930,
+            tipo: "requisicao_enviada_autorizacao",
+            leitura_suportada: true,
+            objeto_relacionado: {
+              tipo: "requisicao",
+              id: 101,
+              numero_publico: "REQ-2026-000101",
+              status: "aguardando_autorizacao",
+            },
+          }),
+        ]);
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/minhas-requisicoes");
+
+    const link = await screen.findByRole("link", { name: "Abrir requisição" });
+    expect(link).toHaveAttribute("href", "/requisicoes/101?contexto=autorizacao");
+    expect(screen.getByText("Fila de autorizações", { selector: ".notification-context" })).toBeInTheDocument();
   });
 
   it("logs out from authenticated shell and returns to login", async () => {
@@ -2381,6 +2727,8 @@ describe("frontend scaffold router", () => {
         return new Response(null, { status: 204 });
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2419,6 +2767,8 @@ describe("frontend scaffold router", () => {
         );
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -2458,6 +2808,8 @@ describe("frontend scaffold router", () => {
         return new Response(null, { status: 204 });
       }
 
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);

--- a/tests/notifications/test_api.py
+++ b/tests/notifications/test_api.py
@@ -1,0 +1,216 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from apps.notifications.models import TipoNotificacao
+from apps.notifications.services import criar_notificacao_papel, criar_notificacao_usuario
+from apps.requisitions.models import Requisicao
+from apps.users.models import PapelChoices, Setor, User
+
+
+@pytest.mark.django_db
+class TestNotificacoesAPI:
+    @staticmethod
+    def _criar_setor(nome: str, chefe_matricula: str, papel=PapelChoices.CHEFE_SETOR) -> Setor:
+        chefe = User.objects.create(
+            matricula_funcional=chefe_matricula,
+            nome_completo=f"Chefe {nome}",
+            papel=papel,
+            is_active=True,
+        )
+        setor = Setor.objects.create(nome=nome, chefe_responsavel=chefe)
+        chefe.setor = setor
+        chefe.save(update_fields=["setor"])
+        return setor
+
+    @staticmethod
+    def _criar_usuario(
+        matricula: str,
+        nome: str,
+        *,
+        papel=PapelChoices.SOLICITANTE,
+        setor: Setor | None = None,
+    ) -> User:
+        return User.objects.create(
+            matricula_funcional=matricula,
+            nome_completo=nome,
+            papel=papel,
+            setor=setor,
+            is_active=True,
+        )
+
+    def test_lista_exige_autenticacao(self):
+        client = APIClient()
+        response = client.get(reverse("notification-list"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_lista_retorna_individuais_do_usuario_e_coletivas_do_papel(self):
+        setor = self._criar_setor("API Notificacoes", "41001")
+        usuario = self._criar_usuario(
+            "41002",
+            "Usuario API",
+            papel=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            setor=setor,
+        )
+        outro_usuario = self._criar_usuario(
+            "41003",
+            "Outro Usuario",
+            papel=PapelChoices.CHEFE_SETOR,
+            setor=setor,
+        )
+        requisicao = Requisicao.objects.create(criador=usuario, beneficiario=usuario)
+
+        notificacao_individual = criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_CANCELADA,
+            titulo="Cancelada",
+            mensagem="Sua requisição foi cancelada.",
+            objeto_relacionado=requisicao,
+        )
+        notificacao_coletiva = criar_notificacao_papel(
+            papel_destinatario=PapelChoices.AUXILIAR_ALMOXARIFADO,
+            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+            titulo="Autorizada",
+            mensagem="Existe requisição para atendimento.",
+            objeto_relacionado=requisicao,
+        )
+        criar_notificacao_usuario(
+            destinatario=outro_usuario,
+            tipo=TipoNotificacao.REQUISICAO_RECUSADA,
+            titulo="Recusada",
+            mensagem="Não deve aparecer para outro usuário.",
+        )
+        criar_notificacao_papel(
+            papel_destinatario=PapelChoices.CHEFE_SETOR,
+            tipo=TipoNotificacao.REQUISICAO_ENVIADA_AUTORIZACAO,
+            titulo="Fila de autorização",
+            mensagem="Não deve aparecer para outro papel.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("notification-list"))
+
+        assert response.status_code == 200
+        assert response.data["count"] == 2
+        ids = [item["id"] for item in response.data["results"]]
+        assert ids == [notificacao_coletiva.id, notificacao_individual.id]
+        assert response.data["results"][0]["leitura_suportada"] is False
+        assert response.data["results"][0]["destino"]["tipo"] == "papel"
+        assert response.data["results"][1]["leitura_suportada"] is True
+        assert response.data["results"][1]["destino"]["tipo"] == "usuario"
+        assert response.data["results"][1]["objeto_relacionado"] == {
+            "tipo": "requisicao",
+            "id": requisicao.id,
+            "numero_publico": None,
+            "status": "rascunho",
+        }
+
+    def test_unread_count_conta_so_individual_nao_lida_do_usuario(self):
+        setor = self._criar_setor("Unread Count", "41004")
+        usuario = self._criar_usuario("41005", "Usuario Count", setor=setor)
+        outro = self._criar_usuario("41006", "Outro Count", setor=setor)
+
+        lida = criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_CANCELADA,
+            titulo="Lida",
+            mensagem="Já lida.",
+        )
+        lida.marcar_como_lida()
+        criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+            titulo="Não lida 1",
+            mensagem="Ainda não lida.",
+        )
+        criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_RECUSADA,
+            titulo="Não lida 2",
+            mensagem="Ainda não lida.",
+        )
+        criar_notificacao_usuario(
+            destinatario=outro,
+            tipo=TipoNotificacao.REQUISICAO_RECUSADA,
+            titulo="Outro usuário",
+            mensagem="Não entra no contador.",
+        )
+        criar_notificacao_papel(
+            papel_destinatario=usuario.papel,
+            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+            titulo="Coletiva",
+            mensagem="Não entra no contador.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.get(reverse("notification-unread-count"))
+
+        assert response.status_code == 200
+        assert response.data == {"unread_count": 2}
+
+    def test_mark_read_marca_individual_e_retorna_estado_atualizado(self):
+        setor = self._criar_setor("Mark Read", "41007")
+        usuario = self._criar_usuario("41008", "Usuario Mark Read", setor=setor)
+        notificacao = criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_ATENDIDA,
+            titulo="Atendida",
+            mensagem="Requisição atendida.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("notification-mark-read", kwargs={"pk": notificacao.id}),
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["lida"] is True
+        assert response.data["lida_em"] is not None
+
+        notificacao.refresh_from_db()
+        assert notificacao.lida is True
+        primeiro_lida_em = notificacao.lida_em
+
+        second_response = client.post(
+            reverse("notification-mark-read", kwargs={"pk": notificacao.id}),
+            data={},
+            format="json",
+        )
+        assert second_response.status_code == 200
+        assert second_response.data["lida"] is True
+
+        notificacao.refresh_from_db()
+        assert notificacao.lida_em == primeiro_lida_em
+
+    def test_mark_read_rejeita_notificacao_coletiva_visivel(self):
+        setor = self._criar_setor("Mark Read Coletiva", "41009")
+        usuario = self._criar_usuario(
+            "41010",
+            "Usuario Coletivo",
+            papel=PapelChoices.CHEFE_ALMOXARIFADO,
+            setor=setor,
+        )
+        notificacao = criar_notificacao_papel(
+            papel_destinatario=PapelChoices.CHEFE_ALMOXARIFADO,
+            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+            titulo="Ação coletiva",
+            mensagem="Visível mas sem leitura individual.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario)
+        response = client.post(
+            reverse("notification-mark-read", kwargs={"pk": notificacao.id}),
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "permission_denied"

--- a/tests/notifications/test_api.py
+++ b/tests/notifications/test_api.py
@@ -3,7 +3,11 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from apps.notifications.models import TipoNotificacao
-from apps.notifications.services import criar_notificacao_papel, criar_notificacao_usuario
+from apps.notifications.services import (
+    criar_notificacao_papel,
+    criar_notificacao_usuario,
+    marcar_notificacao_como_lida,
+)
 from apps.requisitions.models import Requisicao
 from apps.users.models import PapelChoices, Setor, User
 
@@ -119,7 +123,7 @@ class TestNotificacoesAPI:
             titulo="Lida",
             mensagem="Já lida.",
         )
-        lida.marcar_como_lida()
+        marcar_notificacao_como_lida(notificacao=lida, usuario=usuario)
         criar_notificacao_usuario(
             destinatario=usuario,
             tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
@@ -151,6 +155,13 @@ class TestNotificacoesAPI:
 
         assert response.status_code == 200
         assert response.data == {"unread_count": 2}
+
+    def test_unread_count_exige_autenticacao(self):
+        client = APIClient()
+        response = client.get(reverse("notification-unread-count"))
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
 
     def test_mark_read_marca_individual_e_retorna_estado_atualizado(self):
         setor = self._criar_setor("Mark Read", "41007")
@@ -214,3 +225,45 @@ class TestNotificacoesAPI:
 
         assert response.status_code == 403
         assert response.data["error"]["code"] == "permission_denied"
+
+    def test_mark_read_exige_autenticacao(self):
+        setor = self._criar_setor("Mark Read Auth", "41011")
+        usuario = self._criar_usuario("41012", "Usuario Auth", setor=setor)
+        notificacao = criar_notificacao_usuario(
+            destinatario=usuario,
+            tipo=TipoNotificacao.REQUISICAO_ATENDIDA,
+            titulo="Atendida",
+            mensagem="Requisição atendida.",
+        )
+
+        client = APIClient()
+        response = client.post(
+            reverse("notification-mark-read", kwargs={"pk": notificacao.id}),
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == 403
+        assert response.data["error"]["code"] == "not_authenticated"
+
+    def test_mark_read_de_outro_usuario_retorna_not_found(self):
+        setor = self._criar_setor("Mark Read Outros", "41013")
+        destinatario = self._criar_usuario("41014", "Destinatário", setor=setor)
+        outro_usuario = self._criar_usuario("41015", "Outro Usuário", setor=setor)
+        notificacao = criar_notificacao_usuario(
+            destinatario=destinatario,
+            tipo=TipoNotificacao.REQUISICAO_ATENDIDA,
+            titulo="Atendida",
+            mensagem="Requisição atendida.",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=outro_usuario)
+        response = client.post(
+            reverse("notification-mark-read", kwargs={"pk": notificacao.id}),
+            data={},
+            format="json",
+        )
+
+        assert response.status_code == 404
+        assert response.data["error"]["code"] == "not_found"

--- a/tests/test_api_schema.py
+++ b/tests/test_api_schema.py
@@ -152,6 +152,9 @@ class TestOpenAPISchema:
         assert "/api/v1/requisitions/{id}/fulfill/" in paths
         assert "/api/v1/requisitions/pending-approvals/" in paths
         assert "/api/v1/requisitions/pending-fulfillments/" in paths
+        assert "/api/v1/notifications/" in paths
+        assert "/api/v1/notifications/{id}/mark-read/" in paths
+        assert "/api/v1/notifications/unread-count/" in paths
         assert paths["/api/v1/materials/{id}/"]["get"]["operationId"] == "materials_retrieve"
         assert (
             paths["/api/v1/materials/"]["get"]["responses"]["200"]["content"]["application/json"][
@@ -295,6 +298,63 @@ class TestOpenAPISchema:
                         responses[code]["content"]["application/json"]["schema"]["$ref"]
                         == expectation["success_ref"]
                     )
+
+            for code in expectation["error_codes"]:
+                assert code in responses
+                assert responses[code]["content"]["application/json"]["schema"]["$ref"] == error_ref
+
+    def test_notifications_endpoints_declaram_requests_responses_e_status_esperados(self):
+        """Verify notification endpoints expose explicit list/read/count contracts."""
+        schema = self._get_schema()
+        paths = schema["paths"]
+        error_ref = "#/components/schemas/ErrorResponse"
+
+        expected_operations = {
+            ("/api/v1/notifications/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/NotificacaoListPaginated",
+                "error_codes": {"403"},
+                "operation_id": "notifications_list",
+                "required_parameters": {"page", "page_size"},
+            },
+            ("/api/v1/notifications/{id}/mark-read/", "post"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/NotificacaoOutput",
+                "error_codes": {"403", "404"},
+                "operation_id": "notifications_mark_read",
+            },
+            ("/api/v1/notifications/unread-count/", "get"): {
+                "request_body": False,
+                "success_codes": {"200"},
+                "success_ref": "#/components/schemas/NotificacaoUnreadCountOutput",
+                "error_codes": {"403"},
+                "operation_id": "notifications_unread_count",
+            },
+        }
+
+        for (path, method), expectation in expected_operations.items():
+            operation = paths[path][method]
+            responses = operation["responses"]
+
+            assert operation["operationId"] == expectation["operation_id"]
+
+            if expectation.get("required_parameters"):
+                parameters = {param["name"] for param in operation["parameters"]}
+                assert expectation["required_parameters"].issubset(parameters)
+
+            if expectation["request_body"]:
+                assert "requestBody" in operation
+            else:
+                assert "requestBody" not in operation
+
+            for code in expectation["success_codes"]:
+                assert code in responses
+                assert (
+                    responses[code]["content"]["application/json"]["schema"]["$ref"]
+                    == expectation["success_ref"]
+                )
 
             for code in expectation["error_codes"]:
                 assert code in responses


### PR DESCRIPTION
# Contexto

## O que este PR faz
- adiciona API de notificações em `/api/v1/notifications/` com lista paginada por visibilidade (usuário + papel)
- adiciona `POST /api/v1/notifications/{id}/mark-read/` com regra de leitura apenas para notificações individuais
- adiciona `GET /api/v1/notifications/unread-count/` contando apenas notificações individuais não lidas do usuário
- integra contador e lista compacta de notificações no `AppShell` sem alterar a navegação worklist-first
- adiciona testes backend/frontend e atualiza contrato OpenAPI + client tipado da SPA

## Por que esta mudança é necessária
A issue #44 exige notificações contextuais na SPA para apoiar decisões operacionais sem desviar do fluxo principal de worklists. Também formaliza o contrato mínimo backend/frontend para leitura e marcação de notificações.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
Regressão de contrato entre OpenAPI e consumo no shell, especialmente em cenários de sessão expirada e visibilidade por papel versus usuário.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: lista e visibilidade de notificações seguem `destinatario=user OR papel_destinatario=user.papel`; leitura individual continua bloqueada para notificação coletiva
- dados / migration / constraints: sem mudanças
- transação / concorrência / idempotência: `mark-read` permanece idempotente para notificações individuais
- máquina de estados / aprovação / cotas / entregas: sem mudanças
- configuração / CI / dependências: sem mudanças

---

# Testes e validação

## Cenários validados

1. API lista apenas notificações visíveis (usuário + papel), excluindo outros usuários/papéis.
2. `mark-read` funciona e é idempotente para notificação individual, e retorna `403 permission_denied` para coletiva.
3. Shell da SPA mostra contador/lista, badge coletivo sem ação de leitura, ação de leitura individual com refetch de lista + contador.

## Como validar manualmente

1. Autenticar na SPA com usuário operacional e abrir uma worklist (`/minhas-requisicoes`, `/autorizacoes` ou `/atendimentos`).
2. Verificar painel de notificações no shell com contador e lista compacta.
3. Clicar em `Marcar como lida` numa notificação individual e confirmar atualização do contador.
4. Validar que notificações coletivas exibem `Aviso coletivo` e não mostram botão de leitura.
5. Validar link de notificação para `/requisicoes/:id` com contexto (`autorizacao` ou `atendimento`) quando aplicável.

## Payloads / exemplos de uso

```json
{}
```

Closes #44

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumo do PR #60: Notificações Contextuais da SPA

### Objetivo da Mudança
Expor APIs RESTful mínimas no backend (`/api/v1/notifications/`) para listagem paginada filtrada por visibilidade de usuário/papel e marcação de leitura de notificações individuais; integrar no frontend (AppShell) um painel compacto de notificações com contador e suporte a ações, preservando a navegação worklist-first.

---

### Apps Django Impactados
- **notifications**: novo app com models, serializers, viewset, políticas de visibilidade, services e URLs.
- **config**: adiciona inclusão de URLs de notificações em `/api/v1/`.

---

### Risco Funcional

**[CRÍTICO] N+1 Query em GenericForeignKey sem Prefetch:**
- O campo `objeto_relacionado` (GenericForeignKey) é serializado em cada notificação da lista sem `prefetch_related` na política. Cada item fará 1 query SQL para resolver o objeto relacionado (requisição).
  - **Impacto**: Com page_size padrão (20) ou SPA (6 itens), adiciona 6–20 queries extras por listagem.
  - **Recomendação**: Adicionar `Prefetch` ou `prefetch_related` de GenericForeignKey em `queryset_notificacoes_visiveis()` para otimizar acesso a `requisicao` em massa.

**[MÉDIO] Visibilidade de Notificações Coletivas sem Filtro de Setor:**
- Política em `queryset_notificacoes_visiveis()` filtra por `Q(papel_destinatario=usuario.papel)` sem qualquer segmentação por setor.
  - **Impacto**: Um CHEFE_SETOR_A verá notificações coletivas destinadas a CHEFE_SETOR_B se ambos tiverem papel=CHEFE_SETOR.
  - **Risco**: Violação de segmentação por setor se regra de negócio exigir isolamento entre setores em notificações operacionais.

**[BAIXO] Race Condition em Timestamp de Leitura (Improvável em Prática):**
- Dois requests simultâneos podem ambos passar pelo `if not notificacao.lida:` check antes do save. Resultado: ambos fazem update, segundo sobrescreve `lida_em` com novo `timezone.now()`. Constraint garante coerência (lida=True ⟺ lida_em ≠ NULL), mas timestamp varia.
  - **Impacto**: Auditoria/rastreamento de quem/quando marcou pode ter 2–3ms de imprecisão.
  - **Teste**: Atual não cobre concorrência explícita (race condition).

---

### Impacto em Regras de Negócio

- **Visibilidade por Papel:** Notificações coletivas (`papel_destinatario ≠ NULL`) são visíveis a todos os usuários com aquele papel, sem filtro por setor.
- **Marcação de Leitura Restrita:** Apenas notificações individuais (`destinatario ≠ NULL`) podem ser marcadas como lidas. Notificações coletivas retornam 403 em mark-read, mesmo visíveis na lista.
- **Contagem Idempotente:** `unread_count` conta apenas individuais não lidas. Notificações coletivas não são contabilizadas, alinhado com restrição de leitura.
- **Constraint Mutuamente Exclusivo:** Modelo garante que `destinatario` e `papel_destinatario` nunca ambos preenchidos (`notif_destinatario_papel_mutuamente_exclusivos`). ✓

---

### Autenticação, Autorização, Escopo por Perfil/Setor

**Autenticação:**
- `IsAuthenticated` em todos os endpoints. ✓
- Requisições não-autenticadas retornam 401.

**Autorização Contextual:**
- **Em mark-read**: Lógica explícita em `marcar_notificacao_como_lida()` valida:
  1. Rejeita coletivas: `if notificacao.destinatario_id is None → PermissionDenied(403)` ✓
  2. Rejeita cross-user: `if notificacao.destinatario_id != usuario.pk → PermissionDenied(403)` ✓
  - `PermissionDenied` é convertida para 403 via `api_exception_handler` customizado. ✓

**Escopo por Perfil:**
- Notificações individuais: filtradas por `destinatario=usuario`. ✓
- Notificações coletivas: filtradas por `papel_destinatario=usuario.papel`, **sem segmentação por setor**.
  - **Risco**: Superusuário ou usuário de outro setor com mesmo papel verá notificações coletivas que não deveriam ser visíveis.

**Escopo por Setor:**
- Ausente na implementação. Notificações individuais não filtram por setor de criador/beneficiário; notificações coletivas não filtram por setor de usuário.

**[RISCO] Check de Permissão de Objeto:**
- `check_object_permissions()` no ViewSet apenas valida `IsAuthenticated`, sem lógica customizada de objeto.
- Validação real acontece em service, após fetch. Correto funcionalmente, mas sem middleware de segurança explícita no DRF.

---

### Contratos DRF, Serializers, Paginação, Filtros

**Serializers:**
- `NotificacaoOutputSerializer` expõe campos de modelo + 3 campos computados:
  - `leitura_suportada`: `bool` (True se destinatario ≠ NULL, i.e., individual)
  - `destino`: dict com tipo de destinatário (usuario/papel) e identificadores
  - `objeto_relacionado`: dict com tipo (requisicao) + dados resumidos ou apenas ID se deletado
- Campos computados usam `SerializerMethodField`, sem overhead de query se prefetch estiver correto.

**Paginação:**
- Usa `StandardPagination` padrão (page + page_size, defaults 20).
- Envelope de resposta: `NotificacaoListPaginated` (count, next, previous, results).
- ✓ Declarado em OpenAPI com parâmetros `page` e `page_size`.

**Filtros:**
- Nenhum filtro adicional (by tipo, data, etc.). Visibilidade é única lógica de negócio em `get_queryset()`.
- ✓ Correto para MVP, mas pode precisar de filtro por `tipo` em releases futuras.

**Envelope de Erro:**
- mark-read e mark-unread-count usam `ErrorResponseSerializer` para 403 e 404.
- ✓ Schema explícito em OpenAPI.

**OpenAPI:**
- 3 novos endpoints com operationIds esperados.
- 7 novos schemas (destination, objeto_relacionado, output, list, unread-count, tipo enums).
- ✓ Schema atualizado, tipagem frontend sincronizada.

---

### Integridade de Dados, Constraints, Snapshots, Auditoria

**Constraints de Integridade:**
1. `notif_destinatario_papel_mutuamente_exclusivos`: (destinatario ≠ NULL ⟹ papel_destinatario = NULL) AND (papel_destinatario ≠ NULL ⟹ destinatario = NULL). ✓
2. `notif_objeto_relacionado_coerente`: (content_type = NULL ⟺ object_id = NULL). ✓
3. `notif_lida_lida_em_coerentes`: (lida = False ⟺ lida_em = NULL) AND (lida = True ⟺ lida_em ≠ NULL). ✓

**Idempotência:**
- `marcar_notificacao_como_lida()` implementa `if not notificacao.lida: ... save(update_fields=[...])`.
- Teste `test_mark_read_marca_individual_e_retorna_estado_atualizado` valida que `lida_em` não muda em segundo mark. ✓
- Idempotência garante que retry automático em frontend não causa inconsistência.

**Snapshots Históricos:**
- GenericForeignKey armazena apenas `object_id`, não snapshot do estado da requisição no momento da notificação.
- **Risco**: Se requisição for deletada, `objeto_relacionado` retorna `None` ou stub com apenas ID. Não há historicidade do estado.
- **Impacto**: Auditoria futura não pode reconstruir contexto completo da notificação.

**Rastreabilidade de Leitura:**
- Campo `lida_em` registra quando foi marcada como lida, mas não registra **quem** a marcou.
- **Risco**: Se usuário A tiver acesso de admin e marcar notificação de usuário B como lida (via admin action), não há rastreamento.
- **Nota**: Admin action `marcar_como_lida_action` rejeita notificações coletivas, mas executa para individuais com `usuario=request.user` (admin que executa a ação).

---

### Transações, Concorrência, Idempotência

**Transações:**
- `marcar_notificacao_como_lida()` não envolve `@transaction.atomic`. Save é single-row update, atômico no DB por padrão. ✓
- Sem side effects que requeiram transação multi-step.

**Idempotência:**
- ✓ Garantida pelo `if not notificacao.lida:` check.
- ✓ Constraint `notif_lida_lida_em_coerentes` previne estados inconsistentes.

**Concorrência:**
- **Race Condition Potencial (Improvável)**: Dois PUTs simultâneos podem ambos ler `lida=False`, ambos passarem pelo check, ambos fazerem save com `timezone.now()`. Resultado: constraint não viola (lida=True ⟺ lida_em ≠ NULL), mas `lida_em` reflete timestamp do segundo save.
- **Mitigação**: Constraint garante segurança de dados; idempotência garante funcionalidade. Imprecisão de timestamp é cosmética.
- **Teste**: Não há teste de race condition explícita (não-cobertura).

**Saldos/Reservas:**
- N/A — notificações não afetam movimentos de materiais, saldos físicos, reservados ou disponíveis.

---

### Importação SCPI, Dados Oficiais, Divergência de Estoque
N/A

---

### Configuração, CI, Dependências, Lint, Testes, Ambiente Efêmero

**Migrations:**
- Nenhuma migração versionada. Notificações já existem em schema; PR apenas expõe API.
- ✓ Sem risco de rollout/rollback.

**Dependências:**
- Sem novas dependências (DRF, drf-spectacular já presentes).

**Testes Backend:**
- Novo arquivo `tests/notifications/test_api.py` com suite `TestNotificacoesAPI`:
  - ✓ `test_lista_exige_autenticacao()`
  - ✓ `test_lista_retorna_individuais_do_usuario_e_coletivas_do_papel()`
  - ✓ `test_unread_count_conta_so_individual_nao_lida_do_usuario()`
  - ✓ `test_unread_count_exige_autenticacao()`
  - ✓ `test_mark_read_marca_individual_e_retorna_estado_atualizado()` (inclui idempotência)
  - ✓ `test_mark_read_rejeita_notificacao_coletiva_visivel()`
  - ✓ `test_mark_read_exige_autenticacao()`
  - ✓ `test_mark_read_de_outro_usuario_retorna_not_found()`
- **Cobertura**: Autenticação, visibilidade por papel, rejeição de coletivas, idempotência, cross-user rejection.
- **Falta**: Teste de race condition explícita.

**Testes Frontend:**
- Novo arquivo `frontend/src/tests/router-smoke.test.tsx` com:
  - Mocks de API (notificações, mark-read, unread-count)
  - Testes de renderização no AppShell (contador, badges, mark-read action)
  - Validação de links para requisições com contexto operacional correto
- ✓ Cobertura de integração e UX.

**Testes Schema:**
- `tests/test_api_schema.py` adiciona `test_notifications_endpoints_declaram_requests_respostas_e_status_esperados()`:
  - ✓ Valida operationIds esperados
  - ✓ Valida schemas de resposta (NotificacaoOutput, ListPaginated, UnreadCount)
  - ✓ Valida status esperados (200, 403, 404)
  - ✓ Valida parâmetros de paginação (page, page_size)
  - ✓ Valida ausência de requestBody
- ✓ Garante contrato OpenAPI alinhado.

**Lint/Style:**
- Sem violações aparentes. Frontend usa TypeScript + OpenAPI schema tipado.

**CI:**
- Ambiente efêmero com migrations aplicadas. Sem risco.

---

### Divergências com Documentação/Design

**Esperado (Issue #44):**
- APIs mínimas para listar e marcar leitura: ✓
- Contador e lista compacta no AppShell: ✓
- Suporte a notificações coletivas sem marcação individual: ✓
- Testes cobrindo casos principais: ✓

**Não Coberto:**
- **Filtro de setor em coletivas**: Se design esperava segmentação por setor, falta implementação.
- **Snapshot de requisição**: Se auditoria exigir estado histórico da requisição no momento da notificação, ausente.

---

### Validação Manual

**Via API:**
1. **Listar notificações:**
   ```bash
   GET /api/v1/notifications/?page=1&page_size=6 (autenticado)
   ```
   ✓ Validar presença de individuais do usuário + coletivas do seu papel.

2. **Marcar individual como lida (idempotente):**
   ```bash
   POST /api/v1/notifications/{id}/mark-read/ (id=individual)
   ```
   ✓ Validar `lida=true`, `lida_em` preenchido.
   ✓ Repetir chamada: `lida_em` não muda.

3. **Tentar marcar coletiva:**
   ```bash
   POST /api/v1/notifications/{id}/mark-read/ (id=coletiva)
   ```
   ✓ Retorna 403 PermissionDenied.

4. **Contar não-lidas:**
   ```bash
   GET /api/v1/notifications/unread-count/
   ```
   ✓ Retorna apenas contagem de individuais não lidas.

5. **Cross-setor (se regra exigir isolamento):**
   - Login como USER_SETOR_A, verificar se vê notificações coletivas destinadas a papel de USER_SETOR_B.
   - Se vir, confirmar se é esperado por design ou risco.

**Via Admin:**
- Action "Marcar como lida" rejeita coletivas. ✓

**Via Frontend:**
- AppShell exibe painel, contador, mark-read buttons, badges de coletivas. ✓
- Refetch ao marcar. ✓

---

### Checklist Crítico

- ✓ Autorização por usuário em mark-read (check explícito em service + converter PermissionDenied em 403)
- ✓ Rejeição de notificações coletivas em mark-read (403)
- ✓ Idempotência de leitura (if not lida; constraint)
- ✓ Constraint de coerência lida/lida_em
- ✓ Tests cobrindo autenticação, visibilidade, mark-read, rejeição coletiva
- ⚠️ **N+1 em GenericForeignKey sem prefetch** — risco real de performance
- ⚠️ **Visibilidade coletiva sem filtro de setor** — risco funcional se design exigir isolamento
- ⚠️ **Sem teste de race condition** — impacto baixo (idempotente, constraint seguro)
- ⚠️ **Snapshot de requisição não armazenado** — risco para auditoria histórica
- ⚠️ **Sem rastreamento de quem marcou lida** — risco para auditoria de admin actions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/60)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->