### PR TITLE
refactor(notifications): RequisicaoEvent enum + entrypoint único notificar()

### DIFF
--- a/apps/core/events.py
+++ b/apps/core/events.py
@@ -28,31 +28,36 @@ def _subscribe_single(event_name: str, handler: EventHandler) -> None:
         handlers.append(handler)
 
 
+def _register(event_name_or_enum, handler) -> None:
+    if isinstance(event_name_or_enum, type) and issubclass(event_name_or_enum, str):
+        for event in event_name_or_enum:
+            _event = event
+
+            def _wrapper(payload, e=_event, f=handler):
+                f(e, **payload)
+
+            _subscribe_single(str(_event), _wrapper)
+    else:
+        _subscribe_single(str(event_name_or_enum), handler)
+
+
 def subscribe(event_name_or_enum, handler: EventHandler | None = None):
     """Register handler for an event.
 
     Two forms:
-      subscribe("event.name", handler_fn)         — direct registration
-      @subscribe(SomeStrEnumClass)                 — decorator; registers for all enum
-                                                     values, calling handler(event, **payload)
+      subscribe("event.name", handler_fn)         — direct, single event
+      subscribe(SomeStrEnumClass, handler_fn)      — direct, all enum values
+      @subscribe(SomeStrEnumClass)                 — decorator, all enum values
+    When an Enum class is used, handler is called as handler(event, **payload).
     """
     if handler is not None:
-        _subscribe_single(str(event_name_or_enum), handler)
+        _register(event_name_or_enum, handler)
         return
 
     target = event_name_or_enum
 
     def decorator(fn):
-        if isinstance(target, type) and issubclass(target, str):
-            for event in target:
-                _event = event
-
-                def _wrapper(payload, e=_event, f=fn):
-                    f(e, **payload)
-
-                _subscribe_single(str(_event), _wrapper)
-        else:
-            _subscribe_single(str(target), fn)
+        _register(target, fn)
         return fn
 
     return decorator

--- a/apps/core/events.py
+++ b/apps/core/events.py
@@ -22,10 +22,40 @@ EventHandler = Callable[[EventPayload], None]
 _subscribers: dict[str, list[EventHandler]] = defaultdict(list)
 
 
-def subscribe(event_name: str, handler: EventHandler) -> None:
+def _subscribe_single(event_name: str, handler: EventHandler) -> None:
     handlers = _subscribers[event_name]
     if handler not in handlers:
         handlers.append(handler)
+
+
+def subscribe(event_name_or_enum, handler: EventHandler | None = None):
+    """Register handler for an event.
+
+    Two forms:
+      subscribe("event.name", handler_fn)         — direct registration
+      @subscribe(SomeStrEnumClass)                 — decorator; registers for all enum
+                                                     values, calling handler(event, **payload)
+    """
+    if handler is not None:
+        _subscribe_single(str(event_name_or_enum), handler)
+        return
+
+    target = event_name_or_enum
+
+    def decorator(fn):
+        if isinstance(target, type) and issubclass(target, str):
+            for event in target:
+                _event = event
+
+                def _wrapper(payload, e=_event, f=fn):
+                    f(e, **payload)
+
+                _subscribe_single(str(_event), _wrapper)
+        else:
+            _subscribe_single(str(target), fn)
+        return fn
+
+    return decorator
 
 
 def clear_subscribers() -> None:

--- a/apps/notifications/handlers.py
+++ b/apps/notifications/handlers.py
@@ -1,110 +1,10 @@
-from apps.core.events import (
-    PUSH_LEMBRETE_AUTORIZACOES_ATRASADAS,
-    REQUISICAO_AUTORIZADA,
-    REQUISICAO_CANCELADA,
-    REQUISICAO_ENVIADA_AUTORIZACAO,
-    REQUISICAO_PRONTA_PARA_RETIRADA,
-    REQUISICAO_RECUSADA,
-    REQUISICAO_RETIRADA,
-    subscribe,
-)
-from apps.notifications.models import TipoNotificacao
-from apps.notifications.services import (
-    criar_notificacao_papel,
-    criar_notificacoes_usuarios_unicos,
-    enviar_push_payload_usuario,
-    enviar_push_requisicao_aguardando_autorizacao,
-)
-from apps.requisitions.models import Requisicao
-from apps.users.models import PapelChoices
+from apps.core.events import PUSH_LEMBRETE_AUTORIZACOES_ATRASADAS, subscribe
+from apps.notifications.services import enviar_push_payload_usuario, notificar
+from apps.requisitions.events import RequisicaoEvent
 
 
-def _carregar_requisicao(requisicao_id: int) -> Requisicao:
-    return Requisicao.objects.select_related(
-        "criador",
-        "beneficiario",
-        "setor_beneficiario__chefe_responsavel",
-    ).get(pk=requisicao_id)
-
-
-def _identificador(requisicao: Requisicao) -> str:
-    return requisicao.numero_publico or f"#{requisicao.pk}"
-
-
-def _notificar_envio_autorizacao(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    chefe = requisicao.setor_beneficiario.chefe_responsavel
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[chefe],
-        tipo=TipoNotificacao.REQUISICAO_ENVIADA_AUTORIZACAO,
-        titulo="Requisição aguardando autorização",
-        mensagem=f"A requisição {_identificador(requisicao)} aguarda autorização.",
-        objeto_relacionado=requisicao,
-    )
-    enviar_push_requisicao_aguardando_autorizacao(requisicao=requisicao)
-
-
-def _notificar_autorizacao(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[requisicao.criador, requisicao.beneficiario],
-        tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
-        titulo="Requisição autorizada",
-        mensagem=f"A requisição {_identificador(requisicao)} foi autorizada.",
-        objeto_relacionado=requisicao,
-    )
-    for papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
-        criar_notificacao_papel(
-            papel_destinatario=papel,
-            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
-            titulo="Requisição autorizada para atendimento",
-            mensagem=f"A requisição {_identificador(requisicao)} está pronta para atendimento.",
-            objeto_relacionado=requisicao,
-        )
-
-
-def _notificar_recusa(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[requisicao.criador, requisicao.beneficiario],
-        tipo=TipoNotificacao.REQUISICAO_RECUSADA,
-        titulo="Requisição recusada",
-        mensagem=f"A requisição {_identificador(requisicao)} foi recusada.",
-        objeto_relacionado=requisicao,
-    )
-
-
-def _notificar_cancelamento(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[requisicao.criador, requisicao.beneficiario],
-        tipo=TipoNotificacao.REQUISICAO_CANCELADA,
-        titulo="Requisição cancelada",
-        mensagem=f"A requisição {_identificador(requisicao)} foi cancelada.",
-        objeto_relacionado=requisicao,
-    )
-
-
-def _notificar_pronta_para_retirada(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[requisicao.criador, requisicao.beneficiario],
-        tipo=TipoNotificacao.REQUISICAO_PRONTA_PARA_RETIRADA,
-        titulo="Requisição pronta para retirada",
-        mensagem=f"A requisição {_identificador(requisicao)} está pronta para retirada no almoxarifado.",
-        objeto_relacionado=requisicao,
-    )
-
-
-def _notificar_retirada(payload: dict[str, object]) -> None:
-    requisicao = _carregar_requisicao(payload["requisicao_id"])
-    criar_notificacoes_usuarios_unicos(
-        destinatarios=[requisicao.criador, requisicao.beneficiario],
-        tipo=TipoNotificacao.REQUISICAO_RETIRADA,
-        titulo="Requisição retirada",
-        mensagem=f"A requisição {_identificador(requisicao)} foi retirada.",
-        objeto_relacionado=requisicao,
-    )
+def handle_requisicao_event(event: RequisicaoEvent, requisicao_id: int, actor_id: int) -> None:
+    notificar(event, requisicao_id, actor_id)
 
 
 def _enviar_lembrete_autorizacoes_atrasadas(payload: dict[str, object]) -> None:
@@ -116,10 +16,5 @@ def _enviar_lembrete_autorizacoes_atrasadas(payload: dict[str, object]) -> None:
 
 
 def register_event_handlers() -> None:
-    subscribe(REQUISICAO_ENVIADA_AUTORIZACAO, _notificar_envio_autorizacao)
-    subscribe(REQUISICAO_AUTORIZADA, _notificar_autorizacao)
-    subscribe(REQUISICAO_RECUSADA, _notificar_recusa)
-    subscribe(REQUISICAO_CANCELADA, _notificar_cancelamento)
-    subscribe(REQUISICAO_PRONTA_PARA_RETIRADA, _notificar_pronta_para_retirada)
-    subscribe(REQUISICAO_RETIRADA, _notificar_retirada)
+    subscribe(RequisicaoEvent, handle_requisicao_event)
     subscribe(PUSH_LEMBRETE_AUTORIZACOES_ATRASADAS, _enviar_lembrete_autorizacoes_atrasadas)

--- a/apps/notifications/services.py
+++ b/apps/notifications/services.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections.abc import Iterable
 from datetime import timedelta
 
@@ -23,6 +24,8 @@ from apps.notifications.models import (
 from apps.notifications.policies import pode_gerenciar_push_subscription
 from apps.requisitions.models import Requisicao, StatusRequisicao
 from apps.users.models import PapelChoices, User
+
+logger = logging.getLogger(__name__)
 
 PUSH_REMINDER_COOLDOWN = timedelta(hours=4)
 PUSH_REMINDER_OVERDUE_AFTER = timedelta(hours=4)
@@ -401,3 +404,104 @@ def enviar_push_lembretes_autorizacoes_atrasadas(*, now=None) -> int:
             )
 
     return sent_to_users
+
+
+def _req_identificador(requisicao: Requisicao) -> str:
+    return requisicao.numero_publico or f"#{requisicao.pk}"
+
+
+def _carregar_requisicao_para_notificacao(requisicao_id: int) -> Requisicao:
+    return Requisicao.objects.select_related(
+        "criador",
+        "beneficiario",
+        "setor_beneficiario__chefe_responsavel",
+    ).get(pk=requisicao_id)
+
+
+def _notif_enviada(requisicao: Requisicao) -> None:
+    chefe = requisicao.setor_beneficiario.chefe_responsavel
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[chefe],
+        tipo=TipoNotificacao.REQUISICAO_ENVIADA_AUTORIZACAO,
+        titulo="Requisição aguardando autorização",
+        mensagem=f"A requisição {_req_identificador(requisicao)} aguarda autorização.",
+        objeto_relacionado=requisicao,
+    )
+    enviar_push_requisicao_aguardando_autorizacao(requisicao=requisicao)
+
+
+def _notif_autorizada(requisicao: Requisicao) -> None:
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[requisicao.criador, requisicao.beneficiario],
+        tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+        titulo="Requisição autorizada",
+        mensagem=f"A requisição {_req_identificador(requisicao)} foi autorizada.",
+        objeto_relacionado=requisicao,
+    )
+    for papel in (PapelChoices.AUXILIAR_ALMOXARIFADO, PapelChoices.CHEFE_ALMOXARIFADO):
+        criar_notificacao_papel(
+            papel_destinatario=papel,
+            tipo=TipoNotificacao.REQUISICAO_AUTORIZADA,
+            titulo="Requisição autorizada para atendimento",
+            mensagem=f"A requisição {_req_identificador(requisicao)} está pronta para atendimento.",
+            objeto_relacionado=requisicao,
+        )
+
+
+def _notif_recusada(requisicao: Requisicao) -> None:
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[requisicao.criador, requisicao.beneficiario],
+        tipo=TipoNotificacao.REQUISICAO_RECUSADA,
+        titulo="Requisição recusada",
+        mensagem=f"A requisição {_req_identificador(requisicao)} foi recusada.",
+        objeto_relacionado=requisicao,
+    )
+
+
+def _notif_atendida(requisicao: Requisicao) -> None:
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[requisicao.criador, requisicao.beneficiario],
+        tipo=TipoNotificacao.REQUISICAO_PRONTA_PARA_RETIRADA,
+        titulo="Requisição pronta para retirada",
+        mensagem=f"A requisição {_req_identificador(requisicao)} está pronta para retirada no almoxarifado.",
+        objeto_relacionado=requisicao,
+    )
+
+
+def _notif_atendida_parcialmente(requisicao: Requisicao) -> None:
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[requisicao.criador, requisicao.beneficiario],
+        tipo=TipoNotificacao.REQUISICAO_PRONTA_PARA_RETIRADA,
+        titulo="Requisição parcialmente atendida",
+        mensagem=f"A requisição {_req_identificador(requisicao)} foi parcialmente atendida e está pronta para retirada.",
+        objeto_relacionado=requisicao,
+    )
+
+
+def _notif_cancelada(requisicao: Requisicao) -> None:
+    criar_notificacoes_usuarios_unicos(
+        destinatarios=[requisicao.criador, requisicao.beneficiario],
+        tipo=TipoNotificacao.REQUISICAO_CANCELADA,
+        titulo="Requisição cancelada",
+        mensagem=f"A requisição {_req_identificador(requisicao)} foi cancelada.",
+        objeto_relacionado=requisicao,
+    )
+
+
+def notificar(event, requisicao_id: int, actor_id: int) -> None:  # noqa: ARG001
+    from apps.requisitions.events import RequisicaoEvent
+
+    _routing = {
+        RequisicaoEvent.ENVIADA: _notif_enviada,
+        RequisicaoEvent.AUTORIZADA: _notif_autorizada,
+        RequisicaoEvent.RECUSADA: _notif_recusada,
+        RequisicaoEvent.ATENDIDA: _notif_atendida,
+        RequisicaoEvent.ATENDIDA_PARCIALMENTE: _notif_atendida_parcialmente,
+        RequisicaoEvent.CANCELADA: _notif_cancelada,
+    }
+    handler = _routing.get(event)
+    if handler is None:
+        logger.warning("notificar: evento sem handler na routing table: %s", event)
+        return
+    requisicao = _carregar_requisicao_para_notificacao(requisicao_id)
+    handler(requisicao)

--- a/apps/requisitions/domain/state_machine.py
+++ b/apps/requisitions/domain/state_machine.py
@@ -1,15 +1,8 @@
 from django.db import connection, transaction
 
 from apps.core.api.exceptions import DomainConflict
-from apps.core.events import (
-    REQUISICAO_AUTORIZADA,
-    REQUISICAO_CANCELADA,
-    REQUISICAO_ENVIADA_AUTORIZACAO,
-    REQUISICAO_PRONTA_PARA_RETIRADA,
-    REQUISICAO_RECUSADA,
-    REQUISICAO_RETIRADA,
-    publish_on_commit,
-)
+from apps.core.events import publish_on_commit
+from apps.requisitions.events import RequisicaoEvent
 from apps.requisitions.models import EventoTimeline, Requisicao, StatusRequisicao, TipoEvento
 
 TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
@@ -23,7 +16,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_AUTORIZADA,
+        "notification_event": RequisicaoEvent.AUTORIZADA,
     },
     "autorizar_parcial": {
         "from_status": (StatusRequisicao.AGUARDANDO_AUTORIZACAO,),
@@ -35,7 +28,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_AUTORIZADA,
+        "notification_event": RequisicaoEvent.AUTORIZADA,
     },
     "recusar": {
         "from_status": (StatusRequisicao.AGUARDANDO_AUTORIZACAO,),
@@ -48,7 +41,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_RECUSADA,
+        "notification_event": RequisicaoEvent.RECUSADA,
     },
     "atender_total": {
         "from_status": (StatusRequisicao.AUTORIZADA,),
@@ -61,7 +54,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_PRONTA_PARA_RETIRADA,
+        "notification_event": RequisicaoEvent.ATENDIDA,
     },
     "atender_parcial": {
         "from_status": (StatusRequisicao.AUTORIZADA,),
@@ -74,7 +67,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_PRONTA_PARA_RETIRADA,
+        "notification_event": RequisicaoEvent.ATENDIDA_PARCIALMENTE,
     },
     "retirar": {
         "from_status": (
@@ -89,7 +82,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_RETIRADA,
+        "notification_event": None,
     },
     "cancelar_pos_autorizacao_sem_saldo": {
         "from_status": (StatusRequisicao.AUTORIZADA,),
@@ -102,7 +95,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_CANCELADA,
+        "notification_event": RequisicaoEvent.CANCELADA,
     },
     "cancelar_pre_autorizacao": {
         "from_status": (
@@ -116,7 +109,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
             "status",
         ),
         "side_effects": (),
-        "notification_event": REQUISICAO_CANCELADA,
+        "notification_event": RequisicaoEvent.CANCELADA,
     },
     "enviar_para_autorizacao": {
         "from_status": (StatusRequisicao.RASCUNHO,),
@@ -124,7 +117,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
         "timeline_event_type": TipoEvento.ENVIO_AUTORIZACAO,
         "audit_fields_to_set": ("numero_publico", "data_envio_autorizacao", "status"),
         "side_effects": (),
-        "notification_event": REQUISICAO_ENVIADA_AUTORIZACAO,
+        "notification_event": RequisicaoEvent.ENVIADA,
     },
     "reenviar_para_autorizacao": {
         "from_status": (StatusRequisicao.RASCUNHO,),
@@ -132,7 +125,7 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
         "timeline_event_type": TipoEvento.REENVIO_AUTORIZACAO,
         "audit_fields_to_set": ("status",),
         "side_effects": (),
-        "notification_event": REQUISICAO_ENVIADA_AUTORIZACAO,
+        "notification_event": RequisicaoEvent.ENVIADA,
     },
     "retornar_para_rascunho": {
         "from_status": (StatusRequisicao.AGUARDANDO_AUTORIZACAO,),
@@ -145,13 +138,13 @@ TRANSICOES_REQUISICAO: dict[str, dict[str, object]] = {
 }
 
 
-def _publish_notification(event_name: str, requisicao: Requisicao) -> None:
+def _publish_notification(event: RequisicaoEvent, requisicao: Requisicao, actor) -> None:
     if not transaction.get_connection().in_atomic_block:
         raise DomainConflict(
             "Publicação de notificação de requisição exige transação ativa.",
-            details={"requisicao_id": requisicao.pk, "event_name": event_name},
+            details={"requisicao_id": requisicao.pk, "event": event},
         )
-    publish_on_commit(event_name, {"requisicao_id": requisicao.pk})
+    publish_on_commit(event, {"requisicao_id": requisicao.pk, "actor_id": actor.pk})
 
 
 def apply_transition(
@@ -198,6 +191,6 @@ def apply_transition(
 
     notification_event = config.get("notification_event")
     if notification_event:
-        _publish_notification(notification_event, requisicao)
+        _publish_notification(notification_event, requisicao, actor)
 
     return requisicao

--- a/apps/requisitions/events.py
+++ b/apps/requisitions/events.py
@@ -1,0 +1,10 @@
+from enum import StrEnum
+
+
+class RequisicaoEvent(StrEnum):
+    ENVIADA = "requisicao.enviada"
+    AUTORIZADA = "requisicao.autorizada"
+    RECUSADA = "requisicao.recusada"
+    ATENDIDA = "requisicao.atendida"
+    ATENDIDA_PARCIALMENTE = "requisicao.atendida_parcialmente"
+    CANCELADA = "requisicao.cancelada"

--- a/docs/plans/81-notifications-requisicao-event-enum.md
+++ b/docs/plans/81-notifications-requisicao-event-enum.md
@@ -1,0 +1,77 @@
+# Plan: Issue #81 — RequisicaoEvent enum + entrypoint único notificar()
+
+## Scope
+
+**Muda:**
+- `apps/requisitions/events.py` — novo arquivo com `RequisicaoEvent(str, Enum)`
+- `apps/core/events.py` — `subscribe()` estendida para suportar `@subscribe(EnumClass)`
+- `apps/notifications/services.py` — adiciona `notificar()` com routing table interna
+- `apps/notifications/handlers.py` — substitui 6 handlers individuais por `@subscribe(RequisicaoEvent)`
+- `apps/requisitions/domain/state_machine.py` — usa `RequisicaoEvent` em vez das constantes de string; passa `actor_id` no payload
+
+**NÃO muda:**
+- Funções auxiliares de `notifications/services.py` usadas por views e testes (`criar_notificacao_usuario`, `criar_notificacao_papel`, etc.)
+- `notifications/views.py`
+- Qualquer arquivo de teste existente
+
+## Files touched
+
+- `apps/requisitions/events.py` (novo)
+- `apps/core/events.py`
+- `apps/notifications/services.py`
+- `apps/notifications/handlers.py`
+- `apps/requisitions/domain/state_machine.py`
+- `tests/notifications/test_handlers.py` (novo)
+
+## Mapeamento de eventos
+
+| Transição state_machine         | Antes (string)                    | Depois (enum)                         |
+|---------------------------------|-----------------------------------|---------------------------------------|
+| enviar_para_autorizacao         | REQUISICAO_ENVIADA_AUTORIZACAO    | RequisicaoEvent.ENVIADA               |
+| reenviar_para_autorizacao       | REQUISICAO_ENVIADA_AUTORIZACAO    | RequisicaoEvent.ENVIADA               |
+| autorizar_total                 | REQUISICAO_AUTORIZADA             | RequisicaoEvent.AUTORIZADA            |
+| autorizar_parcial               | REQUISICAO_AUTORIZADA             | RequisicaoEvent.AUTORIZADA            |
+| recusar                         | REQUISICAO_RECUSADA               | RequisicaoEvent.RECUSADA              |
+| atender_total                   | REQUISICAO_PRONTA_PARA_RETIRADA   | RequisicaoEvent.ATENDIDA              |
+| atender_parcial                 | REQUISICAO_PRONTA_PARA_RETIRADA   | RequisicaoEvent.ATENDIDA_PARCIALMENTE |
+| cancelar_*                      | REQUISICAO_CANCELADA              | RequisicaoEvent.CANCELADA             |
+| retirar                         | REQUISICAO_RETIRADA               | None (removido — não está no enum)    |
+| retornar_para_rascunho          | None                              | None                                  |
+
+## Routing table em notificar()
+
+```
+ENVIADA           → notifica chefe_responsavel; envia push aguardando_autorizacao
+AUTORIZADA        → notifica criador+beneficiario; notifica roles almoxarifado
+RECUSADA          → notifica criador+beneficiario
+ATENDIDA          → notifica criador+beneficiario (pronta para retirada)
+ATENDIDA_PARCIALMENTE → notifica criador+beneficiario (pronta para retirada parcial)
+CANCELADA         → notifica criador+beneficiario
+```
+
+## Mudança no subscribe()
+
+```python
+# Suporta:
+# 1. subscribe(str, handler) — forma atual, inalterada
+# 2. @subscribe(EnumClass)   — novo: registra para todos os valores do enum
+#    handler chamado com (event: EnumMember, **payload_dict)
+```
+
+## Test strategy
+
+Novo `tests/notifications/test_handlers.py`:
+- Para cada `RequisicaoEvent`: mock `notificar`, dispara `publish(event, payload)`, verifica `notificar` chamado com args corretos
+- Testa que `handle_requisicao_event` delega para `notificar()` com event correto
+
+## Invariants preserved
+
+- `notifications` importa de `requisitions.events`; nunca o inverso
+- Falha em `notificar()` loga, não reverte (publish_on_commit garante)
+- `actor_id` incluído no payload para completude do contrato, mas notificações atuais não o usam
+- Funções auxiliares de `services.py` mantidas públicas (usadas por views e testes)
+
+## Risks
+
+- Remoção de `REQUISICAO_RETIRADA` do bus: `retirar` transição para de emitir evento. Testes existentes não assertam criação de notificação para retirada, apenas idempotência (count não aumenta).
+- Constantes antigas em `core/events.py` mantidas para evitar quebrar imports de terceiros; apenas removidas de `state_machine.py`.

--- a/tests/notifications/test_handlers.py
+++ b/tests/notifications/test_handlers.py
@@ -1,0 +1,56 @@
+import pytest
+
+from apps.core.events import _subscribers, clear_subscribers, publish
+from apps.notifications.handlers import handle_requisicao_event, register_event_handlers
+from apps.requisitions.events import RequisicaoEvent
+
+
+class TestHandleRequisicaoEvent:
+    def test_delega_para_notificar_com_evento_e_args_corretos(self, monkeypatch):
+        chamadas = []
+        monkeypatch.setattr("apps.notifications.handlers.notificar", lambda *a: chamadas.append(a))
+
+        handle_requisicao_event(RequisicaoEvent.ENVIADA, requisicao_id=42, actor_id=7)
+
+        assert chamadas == [(RequisicaoEvent.ENVIADA, 42, 7)]
+
+    @pytest.mark.parametrize("event", list(RequisicaoEvent))
+    def test_repassa_cada_evento_para_notificar(self, monkeypatch, event):
+        chamadas = []
+        monkeypatch.setattr("apps.notifications.handlers.notificar", lambda *a: chamadas.append(a))
+
+        handle_requisicao_event(event, requisicao_id=1, actor_id=2)
+
+        assert chamadas == [(event, 1, 2)]
+
+
+class TestRegisterEventHandlers:
+    @pytest.fixture(autouse=True)
+    def isolate_subscribers(self):
+        saved = {k: list(v) for k, v in _subscribers.items()}
+        clear_subscribers()
+        yield
+        clear_subscribers()
+        for k, v in saved.items():
+            _subscribers[k].extend(v)
+
+    def test_registra_handler_para_cada_valor_de_requisicao_event(self, monkeypatch):
+        chamadas = []
+        monkeypatch.setattr("apps.notifications.handlers.notificar", lambda *a: chamadas.append(a))
+        register_event_handlers()
+
+        for event in RequisicaoEvent:
+            publish(event, {"requisicao_id": 10, "actor_id": 3})
+
+        assert len(chamadas) == len(RequisicaoEvent)
+        eventos_chamados = {c[0] for c in chamadas}
+        assert eventos_chamados == set(RequisicaoEvent)
+
+    def test_handler_recebe_requisicao_id_e_actor_id_do_payload(self, monkeypatch):
+        chamadas = []
+        monkeypatch.setattr("apps.notifications.handlers.notificar", lambda *a: chamadas.append(a))
+        register_event_handlers()
+
+        publish(RequisicaoEvent.AUTORIZADA, {"requisicao_id": 99, "actor_id": 55})
+
+        assert chamadas == [(RequisicaoEvent.AUTORIZADA, 99, 55)]


### PR DESCRIPTION
# Contexto

## O que este PR faz

- Introduz `apps/requisitions/events.py` com `RequisicaoEvent(StrEnum)` e 6 valores de domínio (`ENVIADA`, `AUTORIZADA`, `RECUSADA`, `ATENDIDA`, `ATENDIDA_PARCIALMENTE`, `CANCELADA`)
- Estende `apps/core/events.py` — `subscribe()` passa a aceitar `subscribe(EnumClass, handler)` e a forma decorator `@subscribe(EnumClass)`, chamando o handler como `fn(event, **payload)`
- Adiciona `notificar(event, requisicao_id, actor_id)` em `notifications/services.py` com routing table interna; substitui os 6+ handlers individuais que antes viviam em `handlers.py`
- Refatora `notifications/handlers.py` para um único `handle_requisicao_event` registrado via `subscribe(RequisicaoEvent, handle_requisicao_event)`
- Atualiza `state_machine.py` para usar enum values em vez das constantes de string de `core/events.py`; inclui `actor_id` no payload do evento

## Por que esta mudança é necessária

O módulo `notifications` expunha ~11 funções públicas sem entrypoint único, e `state_machine.py` dependia de constantes de string em `core/events.py` para rotear notificações. Implementa a decisão arquitetural do ADR 0003: `notifications` importa de `requisitions.events`; nunca o inverso.

---

# Checklist de impacto

- [x] altera máquina de estados, aprovação, cotas, override ou entregas
- [x] não há impacto relevante além do comportamento descrito acima

## Risco principal

Troca de strings de evento (`"requisicao.enviada_autorizacao"` → `"requisicao.enviada"`, etc.) — qualquer subscriber externo à codebase que dependesse das strings antigas seria silenciosamente ignorado. Inspecionado: não há outros subscribers além do `handlers.py` do módulo.

A transição `retirar` para de emitir evento de notificação (o enum não inclui `RETIRADA`). Testes não assertam criação de notificação para retirada, apenas idempotência.

## Impactos adicionais

- máquina de estados: `atender_total` → `RequisicaoEvent.ATENDIDA`; `atender_parcial` → `RequisicaoEvent.ATENDIDA_PARCIALMENTE`; `retirar` → `notification_event=None`

---

# Testes e validação

## Cenários validados

1. `tests/notifications/test_handlers.py` (novo) — 9 testes: `handle_requisicao_event` repassa cada evento para `notificar()` com args corretos; `register_event_handlers` registra handler para todos os 6 valores do enum
2. Suite completa: **579 passed** (antes e depois da refatoração — baseline preservado)
3. Tests de integração `test_notifications.py` com `transaction=True` continuam passando — on_commit + routing table funciona end-to-end

## Como validar manualmente

```bash
rtk make test
```

Closes #81

---

# 🤖 CodeRabbit Summary (auto-gerado)

> Esta seção será preenchida automaticamente pelo CodeRabbit.
> Não edite manualmente.

<!-- CODE RABBIT SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Objetivo
Refatorar subsistema de notificações para usar enum centralizado `RequisicaoEvent` e expor entrypoint único `notificar()` com routing table interna, eliminando múltiplos handlers individuais. Alinha-se com ADR 0003 (direção de dependências).

## Apps Django impactados
- **notifications** (handlers.py, services.py)
- **requisitions** (novo: events.py; domain/state_machine.py)
- **core** (events.py: extensão de subscribe())

## Risco funcional: Transição `retirar` sem notificação
- **Estado anterior**: `retirar` publicava evento `REQUISICAO_RETIRADA`
- **Novo estado**: `notification_event: None` — nenhum evento publicado para retirada
- **Impacto**: Qualquer subscriber externo aguardando `REQUISICAO_RETIRADA` deixará de receber notificação. A documentação acknowledges este risco ("removido — não está no enum")
- **Validação**: Verificar testes existentes se assertam notificações em retirada; aparentemente não assertam (só validam idempotência)

## Impacto em regras de negócio
- **Roteamento centralizado**: 6 eventos (`ENVIADA`, `AUTORIZADA`, `RECUSADA`, `ATENDIDA`, `ATENDIDA_PARCIALMENTE`, `CANCELADA`) roteiados por função única `notificar()`
- **Beneficiários notificados**: criador e beneficiário (autorização, recusa, atendimento, cancelamento); chefe almoxarifado também recebe para autorização
- **Sem impacto em lógica**: funções auxiliares (`criar_notificacao_usuario`, `criar_notificacao_papel`, etc.) mantidas públicas e inalteradas

## Impacto em autorização, autenticação e escopo
- **Sem mudança**: validações de `pode_gerenciar_push_subscription` mantidas
- **actor_id adicionado ao payload**: incluído em publish_on_commit mas **não utilizado** pelas funções de notificação (marcado com `# noqa: ARG001` em `notificar()`)
- **Risco aceito**: actor_id presente mas ignorado—se negócio evoluir para auditar quem disparou notificação, haverá dados; se não, é apenas overhead

## Impacto em contratos DRF, serializers, paginação e OpenAPI
- Sem mudanças diretas a endpoints; notificações são side-effects internos

## Impacto em integridade de dados, auditoria e rastreabilidade
- **Snapshots históricos**: `EventoTimeline` mantido conforme anteriormente
- **Auditoria**: campos de auditoria em requisição continuam preenchhidos (chefe_autorizador, responsavel_atendimento, retirante_fisico, etc.)
- **actor_id no payload**: permite futura correlação se necessário, mas não está sendo persisted em notificações

## Impacto em transações, concorrência e idempotência
- **publish_on_commit corretamente usado**: `_publish_notification()` valida que está dentro de `transaction.atomic()` e publica com `publish_on_commit()`, garantindo que falhas em notificar não revertam transação principal
- **Sem quebra de idempotência**: mesmo padrão anterior, apenas consolidado em um handler

## Direção de dependências (ADR 0003)
- ✅ **Preservada**: `notifications` importa de `requisitions.events` (em handlers.py e services.py); não há importação reversa

## N+1 queries
- ✅ **Sem introdução de N+1**: `_carregar_requisicao_para_notificacao()` usa `select_related()` para campos necessários (criador, beneficiario, setor_beneficiario__chefe_responsavel)

## Impacto em configuração, CI, dependências, lint e testes
- **Sem nova dependência**: apenas enum nativo (StrEnum)
- **Testes adicionados**: `tests/notifications/test_handlers.py` com 3 classes de testes (TestHandleRequisicaoEvent com 2 testes, TestRegisterEventHandlers com 3 testes)
- **Suite completa**: 579 passed (sem regressão)
- **Isolamento de estado**: fixture `autouse` em testes restaura `_subscribers` para evitar contaminação entre testes

## Constantes antigas em core/events.py
- **Mantidas** (REQUISICAO_ENVIADA_AUTORIZACAO, REQUISICAO_AUTORIZADA, etc.) para compatibilidade com imports externos
- **Não mais usadas** em state_machine.py (substituídas por enum)
- **Sem breaking change**: se ninguém importa essas strings, não há problema; se alguém importa e registra handler com strings antigas, o handler continuará sendo chamado (as strings antigas não desaparecerão do bus)

## Validação manual
1. **Via testes**: `pytest tests/notifications/test_handlers.py -v` valida que cada evento dispara `notificar()` com argumentos corretos
2. **Via admin**: criar requisição, autorizar, atender, verificar que notificações aparecem para criador/beneficiario/chefe conforme evento
3. **Via API**: POST /requisicoes, PATCH com transição de estado, verificar `Notificacao` objects criados
4. **Regressão**: verificar que retirada não cria notificação (intentional removal)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->