### PR TITLE
[codex] Frontend piloto: cards mobile para worklists

### DIFF
--- a/frontend/src/routes/atendimentos.tsx
+++ b/frontend/src/routes/atendimentos.tsx
@@ -18,6 +18,11 @@ import {
   statusLabel,
   type RequisicaoPendingFulfillmentItem,
 } from "../features/requisitions/requisitions";
+import {
+  ResponsiveWorklistFrame,
+  WorklistEmptyState,
+  WorklistErrorState,
+} from "../shared/ui/worklist";
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -38,11 +43,67 @@ export const Route = createFileRoute("/atendimentos")({
 
 function EmptyState() {
   return (
-    <div className="empty-state">
-      <p className="eyebrow">Sem pendências</p>
-      <h2>Nenhum atendimento pendente</h2>
-      <p>A fila mostra requisições autorizadas aguardando retirada pelo Almoxarifado.</p>
-    </div>
+    <WorklistEmptyState
+      description="A fila mostra requisições autorizadas aguardando retirada pelo Almoxarifado."
+      eyebrow="Sem pendências"
+      title="Nenhum atendimento pendente"
+    />
+  );
+}
+
+function AtendimentoCard({
+  currentPage,
+  requisicao,
+}: {
+  currentPage: number;
+  requisicao: RequisicaoPendingFulfillmentItem;
+}) {
+  return (
+    <article className="worklist-card">
+      <div className="worklist-card-main">
+        <div>
+          <span className="font-semibold text-[var(--ink-strong)]">
+            {requisicao.numero_publico ?? `#${requisicao.id}`}
+          </span>
+          <p className="mt-2 text-xs font-bold uppercase text-[var(--ink-muted)]">
+            {requisicao.total_itens} {requisicao.total_itens === 1 ? "item" : "itens"}
+          </p>
+        </div>
+        <span className={`req-status req-status-${requisicao.status}`}>
+          {statusLabel(requisicao.status)}
+        </span>
+      </div>
+
+      <dl className="worklist-card-details">
+        <div>
+          <dt>Beneficiário</dt>
+          <dd>{requisicao.beneficiario.nome_completo}</dd>
+        </div>
+        <div>
+          <dt>Setor</dt>
+          <dd>{requisicao.setor_beneficiario.nome}</dd>
+        </div>
+        <div>
+          <dt>Autorizador</dt>
+          <dd>{requisicao.chefe_autorizador.nome_completo}</dd>
+        </div>
+        <div>
+          <dt>Autorização</dt>
+          <dd>{formatDateTime(requisicao.data_autorizacao_ou_recusa)}</dd>
+        </div>
+      </dl>
+
+      <div className="worklist-card-footer">
+        <Link
+          className="action-link compact-action"
+          params={{ id: String(requisicao.id) }}
+          search={{ contexto: "atendimento", page: currentPage === 1 ? undefined : currentPage }}
+          to="/requisicoes/$id"
+        >
+          Abrir
+        </Link>
+      </div>
+    </article>
   );
 }
 
@@ -211,18 +272,14 @@ function AtendimentosPage() {
       </div>
 
       {listQuery.isError ? (
-        <div className="error-panel">
+        <WorklistErrorState>
           {queryErrorMessage(listQuery.error, "Não foi possível carregar atendimentos pendentes.")}
-        </div>
+        </WorklistErrorState>
       ) : null}
 
       {!listQuery.isError ? (
-        <div className="table-frame">
-          {listQuery.isPending ? (
-            <div className="loading-state">Carregando atendimentos...</div>
-          ) : rows.length === 0 ? (
-            <EmptyState />
-          ) : (
+        <ResponsiveWorklistFrame
+          desktop={
             <table className="operational-table">
               <thead>
                 {table.getHeaderGroups().map((headerGroup) => (
@@ -247,8 +304,23 @@ function AtendimentosPage() {
                 ))}
               </tbody>
             </table>
-          )}
-        </div>
+          }
+          empty={<EmptyState />}
+          isEmpty={rows.length === 0}
+          isPending={listQuery.isPending}
+          mobile={
+            <div aria-label="Cards da fila de atendimento" className="worklist-card-list">
+              {rows.map((requisicao) => (
+                <AtendimentoCard
+                  currentPage={currentPage}
+                  key={requisicao.id}
+                  requisicao={requisicao}
+                />
+              ))}
+            </div>
+          }
+          skeletonLabel="Carregando atendimentos"
+        />
       ) : null}
 
       <div className="pagination-bar">

--- a/frontend/src/routes/autorizacoes.tsx
+++ b/frontend/src/routes/autorizacoes.tsx
@@ -18,6 +18,11 @@ import {
   statusLabel,
   type RequisicaoPendingApprovalItem,
 } from "../features/requisitions/requisitions";
+import {
+  ResponsiveWorklistFrame,
+  WorklistEmptyState,
+  WorklistErrorState,
+} from "../shared/ui/worklist";
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -38,11 +43,67 @@ export const Route = createFileRoute("/autorizacoes")({
 
 function EmptyState() {
   return (
-    <div className="empty-state">
-      <p className="eyebrow">Sem pendências</p>
-      <h2>Nenhuma autorização pendente</h2>
-      <p>A fila mostra requisições aguardando decisão do chefe do setor responsável.</p>
-    </div>
+    <WorklistEmptyState
+      description="A fila mostra requisições aguardando decisão do chefe do setor responsável."
+      eyebrow="Sem pendências"
+      title="Nenhuma autorização pendente"
+    />
+  );
+}
+
+function AutorizacaoCard({
+  currentPage,
+  requisicao,
+}: {
+  currentPage: number;
+  requisicao: RequisicaoPendingApprovalItem;
+}) {
+  return (
+    <article className="worklist-card">
+      <div className="worklist-card-main">
+        <div>
+          <span className="font-semibold text-[var(--ink-strong)]">
+            {requisicao.numero_publico ?? `#${requisicao.id}`}
+          </span>
+          <p className="mt-2 text-xs font-bold uppercase text-[var(--ink-muted)]">
+            {requisicao.total_itens} {requisicao.total_itens === 1 ? "item" : "itens"}
+          </p>
+        </div>
+        <span className={`req-status req-status-${requisicao.status}`}>
+          {statusLabel(requisicao.status)}
+        </span>
+      </div>
+
+      <dl className="worklist-card-details">
+        <div>
+          <dt>Beneficiário</dt>
+          <dd>{requisicao.beneficiario.nome_completo}</dd>
+        </div>
+        <div>
+          <dt>Setor</dt>
+          <dd>{requisicao.setor_beneficiario.nome}</dd>
+        </div>
+        <div>
+          <dt>Criador</dt>
+          <dd>{requisicao.criador.nome_completo}</dd>
+        </div>
+        <div>
+          <dt>Envio</dt>
+          <dd>{formatDateTime(requisicao.data_envio_autorizacao)}</dd>
+        </div>
+      </dl>
+
+      <div className="worklist-card-footer">
+        <Link
+          className="action-link compact-action"
+          params={{ id: String(requisicao.id) }}
+          search={{ contexto: "autorizacao", page: currentPage === 1 ? undefined : currentPage }}
+          to="/requisicoes/$id"
+        >
+          Abrir
+        </Link>
+      </div>
+    </article>
   );
 }
 
@@ -211,18 +272,14 @@ function AutorizacoesPage() {
       </div>
 
       {listQuery.isError ? (
-        <div className="error-panel">
+        <WorklistErrorState>
           {queryErrorMessage(listQuery.error, "Não foi possível carregar autorizações pendentes.")}
-        </div>
+        </WorklistErrorState>
       ) : null}
 
       {!listQuery.isError ? (
-        <div className="table-frame">
-          {listQuery.isPending ? (
-            <div className="loading-state">Carregando autorizações...</div>
-          ) : rows.length === 0 ? (
-            <EmptyState />
-          ) : (
+        <ResponsiveWorklistFrame
+          desktop={
             <table className="operational-table">
               <thead>
                 {table.getHeaderGroups().map((headerGroup) => (
@@ -247,8 +304,23 @@ function AutorizacoesPage() {
                 ))}
               </tbody>
             </table>
-          )}
-        </div>
+          }
+          empty={<EmptyState />}
+          isEmpty={rows.length === 0}
+          isPending={listQuery.isPending}
+          mobile={
+            <div aria-label="Cards da fila de autorizações" className="worklist-card-list">
+              {rows.map((requisicao) => (
+                <AutorizacaoCard
+                  currentPage={currentPage}
+                  key={requisicao.id}
+                  requisicao={requisicao}
+                />
+              ))}
+            </div>
+          }
+          skeletonLabel="Carregando autorizações"
+        />
       ) : null}
 
       <div className="pagination-bar">

--- a/frontend/src/routes/minhas-requisicoes.tsx
+++ b/frontend/src/routes/minhas-requisicoes.tsx
@@ -22,6 +22,11 @@ import {
   type RequisicaoListItem,
   type RequisicaoStatus,
 } from "../features/requisitions/requisitions";
+import {
+  ResponsiveWorklistFrame,
+  WorklistEmptyState,
+  WorklistErrorState,
+} from "../shared/ui/worklist";
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -57,11 +62,55 @@ function IdentifierCell({ requisicao }: { requisicao: RequisicaoListItem }) {
 
 function EmptyState() {
   return (
-    <div className="empty-state">
-      <p className="eyebrow">Sem resultados</p>
-      <h2>Nenhuma requisição encontrada</h2>
-      <p>Ajuste busca ou status para voltar à lista operacional.</p>
-    </div>
+    <WorklistEmptyState
+      description="Ajuste busca ou status para voltar à lista operacional."
+      eyebrow="Sem resultados"
+      title="Nenhuma requisição encontrada"
+    />
+  );
+}
+
+function MinhasRequisicoesCard({ requisicao }: { requisicao: RequisicaoListItem }) {
+  const thirdParty = isThirdPartyBeneficiary(requisicao);
+
+  return (
+    <article className="worklist-card">
+      <div className="worklist-card-main">
+        <div>
+          <IdentifierCell requisicao={requisicao} />
+          <p className="mt-2 text-xs font-bold uppercase text-[var(--ink-muted)]">
+            {requisicao.total_itens} {requisicao.total_itens === 1 ? "item" : "itens"}
+          </p>
+        </div>
+        <StatusBadge status={requisicao.status} />
+      </div>
+
+      <dl className="worklist-card-details">
+        <div>
+          <dt>Beneficiário</dt>
+          <dd>{requisicao.beneficiario.nome_completo}</dd>
+        </div>
+        <div>
+          <dt>Setor</dt>
+          <dd>{requisicao.setor_beneficiario.nome}</dd>
+        </div>
+        <div>
+          <dt>Atualização</dt>
+          <dd>{contextualDateLabel(requisicao)}</dd>
+        </div>
+      </dl>
+
+      <div className="worklist-card-footer">
+        {thirdParty ? <span className="third-party-badge">Beneficiário terceiro</span> : null}
+        <Link
+          className="action-link compact-action"
+          params={{ id: String(requisicao.id) }}
+          to="/requisicoes/$id"
+        >
+          Abrir
+        </Link>
+      </div>
+    </article>
   );
 }
 
@@ -267,18 +316,14 @@ function MinhasRequisicoesPage() {
       </form>
 
       {listQuery.isError && !authError ? (
-        <div className="error-panel">
+        <WorklistErrorState>
           {queryErrorMessage(listQuery.error, "Não foi possível carregar os dados.")}
-        </div>
+        </WorklistErrorState>
       ) : null}
 
       {!listQuery.isError || authError ? (
-        <div className="table-frame">
-          {listQuery.isPending ? (
-            <div className="loading-state">Carregando requisições...</div>
-          ) : rows.length === 0 ? (
-            <EmptyState />
-          ) : (
+        <ResponsiveWorklistFrame
+          desktop={
             <table className="operational-table">
               <thead>
                 {table.getHeaderGroups().map((headerGroup) => (
@@ -303,8 +348,19 @@ function MinhasRequisicoesPage() {
                 ))}
               </tbody>
             </table>
-          )}
-        </div>
+          }
+          empty={<EmptyState />}
+          isEmpty={rows.length === 0}
+          isPending={listQuery.isPending}
+          mobile={
+            <div aria-label="Cards de minhas requisições" className="worklist-card-list">
+              {rows.map((requisicao) => (
+                <MinhasRequisicoesCard key={requisicao.id} requisicao={requisicao} />
+              ))}
+            </div>
+          }
+          skeletonLabel="Carregando requisições"
+        />
       ) : null}
 
       <div className="pagination-bar">

--- a/frontend/src/shared/ui/worklist.tsx
+++ b/frontend/src/shared/ui/worklist.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, type ReactNode } from "react";
+
+const WORKLIST_MOBILE_QUERY = "(max-width: 860px)";
+
+function getIsMobileWorklist() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+
+  return window.matchMedia(WORKLIST_MOBILE_QUERY).matches;
+}
+
+function useIsMobileWorklist() {
+  const [isMobile, setIsMobile] = useState(getIsMobileWorklist);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return;
+    }
+
+    const mediaQuery = window.matchMedia(WORKLIST_MOBILE_QUERY);
+    const handleChange = () => setIsMobile(mediaQuery.matches);
+
+    handleChange();
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  return isMobile;
+}
+
+export function WorklistEmptyState({
+  description,
+  eyebrow,
+  title,
+}: {
+  description: string;
+  eyebrow: string;
+  title: string;
+}) {
+  return (
+    <div className="empty-state">
+      <p className="eyebrow">{eyebrow}</p>
+      <h2>{title}</h2>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+export function WorklistErrorState({ children }: { children: ReactNode }) {
+  return (
+    <div className="error-panel" role="alert">
+      {children}
+    </div>
+  );
+}
+
+export function WorklistSkeleton({ label }: { label: string }) {
+  return (
+    <div aria-label={label} className="worklist-skeleton" role="status">
+      {Array.from({ length: 3 }).map((_, index) => (
+        <div className="worklist-skeleton-card" key={index}>
+          <span className="worklist-skeleton-line wide" />
+          <span className="worklist-skeleton-line medium" />
+          <span className="worklist-skeleton-line narrow" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ResponsiveWorklistFrame({
+  desktop,
+  empty,
+  isEmpty,
+  isPending,
+  mobile,
+  skeletonLabel,
+}: {
+  desktop: ReactNode;
+  empty: ReactNode;
+  isEmpty: boolean;
+  isPending: boolean;
+  mobile: ReactNode;
+  skeletonLabel: string;
+}) {
+  const isMobile = useIsMobileWorklist();
+
+  return (
+    <div className="table-frame">
+      {isPending ? (
+        <WorklistSkeleton label={skeletonLabel} />
+      ) : isEmpty ? (
+        empty
+      ) : isMobile ? (
+        mobile
+      ) : (
+        desktop
+      )}
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -538,6 +538,7 @@ button:disabled {
   color: var(--ink-soft);
 }
 
+.empty-state h2,
 .empty-state h3 {
   margin-top: 0.55rem;
   font-size: 1.35rem;
@@ -549,6 +550,105 @@ button:disabled {
   border-radius: 8px;
   background: #fff4f4;
   color: var(--danger);
+}
+
+.worklist-card-list {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.worklist-card {
+  display: grid;
+  gap: 1rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.worklist-card + .worklist-card {
+  border-top: 1px solid var(--line-soft);
+}
+
+.worklist-card-main,
+.worklist-card-footer {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.worklist-card-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 0;
+}
+
+.worklist-card-details div {
+  min-width: 0;
+}
+
+.worklist-card-details dt {
+  margin-bottom: 0.2rem;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+.worklist-card-details dd {
+  margin: 0;
+  color: var(--ink-strong);
+  font-size: 0.92rem;
+  overflow-wrap: anywhere;
+}
+
+.worklist-skeleton {
+  display: grid;
+  gap: 0.75rem;
+  padding: 0.75rem;
+}
+
+.worklist-skeleton-card {
+  display: grid;
+  gap: 0.7rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.worklist-skeleton-line {
+  display: block;
+  height: 0.9rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #edf2f7 0%, #f8fafc 50%, #edf2f7 100%);
+  background-size: 200% 100%;
+  animation: skeleton-pulse 1.4s ease-in-out infinite;
+}
+
+.worklist-skeleton-line.wide {
+  width: 70%;
+}
+
+.worklist-skeleton-line.medium {
+  width: 52%;
+}
+
+.worklist-skeleton-line.narrow {
+  width: 34%;
+}
+
+@keyframes skeleton-pulse {
+  0% {
+    background-position: 100% 0;
+  }
+
+  100% {
+    background-position: -100% 0;
+  }
 }
 
 .detail-actions {
@@ -875,12 +975,14 @@ button:disabled {
     width: 100%;
   }
 
-  .table-frame {
-    overflow-x: auto;
+  .worklist-card-main,
+  .worklist-card-footer {
+    align-items: stretch;
+    flex-direction: column;
   }
 
-  .operational-table {
-    min-width: 760px;
+  .worklist-card-details {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -33,6 +33,22 @@ function requestSearchParam(request: Request, name: string) {
   return new URL(requestUrl(request)).searchParams.get(name);
 }
 
+function mockWorklistViewport(isMobile: boolean) {
+  vi.stubGlobal(
+    "matchMedia",
+    vi.fn((query: string) => ({
+      matches: isMobile && query === "(max-width: 860px)",
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
+}
+
 function authSession(papel = "solicitante") {
   return {
     id: 10,
@@ -903,6 +919,84 @@ describe("frontend pilot router", () => {
     expect(screen.getByText("Beneficiário terceiro")).toBeInTheDocument();
   });
 
+  it("renders minhas requisicoes as mobile cards without table", async () => {
+    mockWorklistViewport(true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByLabelText("Cards de minhas requisições")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Abrir" })).toHaveAttribute(
+      "href",
+      "/requisicoes/101",
+    );
+  });
+
+  it("keeps minhas requisicoes as a desktop table", async () => {
+    mockWorklistViewport(false);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return requisitionListResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByRole("table")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Cards de minhas requisições")).not.toBeInTheDocument();
+  });
+
+  it("shows a screen skeleton while minhas requisicoes loads", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/mine/")) {
+          return new Promise<Response>(() => {});
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/minhas-requisicoes");
+
+    expect(await screen.findByRole("status", { name: "Carregando requisições" })).toBeInTheDocument();
+    expect(screen.queryByText("Carregando requisições...")).not.toBeInTheDocument();
+  });
+
   it("does not show third-party badge when creator and beneficiary are the same", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1100,6 +1194,35 @@ describe("frontend pilot router", () => {
     expect(screen.getByText("1 registro")).toBeInTheDocument();
   });
 
+  it("renders authorization queue as mobile cards without table", async () => {
+    mockWorklistViewport(true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(chefeSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-approvals/")) {
+          return pendingApprovalListResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/autorizacoes?page=2");
+
+    expect(await screen.findByLabelText("Cards da fila de autorizações")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Abrir" })).toHaveAttribute(
+      "href",
+      "/requisicoes/101?contexto=autorizacao&page=2",
+    );
+  });
+
   it("redirects solicitante away from authorization queue", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1236,6 +1359,35 @@ describe("frontend pilot router", () => {
     expect(screen.getByText("Chefe Piloto")).toBeInTheDocument();
     expect(screen.getByText(formatDateTime("2026-05-01T12:00:00Z"))).toBeInTheDocument();
     expect(screen.getByText("1 registro")).toBeInTheDocument();
+  });
+
+  it("renders fulfillment queue as mobile cards without table", async () => {
+    mockWorklistViewport(true);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse(warehouseSession());
+        }
+
+        if (requestUrl(request).includes("/api/v1/requisitions/pending-fulfillments/")) {
+          return pendingFulfillmentListResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/atendimentos?page=2");
+
+    expect(await screen.findByLabelText("Cards da fila de atendimento")).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Abrir" })).toHaveAttribute(
+      "href",
+      "/requisicoes/101?contexto=atendimento&page=2",
+    );
   });
 
   it("opens canonical requisition detail from fulfillment queue with context", async () => {


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Adiciona cards mobile para as worklists de `Minhas requisições`, `Fila de autorizações` e `Fila de atendimento`.
- Introduz um frame responsivo compartilhado para alternar entre tabela desktop, cards mobile, skeleton e empty/error states.
- Mantém a navegação com contexto e paginação já existentes, agora em layout adaptado para telas menores.

## Por que esta mudança é necessária
- A SPA do piloto precisa ser usável no mobile sem quebrar a experiência operacional principal, especialmente nas worklists.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [x] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
- Divergência entre a renderização desktop e mobile, incluindo links com contexto e paginação, podendo quebrar navegação de worklists.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor: cards continuam respeitando o mesmo papel e o mesmo contexto das rotas.
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `rtk make frontend-lint` passou.
3. Smoke tests cobrem cards mobile, tabela desktop e skeleton responsivo.

## Como validar manualmente
- Abrir cada worklist em viewport estreita e confirmar cards em vez de tabela.
- Voltar para viewport larga e confirmar tabela sem regressão na navegação.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->
