### PR TITLE
[codex] Frontend piloto: wizard de rascunho

### DIFF
--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -1,9 +1,17 @@
-import { useEffect, useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useFieldArray, useForm, useWatch } from "react-hook-form";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from "react";
+import { useFieldArray, useForm, useWatch, type FieldPath } from "react-hook-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link, useNavigate } from "@tanstack/react-router";
 
 import { authQueryKeys, isAuthError, type AuthSession } from "../auth/session";
+import type { DraftStep } from "./draftSteps";
 import {
   cancelDraftRequisition,
   createDraftRequisition,
@@ -45,9 +53,17 @@ type DraftFormValues = {
 };
 
 const EMPTY_DRAFT_ITEMS: DraftItemForm[] = [];
+const DRAFT_STEPS: Array<{ key: DraftStep; label: string }> = [
+  { key: "beneficiario", label: "Beneficiário" },
+  { key: "itens", label: "Itens" },
+  { key: "revisao", label: "Revisão" },
+  { key: "envio", label: "Envio" },
+];
 
 type DraftRequisitionEditorProps = {
+  activeStep?: DraftStep;
   initialRequisition?: RequisicaoDetail;
+  onStepChange?: (step: DraftStep) => void;
   session: AuthSession;
 };
 
@@ -69,7 +85,9 @@ function currentUserBeneficiary(session: AuthSession) {
   };
 }
 
-function beneficiaryLabel(beneficiary: Pick<BeneficiaryLookupItem, "matricula_funcional" | "nome_completo">) {
+function beneficiaryLabel(
+  beneficiary: Pick<BeneficiaryLookupItem, "matricula_funcional" | "nome_completo">,
+) {
   return `${beneficiary.nome_completo} (${beneficiary.matricula_funcional})`;
 }
 
@@ -158,43 +176,166 @@ function mutationErrorMessage(error: unknown) {
   return queryErrorMessage(error, "Não foi possível concluir a ação.");
 }
 
-export function DraftRequisitionEditor({ initialRequisition, session }: DraftRequisitionEditorProps) {
+function draftStorageKey(sessionId: number, draftId: number | undefined) {
+  return draftId
+    ? `wms-saep:draft:v1:user:${sessionId}:draft:${draftId}`
+    : `wms-saep:draft:v1:user:${sessionId}:new`;
+}
+
+function recentMaterialsStorageKey(sessionId: number) {
+  return `wms-saep:recent-materials:v1:user:${sessionId}`;
+}
+
+function safeReadJson<T>(key: string): T | null {
+  try {
+    const rawValue = window.sessionStorage.getItem(key);
+    return rawValue ? (JSON.parse(rawValue) as T) : null;
+  } catch {
+    return null;
+  }
+}
+
+function safeWriteJson(key: string, value: unknown) {
+  try {
+    window.sessionStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Draft recovery is best-effort and must never block editing.
+  }
+}
+
+function safeRemoveStorage(key: string) {
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch {
+    // Ignore unavailable storage.
+  }
+}
+
+function normalizeSnapshot(values: DraftFormValues): DraftFormValues {
+  return {
+    beneficiaryMode: values.beneficiaryMode === "third_party" ? "third_party" : "self",
+    beneficiaryId: values.beneficiaryId ?? "",
+    beneficiaryLabel: values.beneficiaryLabel ?? "",
+    beneficiarySearch: "",
+    materialSearch: "",
+    observacao: values.observacao ?? "",
+    itens: Array.isArray(values.itens)
+      ? values.itens.map((item) => ({
+          materialId: item.materialId ?? "",
+          materialLabel: item.materialLabel ?? "",
+          materialCode: item.materialCode ?? "",
+          unidadeMedida: item.unidadeMedida ?? "",
+          saldoDisponivel: item.saldoDisponivel ?? null,
+          quantidadeSolicitada: item.quantidadeSolicitada ?? "",
+          observacao: item.observacao ?? "",
+        }))
+      : [],
+  };
+}
+
+function sameDraftValues(first: DraftFormValues, second: DraftFormValues) {
+  return JSON.stringify(normalizeSnapshot(first)) === JSON.stringify(normalizeSnapshot(second));
+}
+
+function quantityErrorMessage(itemLabel: string | number) {
+  return `Quantidade inválida no item ${itemLabel}: use um número válido maior que zero.`;
+}
+
+function quantityFieldName(index: number): `itens.${number}.quantidadeSolicitada` {
+  return `itens.${index}.quantidadeSolicitada`;
+}
+
+function draftFieldError(
+  values: DraftFormValues,
+  session: AuthSession,
+): { name: FieldPath<DraftFormValues>; message: string } | null {
+  const selectedBeneficiaryId = Number.parseInt(values.beneficiaryId, 10);
+  if (
+    !values.beneficiaryId ||
+    !Number.isFinite(selectedBeneficiaryId) ||
+    selectedBeneficiaryId <= 0 ||
+    (values.beneficiaryMode === "third_party" && selectedBeneficiaryId === session.id)
+  ) {
+    return { name: "beneficiaryId", message: "Informe beneficiário." };
+  }
+  if (values.itens.length === 0) {
+    return { name: "itens", message: "Adicione ao menos um item." };
+  }
+  const invalidItemIndex = values.itens.findIndex(
+    (item) => !isPositiveQuantity(item.quantidadeSolicitada),
+  );
+  if (invalidItemIndex >= 0) {
+    const item = values.itens[invalidItemIndex];
+    return {
+      name: `itens.${invalidItemIndex}.quantidadeSolicitada`,
+      message: quantityErrorMessage(item.materialLabel || invalidItemIndex + 1),
+    };
+  }
+  return null;
+}
+
+function stepIndex(step: DraftStep) {
+  return DRAFT_STEPS.findIndex((candidate) => candidate.key === step);
+}
+
+function nextStep(step: DraftStep) {
+  return DRAFT_STEPS[Math.min(stepIndex(step) + 1, DRAFT_STEPS.length - 1)].key;
+}
+
+function previousStep(step: DraftStep) {
+  return DRAFT_STEPS[Math.max(stepIndex(step) - 1, 0)].key;
+}
+
+function StepSection({
+  activeStep,
+  children,
+  step,
+}: {
+  activeStep: DraftStep;
+  children: ReactNode;
+  step: DraftStep;
+}) {
+  return (
+    <section className="draft-step-panel" hidden={activeStep !== step}>
+      {children}
+    </section>
+  );
+}
+
+export function DraftRequisitionEditor({
+  activeStep: activeStepProp = "beneficiario",
+  initialRequisition,
+  onStepChange,
+  session,
+}: DraftRequisitionEditorProps) {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const [formError, setFormError] = useState<string | null>(null);
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const [localStep, setLocalStep] = useState<DraftStep>(activeStepProp);
+  const [recentMaterials, setRecentMaterials] = useState<MaterialListItem[]>(() =>
+    safeReadJson<MaterialListItem[]>(recentMaterialsStorageKey(session.id)) ?? [],
+  );
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const cancelConfirmationButtonRef = useRef<HTMLButtonElement | null>(null);
   const pendingRef = useRef(false);
-  const sessionSetorId = session.setor?.id ?? null;
-  const sessionSetorNome = session.setor?.nome ?? null;
-  const stableSession = useMemo(
-    () =>
-      ({
-        id: session.id,
-        matricula_funcional: session.matricula_funcional,
-        nome_completo: session.nome_completo,
-        papel: session.papel,
-        setor: sessionSetorId !== null && sessionSetorNome !== null
-          ? {
-              id: sessionSetorId,
-              nome: sessionSetorNome,
-            }
-          : null,
-        is_authenticated: session.is_authenticated,
-      }) satisfies AuthSession,
-    [
-      session.id,
-      session.is_authenticated,
-      session.matricula_funcional,
-      session.nome_completo,
-      session.papel,
-      sessionSetorId,
-      sessionSetorNome,
-    ],
+  const storageKey = draftStorageKey(session.id, initialRequisition?.id);
+  const baseValues = useMemo(
+    () => formValuesFromRequisition(initialRequisition, session),
+    [initialRequisition, session],
   );
+  const recoveredValues = useMemo(
+    () => safeReadJson<DraftFormValues>(storageKey),
+    [storageKey],
+  );
+  const hasRecoveredSnapshot = Boolean(recoveredValues && !sameDraftValues(recoveredValues, baseValues));
+  const [showRecoveredDraft, setShowRecoveredDraft] = useState(hasRecoveredSnapshot);
+  const [hasDraftSnapshot, setHasDraftSnapshot] = useState(hasRecoveredSnapshot);
   const form = useForm<DraftFormValues>({
-    defaultValues: formValuesFromRequisition(initialRequisition, stableSession),
+    defaultValues:
+      recoveredValues && !sameDraftValues(recoveredValues, baseValues)
+        ? normalizeSnapshot(recoveredValues)
+        : baseValues,
   });
   const { fields, append, remove } = useFieldArray({
     control: form.control,
@@ -207,6 +348,9 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     useWatch({ control: form.control, name: "beneficiarySearch" })?.trim() ?? "";
   const materialSearch = useWatch({ control: form.control, name: "materialSearch" })?.trim() ?? "";
   const selectedItems = useWatch({ control: form.control, name: "itens" }) ?? EMPTY_DRAFT_ITEMS;
+  const watchedValues = useWatch({ control: form.control });
+  const isDraftDirty = form.formState.isDirty;
+  const activeStep = onStepChange ? activeStepProp : localStep;
   const isEdit = Boolean(initialRequisition);
   const title = isEdit ? "Editar rascunho" : "Nova requisição";
   const identifier = initialRequisition
@@ -216,23 +360,20 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     ...draftBeneficiariesQueryOptions(beneficiarySearch),
     enabled:
       beneficiaryMode === "third_party" &&
-      canRequestForThirdParty(stableSession) &&
+      canRequestForThirdParty(session) &&
       beneficiarySearch.length >= 3,
   });
   const materialsQuery = useQuery({
     ...draftMaterialsQueryOptions(materialSearch),
     enabled: materialSearch.length >= 2,
   });
-  const resetIdentity = `${initialRequisition?.id ?? "new"}:${stableSession.id}`;
-  const resetIdentityRef = useRef(resetIdentity);
-
   useEffect(() => {
-    if (resetIdentityRef.current === resetIdentity) {
+    if (isDraftDirty || hasDraftSnapshot) {
+      safeWriteJson(storageKey, normalizeSnapshot(form.getValues()));
       return;
     }
-    resetIdentityRef.current = resetIdentity;
-    form.reset(formValuesFromRequisition(initialRequisition, stableSession));
-  }, [form, initialRequisition, resetIdentity, stableSession]);
+    safeRemoveStorage(storageKey);
+  }, [form, hasDraftSnapshot, isDraftDirty, storageKey, watchedValues]);
 
   useEffect(() => {
     if (!confirmAction) {
@@ -259,7 +400,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
 
   useEffect(() => {
     if (beneficiaryMode === "self") {
-      const self = currentUserBeneficiary(stableSession);
+      const self = currentUserBeneficiary(session);
       form.setValue("beneficiaryId", String(self.id));
       form.setValue("beneficiaryLabel", beneficiaryLabel(self));
     } else if (previousBeneficiaryModeRef.current === "self") {
@@ -267,11 +408,17 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       form.setValue("beneficiaryLabel", "");
     }
     previousBeneficiaryModeRef.current = beneficiaryMode;
-  }, [beneficiaryMode, form, stableSession]);
+  }, [beneficiaryMode, form, session]);
+
+  function clearDraftStorage() {
+    safeRemoveStorage(storageKey);
+    setShowRecoveredDraft(false);
+    setHasDraftSnapshot(false);
+  }
 
   function afterMutationSuccess(requisition: RequisicaoDetail) {
+    clearDraftStorage();
     queryClient.setQueryData(requisitionsQueryKeys.detail(requisition.id), requisition);
-    // Editor routes do not keep worklists mounted; inactive refetch avoids overwriting this detail cache.
     void queryClient.invalidateQueries({
       queryKey: requisitionsQueryKeys.all,
       refetchType: "inactive",
@@ -303,7 +450,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       afterMutationSuccess(requisition);
       if (initialRequisition) {
         const currentItems = form.getValues("itens");
-        const nextValues = formValuesFromRequisition(requisition, stableSession);
+        const nextValues = formValuesFromRequisition(requisition, session);
         nextValues.itens = nextValues.itens.map((item) => ({
           ...item,
           saldoDisponivel:
@@ -320,7 +467,6 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   });
   const submitMutation = useMutation({
     mutationFn: async (input: RequisicaoDraftInput) => {
-      // Submit requires the latest draft persisted first; if submit fails, the saved draft remains retryable.
       const draft = initialRequisition
         ? await updateDraftRequisition(initialRequisition.id, input)
         : await createDraftRequisition(input);
@@ -347,6 +493,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     },
     onSuccess: async (requisition) => {
       setFormError(null);
+      clearDraftStorage();
       if (initialRequisition) {
         queryClient.removeQueries({
           queryKey: requisitionsQueryKeys.detail(initialRequisition.id),
@@ -362,6 +509,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   });
   const pending = saveMutation.isPending || submitMutation.isPending || discardMutation.isPending;
   const materials = materialsQuery.data?.results ?? [];
+  const displayedMaterials = materialSearch ? materials : recentMaterials.length >= 2 ? recentMaterials : [];
   const beneficiaries = beneficiaryQuery.data ?? [];
   const missingStockSignature = selectedItems
     .filter((item) => item.saldoDisponivel === null)
@@ -415,6 +563,23 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     [selectedItems],
   );
 
+  function goToStep(step: DraftStep) {
+    if (onStepChange) {
+      onStepChange(step);
+      return;
+    }
+    setLocalStep(step);
+  }
+
+  function storeRecentMaterial(material: MaterialListItem) {
+    const nextMaterials = [
+      material,
+      ...recentMaterials.filter((candidate) => candidate.id !== material.id),
+    ].slice(0, 5);
+    setRecentMaterials(nextMaterials);
+    safeWriteJson(recentMaterialsStorageKey(session.id), nextMaterials);
+  }
+
   function addMaterial(material: MaterialListItem) {
     if (pending || !hasPositiveStock(material) || selectedMaterialIds.has(material.id)) {
       return;
@@ -428,6 +593,7 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
       quantidadeSolicitada: "1",
       observacao: "",
     });
+    storeRecentMaterial(material);
     form.setValue("materialSearch", "");
   }
 
@@ -435,9 +601,10 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     if (pending) {
       return;
     }
-    form.setValue("beneficiaryId", String(beneficiary.id));
-    form.setValue("beneficiaryLabel", beneficiaryLabel(beneficiary));
+    form.setValue("beneficiaryId", String(beneficiary.id), { shouldDirty: true });
+    form.setValue("beneficiaryLabel", beneficiaryLabel(beneficiary), { shouldDirty: true });
     form.setValue("beneficiarySearch", "");
+    form.clearErrors("beneficiaryId");
   }
 
   function chooseBeneficiaryMode(mode: DraftFormValues["beneficiaryMode"]) {
@@ -446,10 +613,11 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     }
     form.setValue("beneficiaryMode", mode, { shouldDirty: true });
     if (mode === "self") {
-      const self = currentUserBeneficiary(stableSession);
+      const self = currentUserBeneficiary(session);
       form.setValue("beneficiaryId", String(self.id), { shouldDirty: true });
       form.setValue("beneficiaryLabel", beneficiaryLabel(self), { shouldDirty: true });
       form.setValue("beneficiarySearch", "");
+      form.clearErrors("beneficiaryId");
       return;
     }
     form.setValue("beneficiaryId", "", { shouldDirty: true });
@@ -469,42 +637,82 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
     }
   }
 
-  function validationErrorMessage(values: DraftFormValues) {
-    const selectedBeneficiaryId = Number.parseInt(values.beneficiaryId, 10);
-    if (
-      !values.beneficiaryId ||
-      !Number.isFinite(selectedBeneficiaryId) ||
-      selectedBeneficiaryId <= 0 ||
-      (values.beneficiaryMode === "third_party" && selectedBeneficiaryId === stableSession.id)
-    ) {
-      return "Informe beneficiário.";
+  async function validateDraft({ focus = true }: { focus?: boolean } = {}) {
+    form.clearErrors();
+    const values = form.getValues();
+    const validationError = draftFieldError(values, session);
+    if (validationError) {
+      form.setError(validationError.name, { type: "manual", message: validationError.message }, {
+        shouldFocus: focus,
+      });
+      setFormError(validationError.message);
+      return false;
     }
-    if (values.itens.length === 0) {
-      return "Adicione ao menos um item.";
+    const fieldNames = values.itens.map((_item, index) => quantityFieldName(index));
+    const valid = await form.trigger(fieldNames, { shouldFocus: focus });
+    if (!valid) {
+      return false;
     }
-    const invalidItemIndex = values.itens.findIndex(
-      (item) => !isPositiveQuantity(item.quantidadeSolicitada),
-    );
-    if (invalidItemIndex >= 0) {
-      const item = values.itens[invalidItemIndex];
-      return `Quantidade inválida no item ${item.materialLabel || invalidItemIndex + 1}: use um número válido maior que zero.`;
-    }
-    return null;
+    setFormError(null);
+    return true;
   }
 
-  function saveDraft(valuesToSave: DraftFormValues) {
-    const validationError = validationErrorMessage(valuesToSave);
-    if (validationError) {
-      setFormError(validationError);
+  async function advanceStep() {
+    if (activeStep === "beneficiario") {
+      const validBeneficiary = await validateDraftStep("beneficiario");
+      if (!validBeneficiary) {
+        return;
+      }
+    }
+    if (activeStep === "itens") {
+      const validItems = await validateDraftStep("itens");
+      if (!validItems) {
+        return;
+      }
+    }
+    goToStep(nextStep(activeStep));
+  }
+
+  async function validateDraftStep(step: DraftStep) {
+    form.clearErrors();
+    const values = form.getValues();
+    if (step === "beneficiario") {
+      const selectedBeneficiaryId = Number.parseInt(values.beneficiaryId, 10);
+      if (
+        !values.beneficiaryId ||
+        !Number.isFinite(selectedBeneficiaryId) ||
+        selectedBeneficiaryId <= 0 ||
+        (values.beneficiaryMode === "third_party" && selectedBeneficiaryId === session.id)
+      ) {
+        form.setError("beneficiaryId", { type: "manual", message: "Informe beneficiário." }, {
+          shouldFocus: true,
+        });
+        setFormError("Informe beneficiário.");
+        return false;
+      }
+      setFormError(null);
+      return true;
+    }
+    if (step === "itens") {
+      if (values.itens.length === 0) {
+        form.setError("itens", { type: "manual", message: "Adicione ao menos um item." });
+        setFormError("Adicione ao menos um item.");
+        return false;
+      }
+      return validateDraft();
+    }
+    return true;
+  }
+
+  async function saveDraft(valuesToSave: DraftFormValues) {
+    if (!(await validateDraft())) {
       return;
     }
     saveMutation.mutate(payloadFromValues(valuesToSave));
   }
 
-  function requestSubmitDraft(valuesToSubmit: DraftFormValues) {
-    const validationError = validationErrorMessage(valuesToSubmit);
-    if (validationError) {
-      setFormError(validationError);
+  async function requestSubmitDraft(valuesToSubmit: DraftFormValues) {
+    if (!(await validateDraft())) {
       return;
     }
     setConfirmAction({ type: "submit", values: valuesToSubmit });
@@ -512,6 +720,11 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
 
   function requestDiscardOrCancel() {
     setConfirmAction({ type: initialRequisition?.numero_publico ? "cancel" : "discard" });
+  }
+
+  function discardLocalCopy() {
+    clearDraftStorage();
+    form.reset(baseValues);
   }
 
   function confirmSelectedAction() {
@@ -575,6 +788,8 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
   }
 
   const confirmation = confirmationContent();
+  const itemError = form.formState.errors.itens?.message;
+  const showRecentMaterials = !materialSearch && recentMaterials.length >= 2;
 
   return (
     <section className="space-y-6">
@@ -589,6 +804,42 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
         </Link>
       </div>
 
+      <div className="draft-stepper" aria-label="Etapas do rascunho">
+        {DRAFT_STEPS.map((step) => (
+          <button
+            aria-current={activeStep === step.key ? "step" : undefined}
+            className={activeStep === step.key ? "draft-step active" : "draft-step"}
+            disabled={pending}
+            key={step.key}
+            onClick={() => goToStep(step.key)}
+            type="button"
+          >
+            {step.label}
+          </button>
+        ))}
+      </div>
+
+      {showRecoveredDraft ? (
+        <div className="draft-recovery-banner">
+          <div>
+            <strong>Rascunho local recuperado</strong>
+            <p>Encontramos dados salvos nesta aba. Continue ou descarte a cópia local.</p>
+          </div>
+          <div className="draft-recovery-actions">
+            <button
+              className="preview-button draft-primary"
+              onClick={() => setShowRecoveredDraft(false)}
+              type="button"
+            >
+              Continuar
+            </button>
+            <button className="action-link compact-action" onClick={discardLocalCopy} type="button">
+              Descartar cópia local
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       {formError ? <div className="error-panel">{formError}</div> : null}
 
       <form
@@ -597,179 +848,266 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
           void form.handleSubmit(saveDraft)(event);
         }}
       >
-        <section className="detail-panel draft-section">
-          <p className="eyebrow">Beneficiário</p>
-          <input type="hidden" {...form.register("beneficiaryMode")} />
-          <input type="hidden" {...form.register("beneficiaryId")} />
-          <input type="hidden" {...form.register("beneficiaryLabel")} />
-          <div className="draft-choice-grid">
-            <label className="draft-choice">
-              <input
-                checked={beneficiaryMode === "self"}
-                disabled={pending}
-                name="beneficiaryModeChoice"
-                onChange={() => chooseBeneficiaryMode("self")}
-                type="radio"
-                value="self"
-              />
-              Para mim
-            </label>
-            {canRequestForThirdParty(stableSession) ? (
+        <StepSection activeStep={activeStep} step="beneficiario">
+          <section className="detail-panel draft-section">
+            <h2>Beneficiário</h2>
+            <input type="hidden" {...form.register("beneficiaryMode")} />
+            <input type="hidden" {...form.register("beneficiaryId")} />
+            <input type="hidden" {...form.register("beneficiaryLabel")} />
+            <div className="draft-choice-grid">
               <label className="draft-choice">
                 <input
-                  checked={beneficiaryMode === "third_party"}
+                  checked={beneficiaryMode === "self"}
                   disabled={pending}
                   name="beneficiaryModeChoice"
-                  onChange={() => chooseBeneficiaryMode("third_party")}
+                  onChange={() => chooseBeneficiaryMode("self")}
                   type="radio"
-                  value="third_party"
+                  value="self"
                 />
-                Para terceiro
+                Para mim
               </label>
-            ) : null}
-          </div>
-          <p className="selected-summary">Selecionado: {beneficiaryLabelValue}</p>
-          {beneficiaryMode === "third_party" && canRequestForThirdParty(stableSession) ? (
-            <div className="draft-lookup">
-              <label className="preview-label">
-                Buscar beneficiário
-                <input
-                  className="preview-input"
-                  disabled={pending}
-                  placeholder="Nome com ao menos 3 letras"
-                  {...form.register("beneficiarySearch")}
-                />
-              </label>
-              {beneficiarySearch.length > 0 && beneficiarySearch.length < 3 ? (
-                <p className="helper-text">Digite ao menos 3 caracteres.</p>
-              ) : null}
-              <div className="lookup-results">
-                {beneficiaries.map((beneficiary) => (
-                  <button
-                    className="lookup-result"
+              {canRequestForThirdParty(session) ? (
+                <label className="draft-choice">
+                  <input
+                    checked={beneficiaryMode === "third_party"}
                     disabled={pending}
-                    key={beneficiary.id}
-                    onClick={() => chooseBeneficiary(beneficiary)}
+                    name="beneficiaryModeChoice"
+                    onChange={() => chooseBeneficiaryMode("third_party")}
+                    type="radio"
+                    value="third_party"
+                  />
+                  Para terceiro
+                </label>
+              ) : null}
+            </div>
+            <p className="selected-summary">Selecionado: {beneficiaryLabelValue}</p>
+            {form.formState.errors.beneficiaryId?.message ? (
+              <p className="field-error">{form.formState.errors.beneficiaryId.message}</p>
+            ) : null}
+            {beneficiaryMode === "third_party" && canRequestForThirdParty(session) ? (
+              <div className="draft-lookup">
+                <label className="preview-label">
+                  Buscar beneficiário
+                  <input
+                    className="preview-input"
+                    disabled={pending}
+                    placeholder="Nome com ao menos 3 letras"
+                    {...form.register("beneficiarySearch")}
+                  />
+                </label>
+                {beneficiarySearch.length > 0 && beneficiarySearch.length < 3 ? (
+                  <p className="helper-text">Digite ao menos 3 caracteres.</p>
+                ) : null}
+                <div className="lookup-results">
+                  {beneficiaries.map((beneficiary) => (
+                    <button
+                      className="lookup-result"
+                      disabled={pending}
+                      key={beneficiary.id}
+                      onClick={() => chooseBeneficiary(beneficiary)}
+                      type="button"
+                    >
+                      <strong>{beneficiary.nome_completo}</strong>
+                      <span>
+                        {beneficiary.matricula_funcional} - {beneficiary.setor.nome}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </section>
+        </StepSection>
+
+        <StepSection activeStep={activeStep} step="itens">
+          <section className="detail-panel draft-section">
+            <h2>Itens</h2>
+            <label className="preview-label">
+              Buscar material
+              <input
+                className="preview-input"
+                disabled={pending}
+                placeholder="Código, nome ou descrição"
+                {...form.register("materialSearch")}
+              />
+            </label>
+            {materialsQuery.isLoading ? (
+              <div className="worklist-skeleton" aria-label="Carregando materiais">
+                <span className="worklist-skeleton-line wide" />
+                <span className="worklist-skeleton-line medium" />
+              </div>
+            ) : null}
+            {materialsQuery.isError ? (
+              <p className="helper-text">{queryErrorMessage(materialsQuery.error, "Erro na busca.")}</p>
+            ) : null}
+            {showRecentMaterials ? <p className="eyebrow">Materiais recentes</p> : null}
+            <div className="lookup-results">
+              {displayedMaterials.map((material) => {
+                const disabled = pending || !hasPositiveStock(material) || selectedMaterialIds.has(material.id);
+                return (
+                  <button
+                    aria-label={`Adicionar ${material.nome}`}
+                    className="lookup-result"
+                    disabled={disabled}
+                    key={material.id}
+                    onClick={() => addMaterial(material)}
                     type="button"
                   >
-                    <strong>{beneficiary.nome_completo}</strong>
+                    <strong>{material.nome}</strong>
                     <span>
-                      {beneficiary.matricula_funcional} - {beneficiary.setor.nome}
+                      {material.codigo_completo} - saldo{" "}
+                      {material.saldo_disponivel === null
+                        ? "indisponível"
+                        : formatQuantity(String(material.saldo_disponivel))}{" "}
+                      {material.unidade_medida}
                     </span>
                   </button>
-                ))}
-              </div>
-            </div>
-          ) : null}
-        </section>
-
-        <section className="detail-panel draft-section">
-          <p className="eyebrow">Observação</p>
-          <label className="preview-label">
-            Observação geral
-            <textarea
-              className="preview-input draft-textarea"
-              disabled={pending}
-              rows={3}
-              {...form.register("observacao")}
-            />
-          </label>
-        </section>
-
-        <section className="detail-panel draft-section">
-          <p className="eyebrow">Materiais</p>
-          <label className="preview-label">
-            Buscar material
-            <input
-              className="preview-input"
-              disabled={pending}
-              placeholder="Código, nome ou descrição"
-              {...form.register("materialSearch")}
-            />
-          </label>
-          {materialsQuery.isError ? (
-            <p className="helper-text">{queryErrorMessage(materialsQuery.error, "Erro na busca.")}</p>
-          ) : null}
-          <div className="lookup-results">
-            {materials.map((material) => {
-              const disabled = pending || !hasPositiveStock(material) || selectedMaterialIds.has(material.id);
-              return (
-                <button
-                  aria-label={`Adicionar ${material.nome}`}
-                  className="lookup-result"
-                  disabled={disabled}
-                  key={material.id}
-                  onClick={() => addMaterial(material)}
-                  type="button"
-                >
-                  <strong>{material.nome}</strong>
-                  <span>
-                    {material.codigo_completo} - saldo{" "}
-                    {material.saldo_disponivel === null
-                      ? "indisponível"
-                      : formatQuantity(String(material.saldo_disponivel))}{" "}
-                    {material.unidade_medida}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="detail-panel draft-section">
-          <p className="eyebrow">Itens solicitados</p>
-          {fields.length === 0 ? (
-            <p className="helper-text">Nenhum material adicionado.</p>
-          ) : (
-            <div className="draft-items">
-              {fields.map((field, index) => {
-                const item = selectedItems[index] ?? field;
-                return (
-                  <article className="draft-item-card" key={field.id}>
-                    <div>
-                      <h2>{field.materialLabel}</h2>
-                      <p>
-                        {item.saldoDisponivel === null
-                          ? "Saldo carregando..."
-                          : `Saldo ${formatQuantity(String(item.saldoDisponivel))} ${field.unidadeMedida}`}
-                      </p>
-                    </div>
-                    <div className="draft-item-fields">
-                      <label className="preview-label">
-                        Quantidade solicitada
-                        <input
-                          className="preview-input"
-                          disabled={pending}
-                          inputMode="decimal"
-                          {...form.register(`itens.${index}.quantidadeSolicitada`)}
-                        />
-                      </label>
-                      <label className="preview-label">
-                        Observação do item
-                        <input
-                          className="preview-input"
-                          disabled={pending}
-                          {...form.register(`itens.${index}.observacao`)}
-                        />
-                      </label>
-                      <button
-                        aria-label={`Remover ${field.materialLabel}`}
-                        className="action-link compact-action"
-                        disabled={pending}
-                        onClick={() => removeMaterial(index)}
-                        type="button"
-                      >
-                        Remover
-                      </button>
-                    </div>
-                  </article>
                 );
               })}
             </div>
-          )}
-        </section>
+          </section>
 
-        <div className="draft-actions">
+          <section className="detail-panel draft-section">
+            <h2>Itens solicitados</h2>
+            {itemError ? <p className="field-error">{itemError}</p> : null}
+            {fields.length === 0 ? (
+              <p className="helper-text">Nenhum material adicionado.</p>
+            ) : (
+              <div className="draft-items">
+                {fields.map((field, index) => {
+                  const item = selectedItems[index] ?? field;
+                  return (
+                    <article className="draft-item-card" key={field.id}>
+                      <div>
+                        <h3>{field.materialLabel}</h3>
+                        <p>
+                          {item.saldoDisponivel === null
+                            ? "Saldo carregando..."
+                            : `Saldo ${formatQuantity(String(item.saldoDisponivel))} ${field.unidadeMedida}`}
+                        </p>
+                      </div>
+                      <div className="draft-item-fields">
+                        <label className="preview-label">
+                          Quantidade solicitada
+                          <input
+                            className="preview-input"
+                            disabled={pending}
+                            inputMode="decimal"
+                            {...form.register(`itens.${index}.quantidadeSolicitada`, {
+                              validate: (value) =>
+                                isPositiveQuantity(value) ||
+                                quantityErrorMessage(field.materialLabel),
+                            })}
+                          />
+                        </label>
+                        {form.formState.errors.itens?.[index]?.quantidadeSolicitada?.message ? (
+                          <p className="field-error">
+                            {form.formState.errors.itens[index]?.quantidadeSolicitada?.message}
+                          </p>
+                        ) : null}
+                        <label className="preview-label">
+                          Observação do item
+                          <input
+                            className="preview-input"
+                            disabled={pending}
+                            {...form.register(`itens.${index}.observacao`)}
+                          />
+                        </label>
+                        <button
+                          aria-label={`Remover ${field.materialLabel}`}
+                          className="action-link compact-action"
+                          disabled={pending}
+                          onClick={() => removeMaterial(index)}
+                          type="button"
+                        >
+                          Remover
+                        </button>
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        </StepSection>
+
+        <StepSection activeStep={activeStep} step="revisao">
+          <section className="detail-panel draft-section">
+            <h2>Revisão</h2>
+            <dl className="info-list">
+              <div>
+                <dt>Beneficiário</dt>
+                <dd>{beneficiaryLabelValue}</dd>
+              </div>
+              <div>
+                <dt>Total de itens</dt>
+                <dd>{selectedItems.length}</dd>
+              </div>
+            </dl>
+            <label className="preview-label">
+              Observação geral
+              <textarea
+                className="preview-input draft-textarea"
+                disabled={pending}
+                rows={3}
+                {...form.register("observacao")}
+              />
+            </label>
+          </section>
+
+          <section className="detail-panel draft-section">
+            <h2>Resumo dos itens</h2>
+            {selectedItems.length === 0 ? (
+              <p className="helper-text">Nenhum material adicionado.</p>
+            ) : (
+              <div className="draft-review-list">
+                {selectedItems.map((item) => (
+                  <article className="draft-review-item" key={item.materialId}>
+                    <div>
+                      <strong>{item.materialLabel}</strong>
+                      {item.observacao ? <p>{item.observacao}</p> : null}
+                    </div>
+                    <span>
+                      {item.quantidadeSolicitada} {item.unidadeMedida}
+                    </span>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+        </StepSection>
+
+        <StepSection activeStep={activeStep} step="envio">
+          <section className="detail-panel draft-section">
+            <h2>Envio</h2>
+            <p className="helper-text">
+              Salvar mantém o rascunho editável. Enviar confirma o rascunho no backend e encaminha
+              para autorização.
+            </p>
+            <dl className="info-list">
+              <div>
+                <dt>Beneficiário</dt>
+                <dd>{beneficiaryLabelValue}</dd>
+              </div>
+              <div>
+                <dt>Itens</dt>
+                <dd>{selectedItems.length}</dd>
+              </div>
+            </dl>
+          </section>
+        </StepSection>
+
+        <div className="draft-actions draft-sticky-actions">
+          {activeStep !== "beneficiario" ? (
+            <button
+              className="action-link compact-action"
+              disabled={pending}
+              onClick={() => goToStep(previousStep(activeStep))}
+              type="button"
+            >
+              Voltar etapa
+            </button>
+          ) : null}
           {initialRequisition ? (
             <button
               className="action-link compact-action danger-action"
@@ -778,6 +1116,20 @@ export function DraftRequisitionEditor({ initialRequisition, session }: DraftReq
               type="button"
             >
               {initialRequisition.numero_publico ? "Cancelar requisição" : "Descartar rascunho"}
+            </button>
+          ) : null}
+          {activeStep !== "envio" ? (
+            <button
+              className="preview-button draft-primary"
+              disabled={pending}
+              onClick={() => void advanceStep()}
+              type="button"
+            >
+              {activeStep === "beneficiario"
+                ? "Próximo: itens"
+                : activeStep === "itens"
+                  ? "Próximo: revisão"
+                  : "Próximo: envio"}
             </button>
           ) : null}
           <button className="preview-button draft-primary" disabled={pending} type="submit">

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -460,7 +460,11 @@ export function DraftRequisitionEditor({
         form.reset(nextValues);
       }
       if (!initialRequisition) {
-        await navigate({ to: "/requisicoes/$id", params: { id: String(requisition.id) } });
+        await navigate({
+          to: "/requisicoes/$id",
+          params: { id: String(requisition.id) },
+          search: { etapa: activeStep },
+        });
       }
     },
     onError: handleMutationError,
@@ -593,6 +597,8 @@ export function DraftRequisitionEditor({
       quantidadeSolicitada: "1",
       observacao: "",
     });
+    form.clearErrors("itens");
+    setFormError(null);
     storeRecentMaterial(material);
     form.setValue("materialSearch", "");
   }
@@ -605,6 +611,7 @@ export function DraftRequisitionEditor({
     form.setValue("beneficiaryLabel", beneficiaryLabel(beneficiary), { shouldDirty: true });
     form.setValue("beneficiarySearch", "");
     form.clearErrors("beneficiaryId");
+    setFormError(null);
   }
 
   function chooseBeneficiaryMode(mode: DraftFormValues["beneficiaryMode"]) {
@@ -618,6 +625,7 @@ export function DraftRequisitionEditor({
       form.setValue("beneficiaryLabel", beneficiaryLabel(self), { shouldDirty: true });
       form.setValue("beneficiarySearch", "");
       form.clearErrors("beneficiaryId");
+      setFormError(null);
       return;
     }
     form.setValue("beneficiaryId", "", { shouldDirty: true });

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -319,6 +319,7 @@ export function DraftRequisitionEditor({
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const cancelConfirmationButtonRef = useRef<HTMLButtonElement | null>(null);
   const pendingRef = useRef(false);
+  const suppressNextPersistRef = useRef(false);
   const storageKey = draftStorageKey(session.id, initialRequisition?.id);
   const baseValues = useMemo(
     () => formValuesFromRequisition(initialRequisition, session),
@@ -368,6 +369,10 @@ export function DraftRequisitionEditor({
     enabled: materialSearch.length >= 2,
   });
   useEffect(() => {
+    if (suppressNextPersistRef.current) {
+      suppressNextPersistRef.current = false;
+      return;
+    }
     if (isDraftDirty || hasDraftSnapshot) {
       safeWriteJson(storageKey, normalizeSnapshot(form.getValues()));
       return;
@@ -417,6 +422,7 @@ export function DraftRequisitionEditor({
   }
 
   function afterMutationSuccess(requisition: RequisicaoDetail) {
+    suppressNextPersistRef.current = true;
     clearDraftStorage();
     queryClient.setQueryData(requisitionsQueryKeys.detail(requisition.id), requisition);
     void queryClient.invalidateQueries({

--- a/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
+++ b/frontend/src/features/requisitions/DraftRequisitionEditor.tsx
@@ -211,29 +211,72 @@ function safeRemoveStorage(key: string) {
   }
 }
 
-function normalizeSnapshot(values: DraftFormValues): DraftFormValues {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" ? value : "";
+}
+
+function readNullableNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeSnapshot(values: unknown): DraftFormValues {
+  const snapshot = isRecord(values) ? values : {};
+
   return {
-    beneficiaryMode: values.beneficiaryMode === "third_party" ? "third_party" : "self",
-    beneficiaryId: values.beneficiaryId ?? "",
-    beneficiaryLabel: values.beneficiaryLabel ?? "",
+    beneficiaryMode: snapshot.beneficiaryMode === "third_party" ? "third_party" : "self",
+    beneficiaryId: readString(snapshot.beneficiaryId),
+    beneficiaryLabel: readString(snapshot.beneficiaryLabel),
     beneficiarySearch: "",
     materialSearch: "",
-    observacao: values.observacao ?? "",
-    itens: Array.isArray(values.itens)
-      ? values.itens.map((item) => ({
-          materialId: item.materialId ?? "",
-          materialLabel: item.materialLabel ?? "",
-          materialCode: item.materialCode ?? "",
-          unidadeMedida: item.unidadeMedida ?? "",
-          saldoDisponivel: item.saldoDisponivel ?? null,
-          quantidadeSolicitada: item.quantidadeSolicitada ?? "",
-          observacao: item.observacao ?? "",
+    observacao: readString(snapshot.observacao),
+    itens: Array.isArray(snapshot.itens)
+      ? snapshot.itens.filter(isRecord).map((item) => ({
+          materialId: readString(item.materialId),
+          materialLabel: readString(item.materialLabel),
+          materialCode: readString(item.materialCode),
+          unidadeMedida: readString(item.unidadeMedida),
+          saldoDisponivel: readNullableNumber(item.saldoDisponivel),
+          quantidadeSolicitada: readString(item.quantidadeSolicitada),
+          observacao: readString(item.observacao),
         }))
       : [],
   };
 }
 
-function sameDraftValues(first: DraftFormValues, second: DraftFormValues) {
+function normalizeRecentMaterials(values: unknown): MaterialListItem[] {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+
+  return values
+    .filter(isRecord)
+    .map((item) => {
+      const id = typeof item.id === "number" && Number.isFinite(item.id) ? item.id : null;
+      const codigoCompleto = readString(item.codigo_completo);
+      const nome = readString(item.nome);
+      const unidadeMedida = readString(item.unidade_medida);
+
+      if (id === null || !codigoCompleto || !nome || !unidadeMedida) {
+        return null;
+      }
+
+      return {
+        id,
+        codigo_completo: codigoCompleto,
+        nome,
+        descricao: readString(item.descricao),
+        unidade_medida: unidadeMedida,
+        saldo_disponivel: readNullableNumber(item.saldo_disponivel),
+      };
+    })
+    .filter((item): item is MaterialListItem => item !== null);
+}
+
+function sameDraftValues(first: unknown, second: unknown) {
   return JSON.stringify(normalizeSnapshot(first)) === JSON.stringify(normalizeSnapshot(second));
 }
 
@@ -314,7 +357,7 @@ export function DraftRequisitionEditor({
   const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const [localStep, setLocalStep] = useState<DraftStep>(activeStepProp);
   const [recentMaterials, setRecentMaterials] = useState<MaterialListItem[]>(() =>
-    safeReadJson<MaterialListItem[]>(recentMaterialsStorageKey(session.id)) ?? [],
+    normalizeRecentMaterials(safeReadJson<unknown>(recentMaterialsStorageKey(session.id))),
   );
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const cancelConfirmationButtonRef = useRef<HTMLButtonElement | null>(null);
@@ -326,7 +369,7 @@ export function DraftRequisitionEditor({
     [initialRequisition, session],
   );
   const recoveredValues = useMemo(
-    () => safeReadJson<DraftFormValues>(storageKey),
+    () => safeReadJson<unknown>(storageKey),
     [storageKey],
   );
   const hasRecoveredSnapshot = Boolean(recoveredValues && !sameDraftValues(recoveredValues, baseValues));
@@ -503,6 +546,7 @@ export function DraftRequisitionEditor({
     },
     onSuccess: async (requisition) => {
       setFormError(null);
+      suppressNextPersistRef.current = true;
       clearDraftStorage();
       if (initialRequisition) {
         queryClient.removeQueries({

--- a/frontend/src/features/requisitions/draftSteps.ts
+++ b/frontend/src/features/requisitions/draftSteps.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+export const draftStepSchema = z.enum(["beneficiario", "itens", "revisao", "envio"]);
+export type DraftStep = z.infer<typeof draftStepSchema>;

--- a/frontend/src/routes/requisicoes/$id.tsx
+++ b/frontend/src/routes/requisicoes/$id.tsx
@@ -10,6 +10,7 @@ import {
   meQueryOptions,
 } from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
+import { draftStepSchema, type DraftStep } from "../../features/requisitions/draftSteps";
 import {
   authorizeRequisition,
   cancelAuthorizedRequisition,
@@ -35,6 +36,7 @@ import {
 
 const detailSearchSchema = z.object({
   contexto: z.enum(["autorizacao", "atendimento"]).optional().catch(undefined),
+  etapa: draftStepSchema.optional().catch("beneficiario"),
   page: z.coerce.number().int().min(1).optional().catch(undefined),
 });
 
@@ -707,7 +709,7 @@ function FulfillmentDecisionPanel({
 
 function DetalheRequisicaoPage() {
   const { id } = Route.useParams();
-  const { contexto, page: sourcePage } = Route.useSearch();
+  const { contexto, etapa = "beneficiario", page: sourcePage } = Route.useSearch();
   const requisicaoId = Number(id);
   const backTo =
     contexto === "autorizacao"
@@ -726,6 +728,14 @@ function DetalheRequisicaoPage() {
     enabled: detailQuery.data?.status === "rascunho",
   });
   const authError = detailQuery.isError && isUnauthenticatedError(detailQuery.error);
+
+  function handleDraftStepChange(step: DraftStep) {
+    void navigate({
+      to: "/requisicoes/$id",
+      params: { id },
+      search: (prev) => ({ ...prev, etapa: step }),
+    });
+  }
 
   useEffect(() => {
     if (!authError) {
@@ -775,7 +785,14 @@ function DetalheRequisicaoPage() {
     if (!sessionQuery.data) {
       return <div className="error-panel">Sessão indisponível.</div>;
     }
-    return <DraftRequisitionEditor initialRequisition={requisicao} session={sessionQuery.data} />;
+    return (
+      <DraftRequisitionEditor
+        activeStep={etapa}
+        initialRequisition={requisicao}
+        onStepChange={handleDraftStepChange}
+        session={sessionQuery.data}
+      />
+    );
   }
 
   const thirdParty = isThirdPartyBeneficiary(requisicao);

--- a/frontend/src/routes/requisicoes/nova.tsx
+++ b/frontend/src/routes/requisicoes/nova.tsx
@@ -1,11 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { z } from "zod";
 
 import { requireSession } from "../../features/auth/guards";
 import { meQueryOptions } from "../../features/auth/session";
 import { DraftRequisitionEditor } from "../../features/requisitions/DraftRequisitionEditor";
+import { draftStepSchema, type DraftStep } from "../../features/requisitions/draftSteps";
+
+const draftSearchSchema = z.object({
+  etapa: draftStepSchema.optional().catch("beneficiario"),
+});
 
 export const Route = createFileRoute("/requisicoes/nova")({
+  validateSearch: draftSearchSchema,
   beforeLoad: ({ context, location }) =>
     requireSession({ queryClient: context.queryClient, locationHref: location.href }),
   component: NovaRequisicaoPage,
@@ -13,6 +20,12 @@ export const Route = createFileRoute("/requisicoes/nova")({
 
 function NovaRequisicaoPage() {
   const sessionQuery = useQuery(meQueryOptions);
+  const { etapa = "beneficiario" } = Route.useSearch();
+  const navigate = useNavigate({ from: "/requisicoes/nova" });
+
+  function handleStepChange(step: DraftStep) {
+    void navigate({ search: (prev) => ({ ...prev, etapa: step }) });
+  }
 
   if (sessionQuery.isLoading) {
     return <div className="loading-state">Carregando sessão...</div>;
@@ -33,5 +46,11 @@ function NovaRequisicaoPage() {
     return <div className="error-panel">Sessão indisponível.</div>;
   }
 
-  return <DraftRequisitionEditor session={sessionQuery.data} />;
+  return (
+    <DraftRequisitionEditor
+      activeStep={etapa}
+      onStepChange={handleStepChange}
+      session={sessionQuery.data}
+    />
+  );
 }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -816,6 +816,59 @@ button:disabled {
   gap: 1rem;
 }
 
+.draft-stepper {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.draft-step {
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  min-height: 44px;
+  background: #ffffff;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+.draft-step.active {
+  border-color: rgba(16, 108, 74, 0.34);
+  background: rgba(16, 108, 74, 0.08);
+  color: var(--accent-strong);
+}
+
+.draft-step-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.draft-recovery-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid rgba(16, 108, 74, 0.26);
+  border-radius: 8px;
+  background: rgba(16, 108, 74, 0.08);
+  padding: 1rem;
+}
+
+.draft-recovery-banner strong {
+  color: var(--ink-strong);
+}
+
+.draft-recovery-banner p {
+  margin-top: 0.25rem;
+  color: var(--ink-soft);
+}
+
+.draft-recovery-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 .draft-choice-grid {
   display: flex;
   flex-wrap: wrap;
@@ -839,6 +892,12 @@ button:disabled {
 .helper-text {
   color: var(--ink-soft);
   font-size: 0.9rem;
+}
+
+.field-error {
+  color: var(--danger);
+  font-size: 0.9rem;
+  font-weight: 700;
 }
 
 .draft-textarea {
@@ -879,7 +938,8 @@ button:disabled {
   padding: 1rem;
 }
 
-.draft-item-card h2 {
+.draft-item-card h2,
+.draft-item-card h3 {
   font-weight: 700;
   color: var(--ink-strong);
 }
@@ -898,6 +958,31 @@ button:disabled {
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.draft-review-list {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.draft-review-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  border: 1px solid var(--line-soft);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 1rem;
+}
+
+.draft-review-item strong {
+  color: var(--ink-strong);
+}
+
+.draft-review-item p,
+.draft-review-item span {
+  color: var(--ink-soft);
 }
 
 .draft-primary {
@@ -963,10 +1048,31 @@ button:disabled {
     flex-direction: column;
   }
 
+  .draft-stepper {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .draft-recovery-banner,
+  .draft-review-item {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .draft-actions,
   .detail-actions {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .draft-sticky-actions {
+    position: sticky;
+    bottom: 0;
+    z-index: 8;
+    margin-right: -1rem;
+    margin-left: -1rem;
+    border-top: 1px solid var(--line-soft);
+    background: rgba(246, 249, 246, 0.96);
+    padding: 0.9rem 1rem max(0.9rem, env(safe-area-inset-bottom));
   }
 
   .draft-primary,

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -2935,10 +2935,17 @@ describe("frontend pilot router", () => {
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
+    window.sessionStorage.setItem(
+      "wms-saep:draft:v1:user:10:draft:101",
+      JSON.stringify({ observacao: "Rascunho a descartar" }),
+    );
 
     const { container } = renderRoute("/requisicoes/101");
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Observação geral"), {
+      target: { value: "Rascunho sujo" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Descartar rascunho" }));
     expect(await screen.findByRole("dialog")).toHaveTextContent("Descartar rascunho?");
     fireEvent.click(screen.getByRole("button", { name: "Confirmar descarte" }));
@@ -2947,6 +2954,7 @@ describe("frontend pilot router", () => {
       expect(discardCalled).toBe(true);
       expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
     });
+    expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:draft:101")).toBeNull();
   });
 
   it("cancels a numbered draft instead of discarding it", async () => {
@@ -2974,10 +2982,17 @@ describe("frontend pilot router", () => {
       throw new Error(`Unexpected request: ${requestUrl(request)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
+    window.sessionStorage.setItem(
+      "wms-saep:draft:v1:user:10:draft:101",
+      JSON.stringify({ observacao: "Rascunho numerado" }),
+    );
 
     const { container } = renderRoute("/requisicoes/101");
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Observação geral"), {
+      target: { value: "Cancelamento sujo" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Cancelar requisição" }));
     expect(await screen.findByRole("dialog")).toHaveTextContent("Cancelar requisição?");
     fireEvent.click(screen.getByRole("button", { name: "Confirmar cancelamento" }));
@@ -2986,6 +3001,7 @@ describe("frontend pilot router", () => {
       expect(cancelPayload).toEqual({ motivo_cancelamento: "" });
       expect(container.ownerDocument.location.pathname).toBe("/minhas-requisicoes");
     });
+    expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:draft:101")).toBeNull();
   });
 
   it("shows material stock and blocks adding material without positive stock", async () => {
@@ -3074,6 +3090,42 @@ describe("frontend pilot router", () => {
     expect(screen.getByText("Materiais recentes")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Adicionar Papel sulfite A4" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Adicionar Caneta azul" })).toBeInTheDocument();
+  });
+
+  it("ignores malformed draft and recent-material snapshots from session storage", async () => {
+    window.sessionStorage.setItem(
+      "wms-saep:draft:v1:user:10:new",
+      JSON.stringify({
+        beneficiaryMode: "third_party",
+        beneficiaryId: 123,
+        beneficiaryLabel: ["invalido"],
+        observacao: null,
+        itens: [null, "quebrado", { materialId: 301, saldoDisponivel: "12" }],
+      }),
+    );
+    window.sessionStorage.setItem(
+      "wms-saep:recent-materials:v1:user:10",
+      JSON.stringify([null, "quebrado", { id: 301, nome: "Sem codigo" }]),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+        if (notificationsResponse) return notificationsResponse;
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    expect(screen.getByText("Rascunho local recuperado")).toBeInTheDocument();
+    expect(screen.getByText("Selecionado:")).toBeInTheDocument();
+    expect(screen.queryByText("Sem codigo")).not.toBeInTheDocument();
   });
 
   it("renders notifications counter and collective badge in app shell", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -2531,6 +2531,57 @@ describe("frontend pilot router", () => {
     expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:new")).toContain("2,5");
   });
 
+  it("preserves the current wizard step after the first draft save", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return requisitionDetailResponse();
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { container } = renderRoute("/requisicoes/nova?etapa=itens");
+
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    await waitFor(() => {
+      expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
+      expect(container.ownerDocument.location.search).toBe("?etapa=itens");
+    });
+    expect(createdPayload).toEqual({
+      beneficiario_id: 10,
+      observacao: "",
+      itens: [
+        {
+          material_id: 301,
+          quantidade_solicitada: "1",
+          observacao: "",
+        },
+      ],
+    });
+  });
+
   it("recovers a local draft snapshot and can discard that copy", async () => {
     window.sessionStorage.setItem(
       "wms-saep:draft:v1:user:10:new",
@@ -2681,6 +2732,67 @@ describe("frontend pilot router", () => {
       expect(screen.getAllByText("Informe beneficiário.").length).toBeGreaterThan(0);
     });
     expect(createdPayload).toBeUndefined();
+  });
+
+  it("clears stale global validation banners after beneficiary and item corrections", async () => {
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse(authSession("auxiliar_setor"));
+      }
+
+      if (requestUrl(request).includes("/api/v1/users/beneficiary-lookup/")) {
+        return beneficiaryLookupResponse();
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
+        return materialListResponse();
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Para terceiro"));
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    expect((await screen.findAllByText("Informe beneficiário.")).length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByLabelText("Para mim"));
+    await waitFor(() => {
+      expect(screen.queryByText("Informe beneficiário.")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText("Para terceiro"));
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+    expect((await screen.findAllByText("Informe beneficiário.")).length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText("Buscar beneficiário"), {
+      target: { value: "benef" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: /Beneficiario Terceiro/ }));
+    await waitFor(() => {
+      expect(screen.queryByText("Informe beneficiário.")).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    expect((await screen.findAllByText("Adicione ao menos um item.")).length).toBeGreaterThan(0);
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    await waitFor(() => {
+      expect(screen.queryByText("Adicione ao menos um item.")).not.toBeInTheDocument();
+    });
   });
 
   it("updates an existing draft with full replacement payload", async () => {

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -2356,6 +2356,7 @@ describe("frontend pilot router", () => {
     await waitFor(() => {
       expect(container.ownerDocument.location.pathname).toBe("/requisicoes/101");
     });
+    expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:new")).toBeNull();
     expect(createdPayload).toEqual({
       beneficiario_id: 10,
       observacao: "",
@@ -2735,7 +2736,7 @@ describe("frontend pilot router", () => {
   });
 
   it("clears stale global validation banners after beneficiary and item corrections", async () => {
-    const fetchMock = vi.fn(async (request: Request) => {
+    const fetchMock = vi.fn((request: Request) => {
       if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
         return sessionResponse(authSession("auxiliar_setor"));
       }

--- a/frontend/src/tests/router-smoke.test.tsx
+++ b/frontend/src/tests/router-smoke.test.tsx
@@ -21,6 +21,7 @@ function renderRoute(pathname: string) {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  window.sessionStorage.clear();
 });
 
 const jsonHeaders = { "Content-Type": "application/json" };
@@ -2341,6 +2342,8 @@ describe("frontend pilot router", () => {
     const { container } = renderRoute("/requisicoes/nova");
 
     expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Buscar material"), {
       target: { value: "papel" },
     });
@@ -2363,6 +2366,71 @@ describe("frontend pilot router", () => {
           observacao: "",
         },
       ],
+    });
+  });
+
+  it("navigates draft wizard steps without losing selected data", async () => {
+    let createdPayload: unknown;
+    const fetchMock = vi.fn(async (request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        createdPayload = await request.json();
+        return draftRequisitionDetailResponse();
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova?etapa=beneficiario");
+
+    expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Beneficiário" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
+      target: { value: "1,5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: revisão" }));
+
+    expect(await screen.findByRole("heading", { name: "Revisão" })).toBeInTheDocument();
+    expect(screen.getAllByText("Usuario Piloto (91003)").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("010.001.001 - Papel sulfite A4").length).toBeGreaterThan(0);
+    expect(screen.getByText("1,5 UN")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: envio" }));
+
+    expect(await screen.findByRole("heading", { name: "Envio" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    await waitFor(() => {
+      expect(createdPayload).toEqual({
+        beneficiario_id: 10,
+        observacao: "",
+        itens: [
+          {
+            material_id: 301,
+            quantidade_solicitada: "1.5",
+            observacao: "",
+          },
+        ],
+      });
     });
   });
 
@@ -2394,6 +2462,8 @@ describe("frontend pilot router", () => {
     renderRoute("/requisicoes/nova");
 
     expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Buscar material"), {
       target: { value: "papel" },
     });
@@ -2409,6 +2479,103 @@ describe("frontend pilot router", () => {
       ),
     ).toBeInTheDocument();
     expect(createdPayload).toBeUndefined();
+  });
+
+  it("keeps failed draft save visible and recoverable from session storage", async () => {
+    const fetchMock = vi.fn((request: Request) => {
+      if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+        return sessionResponse();
+      }
+
+      if (
+        requestUrl(request).includes("/api/v1/materials/") &&
+        requestSearchParam(request, "search") === "papel"
+      ) {
+        return materialListResponse();
+      }
+
+      if (requestUrl(request).endsWith("/api/v1/requisitions/") && request.method === "POST") {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "network_error",
+              message: "Falha temporária de conexão.",
+              details: {},
+              trace_id: null,
+            },
+          }),
+          { status: 503, headers: jsonHeaders },
+        );
+      }
+
+      const notificationsResponse = maybeNotificationsRequest(request);
+      if (notificationsResponse) return notificationsResponse;
+      throw new Error(`Unexpected request: ${requestUrl(request)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderRoute("/requisicoes/nova?etapa=itens");
+
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("Buscar material"), {
+      target: { value: "papel" },
+    });
+    fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.change(screen.getByLabelText("Quantidade solicitada"), {
+      target: { value: "2,5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
+
+    expect(await screen.findByText("Falha temporária de conexão.")).toBeInTheDocument();
+    expect(screen.getByLabelText("Quantidade solicitada")).toHaveValue("2,5");
+    expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:new")).toContain("2,5");
+  });
+
+  it("recovers a local draft snapshot and can discard that copy", async () => {
+    window.sessionStorage.setItem(
+      "wms-saep:draft:v1:user:10:new",
+      JSON.stringify({
+        beneficiaryMode: "self",
+        beneficiaryId: "10",
+        beneficiaryLabel: "Usuario Piloto (91003)",
+        beneficiarySearch: "",
+        materialSearch: "",
+        observacao: "Recuperada localmente",
+        itens: [
+          {
+            materialId: "301",
+            materialLabel: "010.001.001 - Papel sulfite A4",
+            materialCode: "010.001.001",
+            unidadeMedida: "UN",
+            saldoDisponivel: 12,
+            quantidadeSolicitada: "4,5",
+            observacao: "Item local",
+          },
+        ],
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+        if (notificationsResponse) return notificationsResponse;
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/nova?etapa=revisao");
+
+    expect(await screen.findByText("Rascunho local recuperado")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Recuperada localmente")).toBeInTheDocument();
+    expect(screen.getByText("4,5 UN")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Descartar cópia local" }));
+
+    expect(screen.queryByText("Rascunho local recuperado")).not.toBeInTheDocument();
+    expect(window.sessionStorage.getItem("wms-saep:draft:v1:user:10:new")).toBeNull();
   });
 
   it("creates draft requisition for a third-party beneficiary when allowed", async () => {
@@ -2448,6 +2615,8 @@ describe("frontend pilot router", () => {
       target: { value: "Beneficiario" },
     });
     fireEvent.click(await screen.findByRole("button", { name: /Beneficiario Terceiro/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Buscar material"), {
       target: { value: "papel" },
     });
@@ -2497,14 +2666,20 @@ describe("frontend pilot router", () => {
     renderRoute("/requisicoes/nova");
 
     expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Buscar material"), {
       target: { value: "papel" },
     });
     fireEvent.click(await screen.findByRole("button", { name: "Adicionar Papel sulfite A4" }));
+    fireEvent.click(screen.getByRole("button", { name: "Voltar etapa" }));
+    expect(await screen.findByRole("heading", { name: "Beneficiário" })).toBeInTheDocument();
     fireEvent.click(screen.getByLabelText("Para terceiro"));
     fireEvent.click(screen.getByRole("button", { name: "Salvar rascunho" }));
 
-    expect(await screen.findByText("Informe beneficiário.")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getAllByText("Informe beneficiário.").length).toBeGreaterThan(0);
+    });
     expect(createdPayload).toBeUndefined();
   });
 
@@ -2537,9 +2712,10 @@ describe("frontend pilot router", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    const { container } = renderRoute("/requisicoes/101");
+    const { container } = renderRoute("/requisicoes/101?etapa=itens");
 
     expect(await screen.findByRole("heading", { name: "Editar rascunho" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Itens" })).toBeInTheDocument();
     expect(screen.getByLabelText("Quantidade solicitada")).toHaveValue("2");
     expect(screen.queryByText(/Saldo não exibido/)).not.toBeInTheDocument();
     expect(await screen.findByText("Saldo 12 UN")).toBeInTheDocument();
@@ -2732,6 +2908,8 @@ describe("frontend pilot router", () => {
     renderRoute("/requisicoes/nova");
 
     expect(await screen.findByRole("heading", { name: "Nova requisição" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Próximo: itens" }));
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
     fireEvent.change(screen.getByLabelText("Buscar material"), {
       target: { value: "caneta" },
     });
@@ -2739,7 +2917,50 @@ describe("frontend pilot router", () => {
     const addButton = await screen.findByRole("button", { name: "Adicionar Caneta sem estoque" });
     expect(addButton).toBeDisabled();
     expect(screen.getByText(/saldo 0 UN/i)).toBeInTheDocument();
-    expect(screen.getByText("Nenhum material adicionado.")).toBeInTheDocument();
+    expect(screen.getAllByText("Nenhum material adicionado.").length).toBeGreaterThan(0);
+  });
+
+  it("shows recent materials only when local data has enough entries", async () => {
+    window.sessionStorage.setItem(
+      "wms-saep:recent-materials:v1:user:10",
+      JSON.stringify([
+        {
+          id: 301,
+          codigo_completo: "010.001.001",
+          nome: "Papel sulfite A4",
+          descricao: "Pacote com 500 folhas",
+          unidade_medida: "UN",
+          saldo_disponivel: 12,
+        },
+        {
+          id: 302,
+          codigo_completo: "010.001.002",
+          nome: "Caneta azul",
+          descricao: "Caneta esferográfica",
+          unidade_medida: "UN",
+          saldo_disponivel: 8,
+        },
+      ]),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((request: Request) => {
+        if (requestUrl(request).endsWith("/api/v1/auth/me/")) {
+          return sessionResponse();
+        }
+
+        const notificationsResponse = maybeNotificationsRequest(request);
+        if (notificationsResponse) return notificationsResponse;
+        throw new Error(`Unexpected request: ${requestUrl(request)}`);
+      }),
+    );
+
+    renderRoute("/requisicoes/nova?etapa=itens");
+
+    expect(await screen.findByRole("heading", { name: "Itens" })).toBeInTheDocument();
+    expect(screen.getByText("Materiais recentes")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Adicionar Papel sulfite A4" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Adicionar Caneta azul" })).toBeInTheDocument();
   });
 
   it("renders notifications counter and collective badge in app shell", async () => {

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -84,6 +84,8 @@ test("creates draft and submits to authorization using seed scenario", async ({ 
   await page.getByLabel("Para terceiro").click();
   await page.getByLabel("Buscar beneficiário").fill("Ped");
   await page.getByRole("button", { name: /Pedro Nunes/i }).click();
+  await page.getByRole("button", { name: "Próximo: itens" }).click();
+  await expect(page.getByRole("heading", { name: "Itens", exact: true })).toBeVisible();
 
   await page.getByLabel("Buscar material").fill("Papel sulfite");
   await page.getByRole("button", { name: /Adicionar Papel sulfite A4/i }).click();
@@ -98,6 +100,20 @@ test("creates draft and submits to authorization using seed scenario", async ({ 
 
   await expect(page.getByRole("heading", { name: /REQ-\d{4}-\d+/ })).toBeVisible();
   await expect(page.getByText("Aguardando autorização")).toBeVisible();
+});
+
+test("draft wizard fits mobile viewport with sticky actions", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await loginAs(page, "91002", /\/minhas-requisicoes(?:\?.*)?$/);
+
+  await page.goto("/requisicoes/nova?etapa=beneficiario");
+  await expect(page.getByRole("heading", { name: "Nova requisição" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Próximo: itens" })).toBeVisible();
+
+  const hasHorizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > document.documentElement.clientWidth,
+  );
+  expect(hasHorizontalOverflow).toBe(false);
 });
 
 test("authorizes pending requisition from worklist", async ({ page }) => {

--- a/frontend/tests/e2e/shell.spec.ts
+++ b/frontend/tests/e2e/shell.spec.ts
@@ -92,7 +92,7 @@ test("creates draft and submits to authorization using seed scenario", async ({ 
   await page.getByLabel("Quantidade solicitada").fill("2");
 
   await page.getByRole("button", { name: "Salvar rascunho" }).click();
-  await expect(page).toHaveURL(/\/requisicoes\/\d+$/);
+  await expect(page).toHaveURL(/\/requisicoes\/\d+\?etapa=itens$/);
   await expect(page.getByRole("heading", { name: "Editar rascunho" })).toBeVisible();
 
   await page.getByRole("button", { name: "Enviar para autorização" }).click();


### PR DESCRIPTION
<!--
⚠️ Este template é complementado automaticamente pelo CodeRabbit.

Um sumário estruturado do PR será gerado abaixo desta descrição,
conforme definido em `.coderabbit.yaml` (high_level_summary).

➡️ Foque em registrar intenção, risco e forma de validação.
➡️ O CodeRabbit fará a síntese técnica complementar.
-->
# Contexto

## O que este PR faz
- Transforma o editor de rascunho em um wizard com etapas de beneficiário, itens, revisão e envio.
- Adiciona recuperação local de rascunho e materiais recentes por sessão, sem bloquear o fluxo se o storage falhar.
- Mantém a navegação entre etapas via query param e preserva o estado ao voltar/avançar.
- Atualiza testes de smoke e o fluxo E2E para cobrir o wizard novo.

## Por que esta mudança é necessária
- A criação e edição de rascunho precisa ficar navegável e resiliente no piloto, especialmente em telas menores e em sessões interrompidas.

---

# Checklist de impacto

Marque apenas o que se aplica:

- [x] altera regra de negócio
- [ ] altera permissão, perfil ou escopo por setor
- [ ] altera model, migration, constraint ou integridade de dados
- [ ] altera transação, concorrência, idempotência ou consistência de saldo/estoque
- [ ] altera máquina de estados, aprovação, cotas, override ou entregas
- [ ] altera configuração, CI ou dependências
- [ ] não há impacto relevante além do comportamento descrito acima

## Risco principal
- O wizard pode perder estado entre etapas ou reapresentar snapshot local errado, afetando a integridade da requisição em rascunho.

## Impactos adicionais (somente se houver)

- permissões / perfil / setor:
- dados / migration / constraints:
- transação / concorrência / idempotência:
- máquina de estados / aprovação / cotas / entregas:
- configuração / CI / dependências:

---

# Testes e validação

## Cenários validados
1. `git diff --check` passou.
2. `rtk make frontend-lint` passou.
3. Smoke tests e E2E cobrem avanço entre etapas, persistência local e recuperação de rascunho.

## Como validar manualmente
- Abrir `/requisicoes/nova` e avançar pelas etapas do wizard.
- Recarregar a página e confirmar recuperação do snapshot local, quando existir.
- Salvar/descartar rascunho e verificar se o fluxo retorna ao estado esperado.

## Payloads / exemplos de uso
Opcional — inclua apenas se ajudar na validação.

```json
{}
```

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Resumo do PR #73 - Frontend: Wizard de Rascunho

- Objetivo
  - Transformar o editor de rascunho em um wizard por etapas (beneficiário → itens → revisão → envio), persistir snapshots locais em sessionStorage para recuperação (best-effort), armazenar "materiais recentes" por sessão e sincronizar etapa via query param `?etapa`. Inclusão de props controladas (`activeStep`, `onStepChange`) e preservação de etapa ao navegar/criar requisição.

- Escopo das mudanças
  - Frontend somente: refatoração extensa de `DraftRequisitionEditor.tsx` (stepper, validação por etapa, grava/recupera snapshot, banner de rascunho recuperado, recent materials), novo `draftSteps.ts`, rotas `/requisicoes/nova` e `/requisicoes/{id}` aceitando `etapa`, CSS para stepper/banner, e atualização/adição de testes smoke/E2E/Playwright. Commit adicional: "fix(frontend): harden draft storage recovery" (resiliência do storage).

- Apps Django impactados
  - Nenhum — não há mudanças em backend, models, serializers, endpoints, OpenAPI ou contratos DRF.

- Risco funcional
  - Baixo–Médio:
    - Perda de estado entre etapas ou aplicação de snapshot local incorreto pode corromper o payload do rascunho.
    - Dependência de sessionStorage (efêmero); falhas no storage são tratadas como best-effort, mas podem degradar UX.
    - Sincronização URL ↔ estado (param `etapa`) precisa estar correta para evitar inconsistências de navegação/estado.

- Impacto em regras de negócio
  - Nenhuma mudança de regra no backend. Validações por etapa são client-side; risco de divergência entre validação frontend e validação server-side — confirmar que regras críticas continuam no servidor.

- Autenticação / autorização / escopo por perfil e setor
  - Sem alteração nos controles de backend. Observação: seleção de "self" e carregamento de identidade são decisões no cliente — não confiar em autorização sensível apenas no frontend.

- Contratos DRF, serializers, paginação, filtros, envelope de erro e OpenAPI
  - Sem alterações — frontend reutiliza endpoints existentes; nenhum contrato público foi modificado.

- Integridade de dados, constraints, snapshots históricos, auditoria e rastreabilidade
  - Snapshots armazenados apenas em sessionStorage (UI) — não há persistência server-side nem alteração de históricos/auditoria.
  - Risco operacional: aplicação incorreta do snapshot ao enviar pode introduzir mudanças inesperadas no servidor — validar payloads antes de salvar/enviar.

- Transações, concorrência, idempotência, saldos (físico/reservado/disponível)
  - Sem impacto direto no backend: nada altera lógica de transações, reservas ou cálculos de saldo no servidor. Risco UX: dados de rascunho inconsistentes poderiam levar a submissões que geram erros de saldo no servidor, mas responsabilidade pela consistência permanece no backend.

- Importação SCPI / dados oficiais de materiais / divergência de estoque
  - Sem impacto: APIs de materiais mantidas. Atenção ao cache local de "materiais recentes" que pode ficar desatualizado, mas não altera dados oficiais.

- Configuração, CI, dependências, lint, testes e ambiente efêmero
  - Lint passou; testes atualizados/expandidos: smoke tests e E2E (Playwright) cobrindo navegação entre etapas, persistência/recuperação de snapshot e mobile. Nenhuma mudança detectada em dependências ou CI.

- Como validar manualmente
  - UI:
    1. Abrir /requisicoes/nova → avançar por Beneficiário → Itens → Revisão → Envio.
    2. Recarregar em qualquer etapa e confirmar que `?etapa=<etapa>` preserva a etapa; validar banner de “rascunho local recuperado” quando aplicável.
    3. Simular falha ao salvar (ex.: forçar 503) → confirmar erro visível, formulário preserva quantidades e grava snapshot recuperável em sessionStorage.
    4. Recuperar rascunho local → testar “Descartar cópia local” e verificar limpeza da chave em sessionStorage e reset do formulário.
    5. Salvar com sucesso → confirmar sessionStorage limpo e navegação para recurso criado/atualizado; checar que `?etapa` é preservado.
    6. Mobile: abrir /requisicoes/nova?etapa=beneficiario em viewport móvel → conferir layout sem overflow e presença do botão “Próximo: itens”.
  - Automação / revisão de código:
    - Executar/inspecionar os testes smoke/E2E atualizados (incluem avanço de etapas, persistência/recuperação e cobertura mobile).
  - Inspeção rápida:
    - Verificar sessionStorage (chaves de rascunho e `wms-saep:recent-materials`) para confirmar gravação/limpeza conforme fluxos.

- Pontos prioritários para revisão de código
  - Onde o snapshot local é mesclado ao payload enviado — garantir não sobrescrever dados sensíveis/consistentes.
  - Consistência entre validação client-side por etapa e validação server-side.
  - Fluxos multi-aba/sessões e recovery pós-falha de rede (evitar reprocessamento indevido).
  - Qualquer lógica de autorização/identidade implementada apenas no cliente.
  - Cobertura de testes para casos de erro no storage e caminhos de discard/cancel em rascunhos numerados e não numerados.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/73)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->