### PR TITLE
docs(frontend): record SPA design system decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: fila de autorização, lista do solicitante
 Lista de trabalho do usuário para acompanhar requisições próprias como criador ou beneficiário.
 _Avoid_: fila de autorização, fila de atendimento
 
+**Solicitar requisição**:
+Ato de iniciar uma requisição no piloto por um usuário operacional ativo, respeitando o escopo de beneficiário permitido para seu papel.
+_Avoid_: função exclusiva do papel Solicitante
+
 **Descartar rascunho**:
 Exclusão de um rascunho que nunca foi enviado para autorização e ainda não virou requisição formal.
 _Avoid_: cancelar rascunho, apagar requisição formal
@@ -56,6 +60,7 @@ _Avoid_: descartar, apagar do sistema
 - Um **Auxiliar de Almoxarifado** trabalha na **Fila de atendimento**
 - Um **Chefe de Almoxarifado** trabalha na **Fila de atendimento** e só autoriza requisições do setor Almoxarifado
 - Cada usuário opera o piloto com um único **Papel operacional principal**
+- Qualquer usuário operacional ativo pode **Solicitar requisição**, com escopo de beneficiário definido pelo seu papel
 - **Descartar rascunho** só existe antes da formalização da requisição
 - **Cancelar requisição** só se aplica a uma requisição já formalizada
 
@@ -73,5 +78,6 @@ _Avoid_: descartar, apagar do sistema
 ## Flagged ambiguities
 
 - "auxiliar de setor" foi usado como se também fosse autorizador — resolvido: ele apoia a criação de requisições do próprio setor, mas não autoriza
+- "solicitar requisição" foi tratado como se fosse exclusivo do papel **Solicitante** — resolvido: todos os papéis operacionais ativos podem solicitar, respeitando o escopo do seu papel
 - "descartar" e "cancelar" podem soar iguais na UI — resolvido: **Descartar rascunho** apaga o rascunho nunca formalizado; **Cancelar requisição** encerra uma requisição formal preservando histórico
 - "papéis múltiplos simultâneos" foi assumido no frontend — resolvido: o piloto atual usa um único **Papel operacional principal** por usuário

--- a/docs/adr/0009-design-system-layout-spa-piloto.md
+++ b/docs/adr/0009-design-system-layout-spa-piloto.md
@@ -1,0 +1,35 @@
+# ADR 0009 — Design system e layout base da SPA do piloto
+
+## Status
+
+Aceita.
+
+## Contexto
+
+Após o reset neutro do frontend do piloto, a issue #29 precisava impedir que a PR #30 recriasse decisões visuais antigas ou inventasse shell, navegação e primitives sem contrato. A SPA continua sendo uma ferramenta operacional do Almoxarifado do SAEP, não uma landing page nem um dashboard genérico.
+
+## Decisão
+
+A PR #30 deve materializar `shadcn/ui` + `Radix UI` de forma incremental, com uma primeira leva mínima e fechada de primitives: `Button`, `Input`, `Label`, `Alert`, `Separator`, `Sheet` e `Card`. Essa lista cobre login, shell autenticado, navegação responsiva e mensagens de erro/negação de permissão sem antecipar componentes de fluxos ainda inexistentes. `DropdownMenu`, `Dialog`, `Tabs`, `Table`, `Badge` e `Toast` ficam fora da PR #30 até haver uso funcional concreto. `lucide-react` pode ser adicionada como dependência visual mínima, com ícones apenas como apoio ao texto ou em controles icon-only com nome acessível.
+
+O shell autenticado deve ser desktop-first, mas já responsivo: sidebar persistente e topo compacto no desktop; navegação recolhida em menu/drawer no mobile. `/login` fica fora do shell autenticado, com layout próprio, marca `SAEP`, nome funcional `WMS Almoxarifado`, formulário compacto e erro visível.
+
+A navegação principal deve esconder áreas que não pertencem ao papel operacional do usuário, enquanto acessos diretos por URL devem renderizar negativa de permissão clara. `/` não terá dashboard próprio na PR #30: redireciona conforme sessão e papel. `Nova requisição` aparece para todos os papéis operacionais ativos como ação primária/rota protegida placeholder, mas não como destino automático pós-login.
+
+A PR #30 deve estabelecer um baseline pragmático de acessibilidade alinhado a WCAG AA para autenticação e shell: foco visível em todos os controles interativos, navegação essencial por teclado, `Label` explícito para inputs, mensagens de erro associadas ao campo quando aplicável, contraste mínimo AA, alvos de clique/toque confortáveis, ícones isolados sempre com nome acessível, estados de foco/hover/disabled/erro distinguíveis sem depender apenas de cor e nenhuma informação transmitida exclusivamente por cor. A PR #30 não exige auditoria completa de acessibilidade, mas esses contratos devem ser cobertos por smoke/unit tests onde fizer sentido.
+
+O contrato de testes da PR #30 deve ter duas camadas. A camada principal é Vitest, cobrindo a matriz de regras: redirect por sessão e papel, login fora do shell, home por papel, papel desconhecido, menu por papel, `Nova requisição` para papéis operacionais, acesso direto negado, logout, erro de login, sessão expirada e erro de bootstrap. A camada Playwright é smoke, não matriz completa: um caminho feliz com login real, shell, navegação mínima e logout; e um caminho negativo de acesso direto proibido renderizando 403 amigável. Worklists ficam fora dos testes da PR #30. Esconder menu é UX; proteção de rota continua sendo requisito de segurança e produto.
+
+O shell da PR #30 deve ser stateless quanto a preferências visuais. No mobile, o menu usa apenas estado local e fecha ao navegar, ao fazer logout ou quando a rota muda. No desktop, a sidebar permanece sempre visível, sem colapso. Persistência em `localStorage` ou `sessionStorage` fica fora da PR #30 e só deve ser reaberta por requisito claro de produtividade, problema validado de espaço horizontal ou decisão formal posterior de layout.
+
+A PR #30 não deve introduzir sistema global de toast. Erro de login pertence ao formulário; erro de bootstrap deve ser um estado de página retryable; erro de logout deve ficar visível no shell ou na área de conta. Feedback transitório global fica para issue futura, quando houver eventos assíncronos não bloqueantes que justifiquem provider, fila, duração, acessibilidade e testes próprios. Primitives mínimas como `FormError`, `InlineAlert` e `RetryableState` são aceitáveis se permanecerem contextuais.
+
+O `components.json` do shadcn deve ser versionado já alinhado à taxonomia do repositório: primitives em `frontend/src/shared/ui` e utilitários em `frontend/src/shared/lib`. A PR #30 não deve criar `components/ui` nem `lib/utils` paralelos, porque a ferramenta não deve redefinir as fronteiras documentadas do projeto.
+
+Componentes genéricos reutilizáveis ficam em `shared/ui`. Componentes compostos e específicos do shell/auth da PR #30 não devem ser promovidos para `shared/ui`; devem permanecer no módulo/app layer correspondente até demonstrarem reutilização real. `Alert` deve ser usado para feedback contextual persistente de erro, negação de permissão e indisponibilidade. `Sheet` deve ser usado apenas para a navegação mobile do shell; formulários, detalhes, confirmação e fluxos operacionais em `Sheet` ficam fora do escopo da PR #30.
+
+## Consequências
+
+- A PR #30 prova autenticação, shell, papel, navegação e guards sem implementar worklists, tabelas, wizard, notificações, PWA, analytics ou fluxos de requisição.
+- A UI deve manter tom institucional, sóbrio e operacional, com tema claro, alto contraste, poucos acentos e densidade moderada.
+- `WMS-SAEP` permanece nome técnico do projeto; a interface operacional deve expor `SAEP` e `WMS Almoxarifado`.

--- a/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
+++ b/docs/design-acesso-rapido/frontend-arquitetura-piloto.md
@@ -60,6 +60,31 @@ O `superusuário` permanece fora do foco da SPA no primeiro corte, usando admin 
 - `Playwright`
 - `pnpm`
 
+### Decisões de design system para a PR #30
+
+- `shadcn/ui` + `Radix UI` devem ser materializados incrementalmente a partir da PR #30, não apenas mantidos como stack nominal.
+- A primeira leva de primitives é fechada para a PR #30: `Button`, `Input`, `Label`, `Alert`, `Separator`, `Sheet` e `Card`. `DropdownMenu`, `Dialog`, `Tabs`, `Table`, `Badge` e `Toast` ficam fora até haver uso funcional concreto.
+- Wrappers locais só devem existir para composições com semântica do produto, como `AuthLayout`, `AppShell` e `NavItem`.
+- O shell da PR #30 continua desktop-first para o uso operacional, mas já deve nascer responsivo: desktop com sidebar persistente e topo compacto; mobile com navegação recolhida em menu/drawer.
+- A navegação principal deve esconder áreas que não pertencem ao `papel` operacional do usuário; acessos diretos por URL devem renderizar uma negativa de permissão clara, com o motivo contextual.
+- O destino pós-login deve apontar para a rota principal futura do papel, ainda que ela renderize placeholder protegido na PR #30: `Solicitante` e `Auxiliar de setor` em `/minhas-requisicoes`; `Chefe de setor` em `/autorizacoes`; `Auxiliar de Almoxarifado` e `Chefe de Almoxarifado` em `/atendimentos`; papel desconhecido em `/unknown-role`.
+- A rota `/` deve permanecer sem dashboard próprio na PR #30: se não autenticado, redireciona para `/login`; se autenticado, redireciona para o destino pós-login do `papel`; se o papel for desconhecido, redireciona para `/unknown-role`.
+- A navegação da PR #30 deve exibir `Nova requisição` para todos os papéis operacionais ativos, como ação primária/rota protegida placeholder, mas nunca como destino automático pós-login. A diferença entre papéis entra no escopo de beneficiário: `Solicitante` para si; `Auxiliar de setor` para o próprio setor; `Chefe de setor` para setor sob responsabilidade; Almoxarifado para qualquer funcionário. Superusuário permanece fora do foco da SPA.
+- A identidade visual do shell deve tratar `SAEP` como marca institucional discreta e `WMS Almoxarifado` como nome funcional curto da interface; evitar expor `WMS-SAEP` como rótulo principal da UI operacional.
+- O tom visual deve ser institucional, sóbrio e operacional: tema claro, alto contraste, poucos acentos, densidade moderada e foco em leitura/ação. Evitar hero, gradientes decorativos, dashboards promocionais e cards grandes explicando o sistema.
+- A PR #30 pode adicionar `lucide-react` como dependência visual mínima. Ícones devem ser importados nominalmente, usados como apoio ao texto na navegação e em ações principais, e só podem aparecer sozinhos em controles reconhecíveis com nome acessível (`aria-label` ou equivalente).
+- `/login` deve ficar fora do shell autenticado, com layout próprio e mínimo: marca `SAEP`, nome `WMS Almoxarifado`, formulário compacto e estado de erro visível. O `AppShell` só deve renderizar depois de uma sessão autenticada.
+- Placeholders protegidos da PR #30 devem ser específicos por área/papel (`Minhas requisições`, `Autorizações`, `Atendimentos`) e explicar que a área protegida foi validada, mas o fluxo operacional entra em PR futura.
+- A PR #30 deve estabelecer baseline pragmático de acessibilidade alinhado a WCAG AA para auth/shell: foco visível, navegação essencial por teclado, `Label` explícito para inputs, erro associado ao campo quando aplicável, contraste AA, alvos confortáveis, ícone isolado com nome acessível, estados distinguíveis sem depender só de cor e nenhuma informação transmitida apenas por cor. Não exige auditoria completa, mas deve cobrir esses contratos por smoke/unit tests onde fizer sentido.
+- O contrato de testes da PR #30 deve priorizar Vitest para a matriz de regras: redirect por sessão/papel, login fora do shell, home por papel, papel desconhecido, menu por papel, `Nova requisição` para papéis operacionais, acesso direto negado, logout, erro de login, sessão expirada e erro de bootstrap. Playwright deve ser smoke: um caminho feliz com login real, shell, navegação mínima e logout; e um caminho negativo de acesso direto proibido com 403 amigável. Não testar worklists nesta PR. Esconder menu é UX; proteção de rota é requisito de segurança e produto.
+- O shell da PR #30 deve ser stateless quanto a preferências visuais: menu mobile com estado local, fechando ao navegar, ao fazer logout ou quando a rota muda; sidebar desktop sempre visível e sem colapso. Não persistir preferência em `localStorage` ou `sessionStorage` nesta PR.
+- A PR #30 não deve introduzir sistema global de toast. Erro de login fica no formulário; erro de bootstrap vira estado de página retryable; erro de logout fica visível no shell ou área de conta. `FormError`, `InlineAlert` e `RetryableState` podem existir como primitives/contextuais, sem provider global.
+- O `components.json` do shadcn deve ser versionado com aliases para `frontend/src/shared/ui` e `frontend/src/shared/lib`. Não criar `components/ui` nem `lib/utils` paralelos.
+- Componentes genéricos reutilizáveis ficam em `shared/ui`; compostos específicos de shell/auth da PR #30 permanecem no módulo/app layer correspondente até demonstrarem reutilização real.
+- `Alert` deve ser usado para feedback contextual persistente de erro, negação de permissão e indisponibilidade.
+- `Sheet` deve ser usado apenas para a navegação mobile do shell; outros usos, como formulários, detalhes, confirmação ou fluxos operacionais, ficam fora da PR #30.
+- A PR #30 não deve introduzir componentes operacionais de worklist, tabela, wizard, notificações, PWA, analytics ou fluxos de requisição.
+
 ## 5. Estrutura de pastas
 
 ```text


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumo do PR `#87`

**Objetivo:**
Registrar decisão de design system e layout base da SPA do piloto (ADR 0009 / issue `#29`) e atualizar documentação de domínio operacional (CONTEXT.md).

---

## Não há impacto em código Django

- PR é puramente documentação (adições em `docs/` e `CONTEXT.md`).
- Nenhuma alteração em `apps/`, `config/`, testes de backend ou models.
- Nenhuma app Django impactada.

---

## Impacto em regras de negócio

- **CONTEXT.md**: Clarifica que **"Solicitar requisição"** não é exclusivo do papel `Solicitante`, mas ato de qualquer usuário operacional ativo respeitando escopo de beneficiário do seu papel.
  - Remove ambiguidade histórica que tratava criação de requisição como privilégio exclusivo de um papel.
  - Alinha linguagem de domínio com fato operacional: `Auxiliar de setor` pode criar requisições, `Chefe de setor` pode criar para seu setor, etc.
  - **Risco**: Implementação do backend (`requisitions.views`, `requisitions.policies`) deve validar autorização por papel no escopo de **beneficiário**, não apenas por criador. Precisa confirmação na revisão de `POST /api/v1/requisitions/`.

---

## Impacto em autenticação, autorização e escopo por perfil

- **ADR 0009 + frontend-arquitetura-piloto.md**: Definem contrato esperado de sessão/papel para PR `#30`:
  - Um único `papel operacional principal` por usuário no piloto (sem múltiplos papéis simultâneos).
  - `/login` fora do shell autenticado; home por papel com redirecionamento diferenciado.
  - Acessos diretos por URL devem renderizar negativa de permissão clara (não 404).
  - Menu principal e ações ("Nova requisição") visíveis conforme papel.
  - Papel desconhecido deve redirecionar para `/unknown-role` sem loop.
  - **Risco**: Lógica de autorização esperada depende da resposta de `GET /api/v1/auth/me/` incluir `papel` de forma explícita e consistente. Políticas de Django (`requisitions.policies`, `users.policies`) devem usar esse papel como base.

---

## Impacto em contratos DRF e APIs

- **Superfícies esperadas definidas, sem implementação**:
  - `GET /api/v1/auth/csrf/`, `POST /api/v1/auth/login/`, `POST /api/v1/auth/logout/`, `GET /api/v1/auth/me/`
  - `GET /api/v1/users/beneficiary-lookup/?q=...` (busca por nome, mínimo 3 chars, sem paginação)
  - `GET /api/v1/requisitions/`, `GET /api/v1/requisitions/mine/`, `GET /api/v1/requisitions/{id}/`
  - Endpoint explícito de atualização de rascunho por substituição completa.
- **Documentação define regra de visibilidade importante**: `GET /api/v1/requisitions/mine/` deve retornar:
  - Em `rascunho`: apenas requisições com `criador_id = user.id`
  - Fora de `rascunho`: requisições com `criador_id = user.id OR beneficiario_id = user.id`
  - **Risco**: Regra de visibilidade `beneficiario_id` em `mine/` precisa estar implementada no filtro e em `requisitions.serializers` / `requisitions.views`.

---

## Impacto em testes e CI

- **Contrato de testes definido para PR `#30`**:
  - **Vitest** (prioridade): matriz de regras (redirect por sessão/papel, login fora do shell, home por papel, papel desconhecido, menu por papel, `Nova requisição` para papéis operacionais, acesso direto negado, logout, erro de login, sessão expirada, erro de bootstrap).
  - **Playwright** (smoke): caminho feliz (login real, shell, navegação, logout) + caminho negativo (acesso direto proibido com 403 amigável).
  - Sem testes de worklists nesta PR.
- **Sequência de implementação anterior ao reset é suspensa**: PR `#30/auth-shell` bloqueada até issue `#29` (este PR) fechar design system. Frontend volta de reset neutro.

---

## Impacto em configuração e dependências

- **Frontend stack confirmado**:
  - `shadcn/ui` + `Radix UI` com primitives mínimas na PR `#30`: `Button`, `Input`, `Label`, `Alert`, `Separator`, `Sheet`, `Card`.
  - Sem `DropdownMenu`, `Dialog`, `Tabs`, `Table`, `Badge`, `Toast` até haver uso funcional.
  - `lucide-react` opcional para ícones (apoio ao texto, icon-only com `aria-label`).
  - Geração de tipos OpenAPI de arquivo (`frontend/openapi/schema.json`), não de endpoint HTTP em build.
- **Components.json** do shadcn deve apontar para `frontend/src/shared/ui` e `frontend/src/shared/lib`.
- **Estateless UI**: Menu mobile com estado local; sidebar desktop sem colapso; nenhuma preferência visual em `localStorage` na PR `#30`.

---

## Impacto em acessibilidade

- **Baseline pragmático WCAG AA esperado** em auth/shell:
  - Foco visível, navegação essencial por teclado.
  - `Label` explícito para inputs.
  - Erro associado ao campo.
  - Contraste mínimo AA.
  - Alvos confortáveis.
  - Ícones isolados com `aria-label`.
  - Estados distinguíveis sem depender só de cor.
  - Sem informação transmitida apenas por cor.
- Não exige auditoria completa, mas deve cobrir esses pontos em smoke/unit tests.

---

## Mudanças menores em CONTEXT.md

- Esclarecimento de `Descartar rascunho` vs `Cancelar requisição`.
- Documento de contexto operacional agora explícito sobre o termo "**Solicitar requisição**" e sua aplicabilidade.

---

## Validação futura (após PR `#30`)

- Confirmar que `GET /api/v1/auth/me/` retorna `papel` e que redirect de home usa esse valor.
- Confirmar que políticas de autorização (`requisitions.policies`, `users.policies`) validam escopo de beneficiário por papel.
- Confirmar que `GET /api/v1/requisitions/mine/` respeita regra de visibilidade (rascunho só criador; fora de rascunho criador + beneficiário).
- Validar matriz de Vitest para redirect/guards e casos de papel desconhecido / sessão expirada.
- Smoke test Playwright com login real, shell, logout e negação 403 amigável.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/joaorighetto/WMS-SAEP/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->